### PR TITLE
Multiple bug fixes related to ServiceEndPoint, NotificationFilter & augmented classes duplicate attributes

### DIFF
--- a/SWAGGER/Tapi.swagger
+++ b/SWAGGER/Tapi.swagger
@@ -5070,30 +5070,37 @@
         },
         "ServiceEndPoint": {
             "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
-            "properties": {
-                "_state": {
-                    "description": "none",
-                    "$ref": "#/definitions/LifecycleStatePac"
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ResourceSpec"
                 },
-                "direction": {
-                    "enum": [
-                        "BIDIRECTIONAL",
-                        "SINK",
-                        "SOURCE",
-                        "UNDEFINED_OR_UNKNOWN"
-                    ],
-                    "type": "string",
-                    "description": "none"
-                },
-                "_layerProtocol": {
-                    "items": {
-                        "$ref": "#/definitions/LayerProtocol"
-                    },
-                    "type": "array",
-                    "description": "none",
-                    "x-key": "localId"
-                }
-            }
+                {
+		            "properties": {
+		                "_state": {
+		                    "description": "none",
+		                    "$ref": "#/definitions/LifecycleStatePac"
+		                },
+		                "direction": {
+		                    "enum": [
+		                        "BIDIRECTIONAL",
+		                        "SINK",
+		                        "SOURCE",
+		                        "UNDEFINED_OR_UNKNOWN"
+		                    ],
+		                    "type": "string",
+		                    "description": "none"
+		                },
+		                "_layerProtocol": {
+		                    "items": {
+		                        "$ref": "#/definitions/LayerProtocol"
+		                    },
+		                    "type": "array",
+		                    "description": "none",
+		                    "x-key": "localId"
+		                }
+		            }
+		        }
+		    ]
         },
         "LocalClass": {
             "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",

--- a/SWAGGER/Tapi.swagger
+++ b/SWAGGER/Tapi.swagger
@@ -5136,10 +5136,6 @@
                             "type": "string",
                             "description": "none"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_layerProtocol": {
                             "items": {
                                 "$ref": "#/definitions/LayerProtocol"
@@ -5151,30 +5147,6 @@
                         "_state": {
                             "description": "none",
                             "$ref": "#/definitions/LifecycleStatePac"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }

--- a/SWAGGER/TapiConnectivity.swagger
+++ b/SWAGGER/TapiConnectivity.swagger
@@ -4672,10 +4672,6 @@
                             "description": "none",
                             "x-key": "localId"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_connectionPort": {
                             "items": {
                                 "$ref": "#/definitions/ConnectionPort"
@@ -4688,34 +4684,10 @@
                             "description": "none",
                             "$ref": "#/definitions/OperationalStatePac"
                         },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
                         "_node": {
                             "type": "string",
                             "description": "none",
                             "x-path": "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:uuid"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }
@@ -4763,45 +4735,17 @@
                             "type": "string",
                             "description": "none"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_state": {
                             "description": "none",
                             "$ref": "#/definitions/AdminStatePac"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
                         },
                         "_schedule": {
                             "description": "none",
                             "$ref": "#/definitions/TimeRange"
                         },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
                         "_connConstraint": {
                             "description": "none",
                             "$ref": "#/definitions/ConnectivityConstraint"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }

--- a/SWAGGER/TapiNotification.swagger
+++ b/SWAGGER/TapiNotification.swagger
@@ -2778,34 +2778,6 @@
                             ],
                             "description": "none"
                         },
-                        "_extensions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "x-key": "extensionsSpecification",
-                            "description": "none"
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "x-key": "valueName",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity."
-                        },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
-                        "label": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "x-key": "valueName",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state."
-                        },
                         "_subscriptionFilter": {
                             "$ref": "#/definitions/SubscriptionFilter",
                             "description": "none"
@@ -2841,10 +2813,6 @@
                                 "CONNECTION_END_POINT"
                             ],
                             "description": "none"
-                        },
-                        "notificationUuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
                         },
                         "changedAttributes": {
                             "type": "array",
@@ -2908,30 +2876,6 @@
                                 "ATTRIBUTE_VALUE_CHANGE"
                             ],
                             "description": "none"
