### PR TITLE
Fix #129 - LocalClass should have a 'name' attribute/property

### DIFF
--- a/SWAGGER/Tapi.swagger
+++ b/SWAGGER/Tapi.swagger
@@ -5498,6 +5498,14 @@
                 "localId": {
                     "type": "string",
                     "description": "none"
+                },
+                "name": {
+                    "items": {
+                        "$ref": "#/definitions/NameAndValue"
+                    },
+                    "type": "array",
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "x-key": "valueName"
                 }
             }
         },

--- a/UML/Tapi.notation
+++ b/UML/Tapi.notation
@@ -691,13 +691,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_rbYfVDNrEea0Br-ajMxp_A" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_rbYfVTNrEea0Br-ajMxp_A" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_u0cs4DNrEea0Br-ajMxp_A" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_u0uY4JLSEeaqpNd__7dv4w" type="3012">
           <element xmi:type="uml:Property" href="Tapi.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_u0cs4TNrEea0Br-ajMxp_A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_u0uY4ZLSEeaqpNd__7dv4w"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_8nwrwDNrEea0Br-ajMxp_A" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_u0uY4pLSEeaqpNd__7dv4w" type="3012">
+          <element xmi:type="uml:Property" href="Tapi.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_u0uY45LSEeaqpNd__7dv4w"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_u0uY5JLSEeaqpNd__7dv4w" type="3012">
           <element xmi:type="uml:Property" href="Tapi.uml#__gLXQxrpEeaeisu1tQM3_Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8nwrwTNrEea0Br-ajMxp_A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_u0uY5ZLSEeaqpNd__7dv4w"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_rbYfVjNrEea0Br-ajMxp_A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_rbYfVzNrEea0Br-ajMxp_A"/>
@@ -717,7 +721,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rbYfYzNrEea0Br-ajMxp_A"/>
       </children>
       <element xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rbYfUTNrEea0Br-ajMxp_A" x="402" y="27" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rbYfUTNrEea0Br-ajMxp_A" x="402" y="18" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rbhpWzNrEea0Br-ajMxp_A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rbhpXDNrEea0Br-ajMxp_A" showTitle="true"/>

--- a/UML/Tapi.uml
+++ b/UML/Tapi.uml
@@ -197,6 +197,13 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
         <ownedAttribute xmi:type="uml:Property" xmi:id="_dlarAN8qEeWT9tG0gGLRFw" name="localId">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MP7aAJLQEeaqpNd__7dv4w" name="name" type="_6efrYNnVEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_-rk80JLSEeaqpNd__7dv4w">
+            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ne02EJLQEeaqpNd__7dv4w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ne02EpLQEeaqpNd__7dv4w" value="*"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__gLXQxrpEeaeisu1tQM3_Q" name="_extensions" type="_VZkuoC6BEea0_JngOlSKcA" isReadOnly="true" aggregation="composite" association="__gLXQBrpEeaeisu1tQM3_Q">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2iUTUDNyEea0Br-ajMxp_A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2iUTUjNyEea0Br-ajMxp_A" value="*"/>
@@ -1020,4 +1027,9 @@ Indicates to what degree the LayerTermination is terminated.</body>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1zVJvEeWcs7ZjyujtOg" base_Operation="_WHPN8FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rix31EeaVEcfXx-aEqQ" base_Element="_WHPOAFJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKq8YFJvEeWcs7ZjyujtOg" base_Operation="_WHPOAFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MP7aAZLQEeaqpNd__7dv4w" base_Element="_MP7aAJLQEeaqpNd__7dv4w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MP7aApLQEeaqpNd__7dv4w" base_StructuralFeature="_MP7aAJLQEeaqpNd__7dv4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Ne02EZLQEeaqpNd__7dv4w" base_Element="_Ne02EJLQEeaqpNd__7dv4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Ne02E5LQEeaqpNd__7dv4w" base_Element="_Ne02EpLQEeaqpNd__7dv4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_-rk80ZLSEeaqpNd__7dv4w" base_Element="_-rk80JLSEeaqpNd__7dv4w"/>
 </xmi:XMI>

--- a/YANG/Tapi.yang
+++ b/YANG/Tapi.yang
@@ -93,6 +93,11 @@ module Tapi {
                 type string;
                 description "none";
             }
+            list name {
+                key 'valueName';
+                uses NameAndValue;
+                description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
+            }
             list _extensions {
                 key 'extensionsSpecification';
                 config false;


### PR DESCRIPTION
Fixes #129 - This can be used to specify the specific label-value of a ServicePort (such as timeslot, vlan, etc) in cases the corresponding ServiceEndPoint supports a range/multiple values