### PR TITLE
Bug Fix: Moved ServiceEndPoint RPC operations to common Tapi module

### DIFF
--- a/SWAGGER/Tapi.swagger
+++ b/SWAGGER/Tapi.swagger
@@ -4868,6 +4868,65 @@
                 ],
                 "operationId": "retrieveContext_extensions_extensionsById"
             }
+        },
+        "/operations/getServiceEndPointDetails/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetServiceEndPointDetailsRPCOutputSchema"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "description": "Create operation of resource: getServiceEndPointDetails",
+                "parameters": [
+                    {
+                        "required": true,
+                        "description": "getServiceEndPointDetailsbody object",
+                        "schema": {
+                            "$ref": "#/definitions/GetServiceEndPointDetailsRPCInputSchema"
+                        },
+                        "name": "getServiceEndPointDetails",
+                        "in": "body"
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Create getServiceEndPointDetails by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "createGetServiceEndPointDetailsById"
+            }
+        },
+        "/operations/getServiceEndPointList/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/GetServiceEndPointListRPCOutputSchema"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "description": "Create operation of resource: getServiceEndPointList",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Create getServiceEndPointList by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "createGetServiceEndPointListById"
+            }
         }
     },
     "definitions": {
@@ -5239,6 +5298,33 @@
                     }
                 }
             ]
+        },
+        "GetServiceEndPointDetailsRPCInputSchema": {
+            "properties": {
+                "serviceEPIdOrName": {
+                    "type": "string",
+                    "description": "none"
+                }
+            }
+        },
+        "GetServiceEndPointDetailsRPCOutputSchema": {
+            "properties": {
+                "serviceEndPoint": {
+                    "$ref": "#/definitions/ServiceEndPoint",
+                    "description": "none"
+                }
+            }
+        },
+        "GetServiceEndPointListRPCOutputSchema": {
+            "properties": {
+                "serviceEndPoint": {
+                    "type": "array",
+                    "description": "none",
+                    "items": {
+                        "$ref": "#/definitions/ServiceEndPoint"
+                    }
+                }
+            }
         }
     }
 }

--- a/SWAGGER/TapiConnectivity.swagger
+++ b/SWAGGER/TapiConnectivity.swagger
@@ -3266,41 +3266,6 @@
                 "operationId": "createGetConnectionEndPointDetailsById"
             }
         },
-        "/operations/getServiceEndPointDetails/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/GetServiceEndPointDetailsRPCOutputSchema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: getServiceEndPointDetails",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "getServiceEndPointDetailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/GetServiceEndPointDetailsRPCInputSchema"
-                        },
-                        "name": "getServiceEndPointDetails",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create getServiceEndPointDetails by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "createGetServiceEndPointDetailsById"
-            }
-        },
         "/operations/getConnectivityServiceDetails/": {
             "post": {
                 "responses": {
@@ -3334,30 +3299,6 @@
                     "application/json"
                 ],
                 "operationId": "createGetConnectivityServiceDetailsById"
-            }
-        },
-        "/operations/getServiceEndPointList/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/GetServiceEndPointListRPCOutputSchema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: getServiceEndPointList",
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create getServiceEndPointList by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "createGetServiceEndPointListById"
             }
         },
         "/operations/createConnectivityService/": {
@@ -4806,22 +4747,6 @@
                 }
             }
         },