-                        },
-                        "_extensions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "x-key": "extensionsSpecification",
-                            "description": "none"
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "x-key": "valueName",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity."
-                        },
-                        "label": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "x-key": "valueName",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state."
                         },
                         "targetObjectIdentifier": {
                             "type": "string",

--- a/SWAGGER/TapiNotification.swagger
+++ b/SWAGGER/TapiNotification.swagger
@@ -2398,79 +2398,93 @@
             "description": "none"
         },
         "NotificationChannel": {
-            "properties": {
-                "nextSequenceNo": {
-                    "type": "string",
-                    "description": "The sequence number of the next notification that will be published on the channel"
+            "allOf": [
+                {
+                    "$ref": "#/definitions/LocalClass"
                 },
-                "streamAddress": {
-                    "type": "string",
-                    "description": "The address/location/URI of the channel/stream to which the subscribed notifications are published.\nThis specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string."
-                }
-            },
+                {
+		            "properties": {
+		                "nextSequenceNo": {
+		                    "type": "string",
+		                    "description": "The sequence number of the next notification that will be published on the channel"
+		                },
+		                "streamAddress": {
+		                    "type": "string",
+		                    "description": "The address/location/URI of the channel/stream to which the subscribed notifications are published.\nThis specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string."
+		                }
+		            }
+		        }
+		    ],
             "description": "none"
         },
         "SubscriptionFilter": {
-            "properties": {
-                "requestedNotificationTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "OBJECT_CREATION",
-                            "OBJECT_DELETION",
-                            "ATTRIBUTE_VALUE_CHANGE"
-                        ],
-                        "description": "none"
-                    }
+            "allOf": [
+                {
+                    "$ref": "#/definitions/LocalClass"
                 },
-                "requestedObjectIdentifier": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "none"
-                    }
-                },
-                "requestedLayerProtocols": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "OCH",
-                            "ODU",
-                            "ETH",
-                            "MPLS_TP"
-                        ],
-                        "description": "none"
-                    }
-                },
-                "requestedObjectTypes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "TOPOLOGY",
-                            "NODE",
-                            "LINK",
-                            "CONNECTION",
-                            "PATH",
-                            "CONNECTIVITY_SERVICE",
-                            "VIRTUAL_NETWORK_SERVICE",
-                            "PATH_COMPUTATION_SERVICE",
-                            "NODE_EDGE_POINT",
-                            "SERVICE_END_POINT",
-                            "CONNECTION_END_POINT"
-                        ],
-                        "description": "none"
-                    }
-                },
-                "includeContent": {
-                    "type": "boolean",
-                    "description": "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)"
-                }
-            },
-            "description": "none"
-        },
+                {
+		            "properties": {
+		                "requestedNotificationTypes": {
+		                    "type": "array",
+		                    "items": {
+		                        "type": "string",
+		                        "enum": [
+		                            "OBJECT_CREATION",
+		                            "OBJECT_DELETION",
+		                            "ATTRIBUTE_VALUE_CHANGE"
+		                        ],
+		                        "description": "none"
+		                    }
+		                },
+		                "requestedObjectIdentifier": {
+		                    "type": "array",
+		                    "items": {
+		                        "type": "string",
+		                        "description": "none"
+		                    }
+		                },
+		                "requestedLayerProtocols": {
+		                    "type": "array",
+		                    "items": {
+		                        "type": "string",
+		                        "enum": [
+		                            "OCH",
+		                            "ODU",
+		                            "ETH",
+		                            "MPLS_TP"
+		                        ],
+		                        "description": "none"
+		                    }
+		                },
+		                "requestedObjectTypes": {
+		                    "type": "array",
+		                    "items": {
+		                        "type": "string",
+		                        "enum": [
+		                            "TOPOLOGY",
+		                            "NODE",
+		                            "LINK",
+		                            "CONNECTION",
+		                            "PATH",
+		                            "CONNECTIVITY_SERVICE",
+		                            "VIRTUAL_NETWORK_SERVICE",
+		                            "PATH_COMPUTATION_SERVICE",
+		                            "NODE_EDGE_POINT",
+		                            "SERVICE_END_POINT",
+		                            "CONNECTION_END_POINT"
+		                        ],
+		                        "description": "none"
+		                    }
+		                },
+		                "includeContent": {
+		                    "type": "boolean",
+		                    "description": "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)"
+		                }
+		            }
+		        }
+		    ],
+		    "description": "none"
+		},
         "NameAndValueChange": {
             "properties": {
                 "valueName": {

--- a/SWAGGER/TapiPathComputation.swagger
+++ b/SWAGGER/TapiPathComputation.swagger
@@ -4398,37 +4398,9 @@
                             "description": "none",
                             "x-key": "localId"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_routingConstraint": {
                             "description": "none",
                             "$ref": "#/definitions/RoutingConstraint"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }
@@ -4449,18 +4421,6 @@
                             "description": "none",
                             "x-key": "localId"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
-                        },
                         "_routingConstraint": {
                             "description": "none",
                             "$ref": "#/definitions/RoutingConstraint"
@@ -4468,22 +4428,6 @@
                         "_optimizationConstraint": {
                             "description": "none",
                             "$ref": "#/definitions/PathOptimizationConstraint"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
                         },
                         "_objectiveFunction": {
                             "description": "none",

--- a/SWAGGER/TapiTopology.swagger
+++ b/SWAGGER/TapiTopology.swagger
@@ -4522,10 +4522,6 @@
                             },
                             "type": "array"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_link": {
                             "items": {
                                 "$ref": "#/definitions/Link"
@@ -4534,14 +4530,6 @@
                             "description": "none",
                             "x-key": "uuid"
                         },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
                         "_node": {
                             "items": {
                                 "$ref": "#/definitions/Node"
@@ -4549,22 +4537,6 @@
                             "type": "array",
                             "description": "none",
                             "x-key": "uuid"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }
@@ -4578,22 +4550,6 @@
                 },
                 {
                     "properties": {
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
                         "_topology": {
                             "items": {
                                 "type": "string",
@@ -4601,18 +4557,6 @@
                                 "x-path": "/Tapi:Context/Tapi:_topology/Tapi:uuid"
                             },
                             "type": "array"
-                        },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }

--- a/SWAGGER/TapiVirtualNetwork.swagger
+++ b/SWAGGER/TapiVirtualNetwork.swagger
@@ -3259,10 +3259,6 @@
                             },
                             "type": "array"
                         },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique\n(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)"
-                        },
                         "_vnwConstraint": {
                             "items": {
                                 "$ref": "#/definitions/VirtualNetworkConstraint"
@@ -3280,33 +3276,9 @@
                             "description": "none",
                             "x-path": "/Tapi:Context/Tapi:_topology/Tapi:uuid"
                         },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "valueName"
-                        },
                         "_schedule": {
                             "description": "none",
                             "$ref": "#/definitions/TimeRange"
-                        },
-                        "_extensions": {
-                            "items": {
-                                "$ref": "#/definitions/ExtensionsSpec"
-                            },
-                            "type": "array",
-                            "description": "none",
-                            "x-key": "extensionsSpecification"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/NameAndValue"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "valueName"
                         }
                     }
                 }

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -132,6 +132,9 @@
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_phsNMCzxEeaYO8M_h7XJ5A" name="SubscriptionFilter" isLeaf="true">
+        <generalization xmi:type="uml:Generalization" xmi:id="_MiwBQHoXEeaA6c2_Hy2S8A">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_8YhJQCzxEeaYO8M_h7XJ5A" name="requestedNotificationTypes" type="_hZotgCzcEeaYO8M_h7XJ5A" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VsFfQCzyEeaYO8M_h7XJ5A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VsFfQizyEeaYO8M_h7XJ5A" value="*"/>
@@ -209,6 +212,9 @@ The exact semantics of how this sequence number is assigned (per channel or subs
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_aQ9x8E8bEea3rq3M7G3w3w" name="NotificationChannel">
+        <generalization xmi:type="uml:Generalization" xmi:id="_NwKPkHoXEeaA6c2_Hy2S8A">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xvMMYE8aEea3rq3M7G3w3w" name="streamAddress" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_5u9fUE8aEea3rq3M7G3w3w" annotatedElement="_xvMMYE8aEea3rq3M7G3w3w">
             <body>The address/location/URI of the channel/stream to which the subscribed notifications are published.&#xD;
@@ -334,7 +340,7 @@ This specifics of this is typically dependent on the implementation protocol &am
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNsCznEeaYO8M_h7XJ5A" base_Element="__Pe64CznEeaYO8M_h7XJ5A"/>
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNsSznEeaYO8M_h7XJ5A" base_Element="__Pe64SznEeaYO8M_h7XJ5A"/>
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNsiznEeaYO8M_h7XJ5A" base_Element="__Pe64iznEeaYO8M_h7XJ5A"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="__QrNsyznEeaYO8M_h7XJ5A" base_StructuralFeature="__Pe64iznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__QrNsyznEeaYO8M_h7XJ5A" base_StructuralFeature="__Pe64iznEeaYO8M_h7XJ5A" partOfObjectKey="1"/>
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNtCznEeaYO8M_h7XJ5A" base_Element="__Pe64yznEeaYO8M_h7XJ5A"/>
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNtSznEeaYO8M_h7XJ5A" base_Element="__Pe65CznEeaYO8M_h7XJ5A"/>
   <OpenModel_Profile:OpenModelElement xmi:id="__QrNtiznEeaYO8M_h7XJ5A" base_Element="__Pe65SznEeaYO8M_h7XJ5A"/>
@@ -537,4 +543,6 @@ This specifics of this is typically dependent on the implementation protocol &am
   <OpenModel_Profile:OpenModelElement xmi:id="_9CxHhE8cEea3rq3M7G3w3w" base_Element="_9CxHgU8cEea3rq3M7G3w3w"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_TLUZYU8lEea3rq3M7G3w3w" base_Element="_TLUZYE8lEea3rq3M7G3w3w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TLVAcE8lEea3rq3M7G3w3w" base_StructuralFeature="_TLUZYE8lEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MiwBQXoXEeaA6c2_Hy2S8A" base_Element="_MiwBQHoXEeaA6c2_Hy2S8A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NwKPkXoXEeaA6c2_Hy2S8A" base_Element="_NwKPkHoXEeaA6c2_Hy2S8A"/>
 </xmi:XMI>

--- a/YANG/Tapi.yang
+++ b/YANG/Tapi.yang
@@ -225,7 +225,7 @@ module Tapi {
                 config false;
                 description "none";
             }
-            //uses ResourceSpec;
+            uses ResourceSpec;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }

