### PR TITLE
Bug Fix: GetTopology RPC should return the array of references, not topologies

### DIFF
--- a/SWAGGER/TapiTopology.swagger
+++ b/SWAGGER/TapiTopology.swagger
@@ -4646,7 +4646,8 @@
             "properties": {
                 "topology": {
                     "items": {
-                        "$ref": "#/definitions/Topology"
+                        "type": "string",
+                         "x-path": "/Context/_topology/{uuid}/"
                     },
                     "type": "array",
                     "description": "none"


### PR DESCRIPTION
Fixes #96 