-        "GetServiceEndPointDetailsRPCInputSchema": {
-            "properties": {
-                "serviceEPIdOrName": {
-                    "type": "string",
-                    "description": "none"
-                }
-            }
-        },
-        "GetServiceEndPointDetailsRPCOutputSchema": {
-            "properties": {
-                "serviceEndPoint": {
-                    "type": "string",
-                    "description": "none"
-                }
-            }
-        },
         "GetConnectivityServiceDetailsRPCInputSchema": {
             "properties": {
                 "serviceIdOrName": {
@@ -4835,14 +4760,6 @@
                 "connService": {
                     "description": "none",
                     "$ref": "#/definitions/ConnectivityService"
-                }
-            }
-        },
-        "GetServiceEndPointListRPCOutputSchema": {
-            "properties": {
-                "serviceEndPoint": {
-                    "type": "string",
-                    "description": "none"
                 }
             }
         },

--- a/UML/Tapi.notation
+++ b/UML/Tapi.notation
@@ -969,7 +969,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r4sdgz3fEea-1_BGg-qcjQ"/>
       </children>
       <element xmi:type="uml:Class" href="Tapi.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r4sdcT3fEea-1_BGg-qcjQ" x="584" y="396" width="210" height="99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r4sdcT3fEea-1_BGg-qcjQ" x="584" y="395" width="210" height="99"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_r42Oiz3fEea-1_BGg-qcjQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_r42OjD3fEea-1_BGg-qcjQ" showTitle="true"/>

--- a/UML/Tapi.uml
+++ b/UML/Tapi.uml
@@ -587,6 +587,22 @@ Indicates to what degree the LayerTermination is terminated.</body>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_FhzwMHrqEeavcODnuX7FyA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_JSfMgHrqEeavcODnuX7FyA" name="TapiService">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN8FJvEeWcs7ZjyujtOg" name="getServiceEndPointDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8VJvEeWcs7ZjyujtOg" name="serviceEPIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8lJvEeWcs7ZjyujtOg" name="serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPOAFJvEeWcs7ZjyujtOg" name="getServiceEndPointList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPOAlJvEeWcs7ZjyujtOg" name="serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WHPOA1JvEeWcs7ZjyujtOg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WHPOBFJvEeWcs7ZjyujtOg" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+    </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_cmHp5DA4Eea4fKwSGMr6CA">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_59DPoDOEEeansfg7-s4Unw" source="PapyrusVersion">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPoTOEEeansfg7-s4Unw" key="Version" value="0.2.4"/>
@@ -989,4 +1005,19 @@ Indicates to what degree the LayerTermination is terminated.</body>
   <OpenModel_Profile:OpenModelElement xmi:id="_wsEqVETZEead1bezhJG4aw" base_Element="_wsEqUUTZEead1bezhJG4aw"/>
   <OpenModel_Profile:SpecReference xmi:id="_z53cAETZEead1bezhJG4aw" base_StructuralFeature="_qG8wcETZEead1bezhJG4aw"/>
   <OpenModel_Profile:SpecTarget xmi:id="_1Vz1kETZEead1bezhJG4aw" base_StructuralFeature="_wsEqUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_FlA1MHrqEeavcODnuX7FyA" base_Element="_FhzwMHrqEeavcODnuX7FyA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JSoWcHrqEeavcODnuX7FyA" base_Element="_JSfMgHrqEeavcODnuX7FyA"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_JSoWcXrqEeavcODnuX7FyA" base_Interface="_JSfMgHrqEeavcODnuX7FyA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zlJvEeWcs7ZjyujtOg" base_Parameter="_WHPN8VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1z1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN8lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKq8YlJvEeWcs7ZjyujtOg" base_Parameter="_WHPOAlJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhh31EeaVEcfXx-aEqQ" base_Element="_WHPN8VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhx31EeaVEcfXx-aEqQ" base_Element="_WHPN8lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjB31EeaVEcfXx-aEqQ" base_Element="_WHPOAlJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjR31EeaVEcfXx-aEqQ" base_Element="_WHPOA1JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rjh31EeaVEcfXx-aEqQ" base_Element="_WHPOBFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RhR31EeaVEcfXx-aEqQ" base_Element="_WHPN8FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1zVJvEeWcs7ZjyujtOg" base_Operation="_WHPN8FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rix31EeaVEcfXx-aEqQ" base_Element="_WHPOAFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKq8YFJvEeWcs7ZjyujtOg" base_Operation="_WHPOAFJvEeWcs7ZjyujtOg"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -1005,6 +1005,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7Hv64nTwEeaoHe3mKsYq3Q" x="610" y="173"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZdeNvXrqEeavcODnuX7FyA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZdeNvnrqEeavcODnuX7FyA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZdeNwHrqEeavcODnuX7FyA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZdeNv3rqEeavcODnuX7FyA" x="610" y="173"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_vmgeMzBFEeam35bpdXJzEw">
@@ -2046,6 +2054,16 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Hv653TwEeaoHe3mKsYq3Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Hv66HTwEeaoHe3mKsYq3Q"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZdeNwXrqEeavcODnuX7FyA" type="StereotypeCommentLink" source="_0HHmGDBFEeam35bpdXJzEw" target="_ZdeNvXrqEeavcODnuX7FyA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZdeNwnrqEeavcODnuX7FyA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZdeNxnrqEeavcODnuX7FyA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZdeNw3rqEeavcODnuX7FyA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZdeNxHrqEeavcODnuX7FyA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZdeNxXrqEeavcODnuX7FyA"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_BlU0MDBGEeam35bpdXJzEw" type="2008">
@@ -2802,6 +2820,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_65dnQnTwEeaoHe3mKsYq3Q" x="482" y="33"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZVIJs3rqEeavcODnuX7FyA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZVIJtHrqEeavcODnuX7FyA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZVIJtnrqEeavcODnuX7FyA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZVIJtXrqEeavcODnuX7FyA" x="478" y="49"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_9y8uwzBFEeam35bpdXJzEw">
@@ -2817,7 +2843,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU0-DBGEeam35bpdXJzEw" type="4007" source="_BlU16TBGEeam35bpdXJzEw" target="_BlU0MDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU0-TBGEeam35bpdXJzEw" type="6016">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU0-jBGEeam35bpdXJzEw" x="25" y="24"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU0-jBGEeam35bpdXJzEw" x="-14" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU0-zBGEeam35bpdXJzEw" visible="false" type="6017">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU0_DBGEeam35bpdXJzEw" y="60"/>
@@ -3788,6 +3814,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_65dnRnTwEeaoHe3mKsYq3Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_65dnR3TwEeaoHe3mKsYq3Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_65dnSHTwEeaoHe3mKsYq3Q"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZVIJt3rqEeavcODnuX7FyA" type="StereotypeCommentLink" source="_BlU1pjBGEeam35bpdXJzEw" target="_ZVIJs3rqEeavcODnuX7FyA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZVIJuHrqEeavcODnuX7FyA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZVIJvHrqEeavcODnuX7FyA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZVIJuXrqEeavcODnuX7FyA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZVIJunrqEeavcODnuX7FyA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZVIJu3rqEeavcODnuX7FyA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -250,26 +250,11 @@
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN71JvEeWcs7ZjyujtOg" name="connEP" type="_oC2ZEEG_EeWAMMFKXSVi-w" direction="out" effect="read"/>
         </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN8FJvEeWcs7ZjyujtOg" name="getServiceEndPointDetails" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8VJvEeWcs7ZjyujtOg" name="serviceEPIdOrName" effect="read">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8lJvEeWcs7ZjyujtOg" name="serviceEndPoint" direction="out" effect="read">
-            <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-          </ownedParameter>
-        </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN81JvEeWcs7ZjyujtOg" name="getConnectivityServiceDetails" isLeaf="true">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9FJvEeWcs7ZjyujtOg" name="serviceIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9VJvEeWcs7ZjyujtOg" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read"/>
-        </ownedOperation>
-        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPOAFJvEeWcs7ZjyujtOg" name="getServiceEndPointList" isLeaf="true">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPOAlJvEeWcs7ZjyujtOg" name="serviceEndPoint" direction="out" effect="read">
-            <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WHPOA1JvEeWcs7ZjyujtOg"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WHPOBFJvEeWcs7ZjyujtOg" value="*"/>
-          </ownedParameter>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_AnTcAKU5EeWkWNPM1BHzGA" name="createConnectivityService" isLeaf="true">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="servicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" isUnique="false" effect="read">
@@ -619,11 +604,8 @@ Note that depending on the service supported by an FC, an the FC can have multip
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1yVJvEeWcs7ZjyujtOg" base_Parameter="_WHPN6lJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1y1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN7lJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zFJvEeWcs7ZjyujtOg" base_Parameter="_WHPN71JvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zlJvEeWcs7ZjyujtOg" base_Parameter="_WHPN8VJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1z1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN8lJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk10VJvEeWcs7ZjyujtOg" base_Parameter="_WHPN9FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk10lJvEeWcs7ZjyujtOg" base_Parameter="_WHPN9VJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelParameter xmi:id="_WKq8YlJvEeWcs7ZjyujtOg" base_Parameter="_WHPOAlJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MIWTMWh5EeWZEqTYAF8eqA" base_StructuralFeature="_MIWTJ2h5EeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MIWTMmh5EeWZEqTYAF8eqA" base_StructuralFeature="_MIWTK2h5EeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_sKhc4mh-EeWZEqTYAF8eqA" base_StructuralFeature="_sIutJ2h-EeWZEqTYAF8eqA"/>
@@ -863,13 +845,8 @@ Note that depending on the service supported by an FC, an the FC can have multip
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rgh31EeaVEcfXx-aEqQ" base_Element="_wH0IEN6OEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rgx31EeaVEcfXx-aEqQ" base_Element="_WHPN7lJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7RhB31EeaVEcfXx-aEqQ" base_Element="_WHPN71JvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhh31EeaVEcfXx-aEqQ" base_Element="_WHPN8VJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhx31EeaVEcfXx-aEqQ" base_Element="_WHPN8lJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7RiR31EeaVEcfXx-aEqQ" base_Element="_WHPN9FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rih31EeaVEcfXx-aEqQ" base_Element="_WHPN9VJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjB31EeaVEcfXx-aEqQ" base_Element="_WHPOAlJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjR31EeaVEcfXx-aEqQ" base_Element="_WHPOA1JvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rjh31EeaVEcfXx-aEqQ" base_Element="_WHPOBFJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7RkB31EeaVEcfXx-aEqQ" base_Element="_T9ChoKU5EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7RkR31EeaVEcfXx-aEqQ" base_Element="_hoAc0KU5EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rkh31EeaVEcfXx-aEqQ" base_Element="_hoJmwKU5EeWkWNPM1BHzGA"/>
@@ -924,10 +901,6 @@ Note that depending on the service supported by an FC, an the FC can have multip
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk10FJvEeWcs7ZjyujtOg" base_Operation="_WHPN81JvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7RfB31EeaVEcfXx-aEqQ" base_Element="_WHPN6FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1x1JvEeWcs7ZjyujtOg" base_Operation="_WHPN6FJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RhR31EeaVEcfXx-aEqQ" base_Element="_WHPN8FJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1zVJvEeWcs7ZjyujtOg" base_Operation="_WHPN8FJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rix31EeaVEcfXx-aEqQ" base_Element="_WHPOAFJvEeWcs7ZjyujtOg"/>
-  <OpenModel_Profile:OpenModelOperation xmi:id="_WKq8YFJvEeWcs7ZjyujtOg" base_Operation="_WHPOAFJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rlh31EeaVEcfXx-aEqQ" base_Element="_qH8fkL2NEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_qH8fkb2NEeWdore3Cxez9g" base_Operation="_qH8fkL2NEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_PfNxYS5zEea0_JngOlSKcA" base_Element="_PfNxYC5zEea0_JngOlSKcA"/>

--- a/YANG/Tapi.yang
+++ b/YANG/Tapi.yang
@@ -9,7 +9,7 @@ module Tapi {
         Editor: your-name
                 <mailto:your-email@example.com>";
     description "none";
-    revision 2016-07-19 {
+    revision 2016-09-14 {
         description "Latest revision";
         reference "RFC 6020 and RFC 6087";
     }
@@ -463,5 +463,33 @@ module Tapi {
             "RFC 4122: A Universally Unique IDentifier (UUID) URN
                        Namespace";
        }
+    
+    /***********************
+    * package Interfaces
+    **********************/ 
+        rpc getServiceEndPointDetails {
+            description "none";
+            input {
+                leaf serviceEPIdOrName {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container serviceEndPoint {
+                    uses ServiceEndPoint;
+                    description "none";
+                }
+            }
+        }
+        rpc getServiceEndPointList {
+            description "none";
+            output {
+                list serviceEndPoint {
+                    uses ServiceEndPoint;
+                    description "none";
+                }
+            }
+        }
     
 }

--- a/YANG/TapiConnectivity.yang
+++ b/YANG/TapiConnectivity.yang
@@ -15,7 +15,7 @@ module TapiConnectivity {
         Editor: your-name
                 <mailto:your-email@example.com>";
     description "none";
-    revision 2016-07-19 {
+    revision 2016-09-14 {
         description "Latest revision";
         reference "RFC 6020 and RFC 6087";
     }
@@ -361,21 +361,6 @@ module TapiConnectivity {
                 }
             }
         }
-        rpc getServiceEndPointDetails {
-            description "none";
-            input {
-                leaf serviceEPIdOrName {
-                    type string;
-                    description "none";
-                }
-            }
-            output {
-                leaf serviceEndPoint {
-                    type string;
-                    description "none";
-                }
-            }
-        }
         rpc getConnectivityServiceDetails {
             description "none";
             input {
@@ -387,15 +372,6 @@ module TapiConnectivity {
             output {
                 container connService {
                     uses ConnectivityService;
-                    description "none";
-                }
-            }
-        }
-        rpc getServiceEndPointList {
-            description "none";
-            output {
-                leaf serviceEndPoint {
-                    type string;
                     description "none";
                 }
             }


### PR DESCRIPTION
The RESTful SCRUD access for ServiceEndPoint schema was moved to Tapi model, but the interface/RPC operations were not, which in turn caused error in the final generated SWAGGER APIs