--- a/YANG/TapiNotification.yang
+++ b/YANG/TapiNotification.yang
@@ -85,6 +85,7 @@ module TapiNotification {
                 config false;
                 description "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)";
             }
+            uses Tapi:LocalClass;
             description "none";
         }
         notification Notification {
@@ -128,6 +129,7 @@ module TapiNotification {
                 description "none";
             }
             list changedAttributes {
+            	key 'valueName';
                 uses NameAndValueChange;
                 description "none";
             }
@@ -155,6 +157,7 @@ module TapiNotification {
                 config false;
                 description "The sequence number of the next notification that will be published on the channel";
             }
+            uses Tapi:LocalClass;
             description "none";
         }
     


### PR DESCRIPTION
Fixes #91 
1) The "uses ResourceSpec" statement was manually commented in YANG file to fix tool generation error. As a side-effect, the resulting ServiceEndPoint definition in swagger is incomplete in the sense the inherited attributes are missing.
2) Duplicate GlobalClass attributes in augmented TAPI classes - augmented TAPI classes/groupings that extend the base GlobalClass via the ResourceSpec/ServiceSpec have redefined the GlobalClass attributes (uuid, name, label, extensions) in the augmented swagger files.
3) 	Fixed NotificationFilter & NotificationChannel to extend LocalClass