### PR TITLE
Raw TAPI YANG files generated by the EAGLE xmi2yang tool (e95c9fb)

### DIFF
--- a/YANG/.settings/org.eclipse.core.resources.prefs
+++ b/YANG/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,3 @@
 eclipse.preferences.version=1
-encoding/Tapi.yang=UTF-8
-encoding/TapiTopology.yang=UTF-8
+encoding/tapi-common.yang=UTF-8
+encoding/tapi-topology.yang=UTF-8

--- a/YANG/project/config.txt
+++ b/YANG/project/config.txt
@@ -1,0 +1,13 @@
+Notice: this config file will be read to JSON. If you want to write some special characters "'", """ and "\" in the content, please add an escape character in front of them. For example, if the content should include "I'm", please write "I\'m" instead.
+
+If there are errors in reading config file, please report an issue on git.
+
+{"namespace":"urn:onf:params:xml:ns:yang:",
+"prefix":"Tapi-abc",
+"organization":"Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project",
+"contact":"
+WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>",
+"revision":{"date":"2016-12-15", "description":"TAPI SDK 1.1.alpha", "reference":"ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087"}}

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -1,257 +1,192 @@
-module Tapi {
-    namespace "urn:onf:params:xml:ns:yang:Tapi";
-    prefix Tapi;
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+module tapi-common {
+    namespace "urn:onf:params:xml:ns:yang:TapiCommon";
+    prefix tapi-abc;
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-09-14 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_serviceEndPoint" {
-        uses ServiceEndPoint;
+        uses service-end-point;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping AdminStatePac {
-            leaf administrativeState {
-                type AdministrativeState;
+        grouping admin-state-pac {
+            leaf administrative-state {
+                type administrative-state;
                 description "none";
             }
-            leaf operationalState {
-                type OperationalState;
+            leaf operational-state {
+                type operational-state;
                 description "none";
             }
-            leaf lifecycleState {
-                type LifecycleState;
+            leaf lifecycle-state {
+                type lifecycle-state;
                 description "none";
             }
             description "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.";
         }
-        grouping GlobalClass {
+        grouping global-class {
             leaf uuid {
-                type UniversalId;
+                type universal-id;
                 description "UUID: An identifier that is universally unique
                     (consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)";
             }
             list name {
-                key 'valueName';
-                uses NameAndValue;
+                key 'value-name';
+                min-elements 1;
+                uses name-and-value;
                 description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
             }
             list label {
-                key 'valueName';
-                uses NameAndValue;
+                key 'value-name';
+                uses name-and-value;
                 description "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.";
-            }
-            list _extensions {
-                key 'extensionsSpecification';
-                config false;
-                uses ExtensionsSpec;
-                description "none";
             }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
         }
-        grouping LayerProtocol {
-            leaf layerProtocolName {
-                type LayerProtocolName;
+        list layer-protocol {
+            key 'local-id';
+            uses layer-protocol;
+            description "none";
+        }
+        grouping layer-protocol {
+            leaf layer-protocol-name {
+                type layer-protocol-name;
                 description "Indicate the specific layer-protocol described by the LayerProtocol entity.";
             }
-            leaf terminationDirection {
-                type TerminationDirection;
+            leaf termination-direction {
+                type termination-direction;
                 description "The overall directionality of the LP. 
                     - A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.
                     - A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows
                     - A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows";
             }
-            leaf terminationState {
-                type TerminationState;
+            leaf termination-state {
+                type termination-state;
                 description "Indicates whether the layer is terminated and if so how.";
             }
-            uses LocalClass;
+            uses local-class;
             description "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. 
                 It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. 
                 Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ";
         }
-        grouping LifecycleStatePac {
-            leaf lifecycleState {
-                type LifecycleState;
+        grouping lifecycle-state-pac {
+            leaf lifecycle-state {
+                type lifecycle-state;
                 description "none";
             }
             description "Provides state attributes for an entity that has lifeccycle aspects only.";
         }
-        grouping LocalClass {
-            leaf localId {
+        grouping local-class {
+            leaf local-id {
                 type string;
                 description "none";
             }
             list name {
-                key 'valueName';
-                uses NameAndValue;
+                key 'value-name';
+                uses name-and-value;
                 description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
-            }
-            list _extensions {
-                key 'extensionsSpecification';
-                config false;
-                uses ExtensionsSpec;
-                description "none";
             }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
         }
-        grouping OperationalStatePac {
-            leaf operationalState {
-                type OperationalState;
+        grouping operational-state-pac {
+            leaf operational-state {
+                type operational-state;
                 description "none";
             }
-            leaf lifecycleState {
-                type LifecycleState;
+            leaf lifecycle-state {
+                type lifecycle-state;
                 description "none";
             }
             description "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.";
         }
-        grouping TimeRange {
-            leaf endTime {
-                type DateAndTime;
+        container time-range {
+            uses time-range;
+            description "none";
+        }
+        grouping time-range {
+            leaf end-time {
+                type date-and-time;
                 description "none";
             }
-            leaf startTime {
-                type DateAndTime;
+            leaf start-time {
+                type date-and-time;
                 description "none";
             }
             description "none";
         }
-        grouping ExtensionsSpec {
-            leaf extensionsSpecification {
-                type string;
-                config false;
-                description "none";
-            }
-            leaf-list extensionsSpecTarget {
-                type string;
-                config false;
-                min-elements 0;
-                description "none";
-            }
+        grouping extensions-spec {
             description "none";
         }
-        grouping Context {
-            container _nwTopologyService {
-                presence "Context is available";
-                config false;
-                uses ServiceSpec;
-                description "none";
-            }
-            list _connectivityService {             
-                key 'uuid';
-                uses ServiceSpec;
-                description "none";
-            }
-            list _vnwService {
-                key 'uuid';
-                uses ServiceSpec;
-                description "none";
-            }
-            list _pathCompService {
-                key 'uuid';
-                uses ServiceSpec;
-                description "none";
-            }
-            list _notifSubscription {
-                key 'uuid';
-                uses ServiceSpec;
-                description "none";
-            }
-            list _serviceEndPoint {
-                key 'uuid';
-                config false;
-                uses ResourceSpec;
-                description "none";
-            }
-            list _topology {
-                key 'uuid';
-                config false;
-                uses ResourceSpec;
-                description "none";
-            }
-            list _connection {
-                key 'uuid';
-                config false;
-                uses ResourceSpec;
-                description "none";
-            }
-            list _path {
-                key 'uuid';
-                config false;
-                uses ResourceSpec;
-                description "none";
-            }
-            list _notification {
-                key 'uuid';
-                config false;
-                uses ResourceSpec;
-                description "none";
-            }
-            uses GlobalClass;
+        list context {
+            key 'uuid';
+            uses context;
+            description "none";
+        }
+        grouping context {
+            uses global-class;
             description "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).";
         }
-        container Context {
-            presence "Context is available";
-            uses Context;
-            description "none";        
-        }
-        grouping ResourceSpec {
-            uses GlobalClass;
+        grouping resource-spec {
+            uses global-class;
             description "none";
         }
-        grouping ServiceSpec {
-            uses GlobalClass;
+        grouping service-spec {
+            uses global-class;
             description "none";
         }
-        grouping ServiceEndPoint {
-            list _layerProtocol {
-                key 'localId';
+        list service-end-point {
+            key 'uuid';
+            uses service-end-point;
+            description "none";
+        }
+        grouping service-end-point {
+            list layer-protocol {
+                key 'local-id';
                 config false;
                 min-elements 1;
-                uses LayerProtocol;
+                uses layer-protocol;
                 description "none";
             }
-            container _state {
+            container state {
                 config false;
-                uses LifecycleStatePac;
+                uses lifecycle-state-pac;
                 description "none";
             }
             leaf direction {
-                type TerminationDirection;
+                type termination-direction;
                 config false;
                 description "none";
             }
-            //uses ResourceSpec;
+            uses resource-spec;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
-    
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        typedef AdministrativeState {
+        typedef administrative-state {
             type enumeration {
-                enum LOCKED {
+                enum locked {
                     description "Users are administratively prohibited from making use of the resource.";
                 }
-                enum UNLOCKED {
+                enum unlocked {
                     description "Users are allowed to use the resource";
                 }
             }
             description "The possible values of the administrativeState.";
         }
-        typedef DateAndTime {
+        typedef date-and-time {
             type string;
             description "This primitive type defines the date and time according to the following structure:
                 yyyyMMddhhmmss.s[Z|{+|-}HHMm] where:
@@ -267,52 +202,52 @@ module Tapi {
                 HH        00..23            time zone difference in hours
                 Mm    00..59            time zone difference in minutes.";
         }
-        typedef DirectiveValue {
+        typedef directive-value {
             type enumeration {
-                enum MINIMIZE {
+                enum minimize {
                     description "none";
                 }
-                enum MAXIMIZE {
+                enum maximize {
                     description "none";
                 }
-                enum ALLOW {
+                enum allow {
                     description "none";
                 }
-                enum DISALLOW {
+                enum disallow {
                     description "none";
                 }
-                enum DONT_CARE {
+                enum dont-care {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef ForwardingDirection {
+        typedef forwarding-direction {
             type enumeration {
-                enum BIDIRECTIONAL {
+                enum bidirectional {
                     description "The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)";
                 }
-                enum UNIDIRECTIONAL {
+                enum unidirectional {
                     description "The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.";
                 }
-                enum UNDEFINED_OR_UNKNOWN {
+                enum undefined-or-unknown {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
             description "The directionality of a Forwarding entity.";
         }
-        typedef LayerProtocolName {
+        typedef layer-protocol-name {
             type enumeration {
-                enum OCH {
+                enum och {
                     description "none";
                 }
-                enum ODU {
+                enum odu {
                     description "none";
                 }
-                enum ETH {
+                enum eth {
                     description "none";
                 }
-                enum MPLS_TP {
+                enum mpls-tp {
                     description "none";
                 }
             }
@@ -323,30 +258,32 @@ module Tapi {
                 -    Layer 2 (L2): Carrier Grade Ethernet (ETY, ETH), MPLS-TP (MT)
                 ";
         }
-        typedef LifecycleState {
+        typedef lifecycle-state {
             type enumeration {
-                enum PLANNED {
+                enum planned {
                     description "The resource is planned but is not present in the network.";
                 }
-                enum POTENTIAL {
+                enum potential {
                     description "The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.
                         o    When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.
                         o    If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.";
                 }
-                enum INSTALLED {
+                enum installed {
                     description "The resource is present in the network and is capable of providing the service expected.";
                 }
-                enum RESTORING {
-                    description "The resource is resilient and is performing a restoration operation.";
-                }
-                enum PENDING_REMOVAL {
+                enum pending-removal {
                     description "The resource has been marked for removal";
                 }
             }
             description "The possible values of the lifecycleState.";
         }
-        grouping NameAndValue {
-            leaf valueName {
+        list name-and-value {
+            key 'value-name';
+            uses name-and-value;
+            description "none";
+        }
+        grouping name-and-value {
+            leaf value-name {
                 type string;
                 description "The name of the value. The value need not have a name.";
             }
@@ -356,57 +293,57 @@ module Tapi {
             }
             description "A scoped name-value pair";
         }
-        typedef OperationalState {
+        typedef operational-state {
             type enumeration {
-                enum DISABLED {
+                enum disabled {
                     description "The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.";
                 }
-                enum ENABLED {
+                enum enabled {
                     description "The resource is partially or fully operable and available for use";
                 }
             }
             description "The possible values of the operationalState.";
         }
-        typedef PortDirection {
+        typedef port-direction {
             type enumeration {
-                enum BIDIRECTIONAL {
+                enum bidirectional {
                     description "The Port has both an INPUT flow and an OUTPUT flow defined.";
                 }
-                enum INPUT {
+                enum input {
                     description "The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).";
                 }
-                enum OUTPUT {
+                enum output {
                     description "The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).";
                 }
-                enum UNIDENTIFIED_OR_UNKNOWN {
+                enum unidentified-or-unknown {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
             description "The orientation of flow at the Port of a Forwarding entity";
         }
-        typedef PortRole {
+        typedef port-role {
             type enumeration {
-                enum SYMMETRIC {
+                enum symmetric {
                     description "none";
                 }
-                enum ROOT {
+                enum root {
                     description "none";
                 }
-                enum LEAF {
+                enum leaf {
                     description "none";
                 }
-                enum UNKNOWN {
+                enum unknown {
                     description "none";
                 }
             }
             description "The role of an end in the context of the function of the forwarding entity that it bounds";
         }
-        typedef TerminationDirection {
+        typedef termination-direction {
             type enumeration {
-                enum BIDIRECTIONAL {
+                enum bidirectional {
                     description "A Termination with both SINK and SOURCE flows.";
                 }
-                enum SINK {
+                enum sink {
                     description "The flow is up the layer stack from the server side to the client side. 
                         Considering an example of a Termination function within the termination entity, a SINK flow:
                         - will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component
@@ -415,7 +352,7 @@ module Tapi {
                         A SINK termination is one that only supports a SINK flow.
                         A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity";
                 }
-                enum SOURCE {
+                enum source {
                     description "The flow is down the layer stack from the server side to the client side. 
                         Considering an example of a Termination function within the termination entity, a SOURCE flow:
                         - will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component
@@ -424,82 +361,70 @@ module Tapi {
                         A SOURCE termination is one that only supports a SOURCE flow.
                         A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity";
                 }
-                enum UNDEFINED_OR_UNKNOWN {
+                enum undefined-or-unknown {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
             description "The directionality of a termination entity";
         }
-        typedef TerminationState {
+        typedef termination-state {
             type enumeration {
-                enum LP_CAN_NEVER_TERMINATE {
+                enum lp-can-never-terminate {
                     description "A non-flexible case that can never be terminated.";
                 }
-                enum LT_NOT_TERMINATED {
+                enum lt-not-terminated {
                     description "A flexible termination that can terminate but is currently not terminated.";
                 }
-                enum TERMINATED_SERVER_TO_CLIENT_FLOW {
+                enum terminated-server-to-client-flow {
                     description "A flexible termination that is currently terminated for server to client flow only.";
                 }
-                enum TERMINATED_CLIENT_TO_SERVER_FLOW {
+                enum terminated-client-to-server-flow {
                     description "A flexible termination that is currently terminated for client to server flow only.";
                 }
-                enum TERMINATED_BIDIRECTIONAL {
+                enum terminated-bidirectional {
                     description "A flexible termination that is currently terminated in both directions of flow.";
                 }
-                enum LT_PERMENANTLY_TERMINATED {
+                enum lt-permenantly-terminated {
                     description "A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).";
                 }
-                enum TERMINATION_STATE_UNKNOWN {
+                enum termination-state-unknown {
                     description "There TerminationState cannot be determined.";
                 }
             }
             description "Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.
                 Indicates to what degree the LayerTermination is terminated.";
         }
-        typedef UniversalId {
-            type string {
-                pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
-            }
-           description
-            "A Universally Unique IDentifier in the string representation
-             defined in RFC 4122.  The canonical representation uses
-             lowercase characters.
-    
-             The following is an example of a UUID in string representation:
-             f81d4fae-7dec-11d0-a765-00a0c91e6bf6
-             ";
-           reference
-            "RFC 4122: A Universally Unique IDentifier (UUID) URN
-                       Namespace";
-       }
-    
+        typedef universal-id {
+            type string;
+            description "The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.";
+        }
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc getServiceEndPointDetails {
+        rpc get-service-end-point-details {
             description "none";
             input {
-                leaf serviceEPIdOrName {
+                leaf service-epid-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container serviceEndPoint {
-                    uses ServiceEndPoint;
+                container service-end-point {
+                    uses service-end-point;
                     description "none";
                 }
             }
         }
-        rpc getServiceEndPointList {
+        rpc get-service-end-point-list {
             description "none";
             output {
-                list serviceEndPoint {
-                    uses ServiceEndPoint;
+                list service-end-point {
+                    uses service-end-point;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -1,277 +1,302 @@
-module TapiConnectivity {
+module tapi-connectivity {
     namespace "urn:onf:params:xml:ns:yang:TapiConnectivity";
-    prefix TapiConnectivity;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    import TapiTopology {
-        prefix TapiTopology;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    import tapi-path-computation {
+        prefix tapi-path-computation;
+    }
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-09-14 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_connection" {
-        uses Connection;
+        uses connection;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_connectivityService" {
-        uses ConnectivityService;
+        uses connectivity-service;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping Connection {
-            list _connectionPort {
-                key 'localId';
+        list connection {
+            key 'uuid';
+            uses connection;
+            description "none";
+        }
+        grouping connection {
+            list connection-end-point {
+                key 'uuid';
                 config false;
-                uses ConnectionPort;
+                min-elements 2;
+                uses connection-end-point;
                 description "none";
             }
-            list _route {
-                key 'localId';
+            list route {
+                key 'local-id';
                 config false;
-                uses Route;
+                uses route;
                 description "none";
             }
-            leaf _node {
+            leaf node {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
-            container _state {
+            container state {
                 config false;
-                uses Tapi:OperationalStatePac;
+                uses tapi-common:operational-state-pac;
                 description "none";
             }
-            leaf layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
             leaf direction {
-                type Tapi:ForwardingDirection;
+                type tapi-common:forwarding-direction;
                 config false;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        grouping ConnectionEndPoint {
-            list _layerProtocol {
-                key 'localId';
+        list connection-end-point {
+            key 'uuid';
+            uses connection-end-point;
+            description "none";
+        }
+        grouping connection-end-point {
+            list layer-protocol {
+                key 'local-id';
                 config false;
                 min-elements 1;
-                uses Tapi:LayerProtocol;
+                uses tapi-common:layer-protocol;
                 description "none";
             }
-            leaf-list _clientNodeEdgePoint {
+            leaf-list client-node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf _serverNodeEdgePoint {
+            leaf server-node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf _peerConnectionEndPoint {
+            leaf peer-connection-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:uuid';
+                    path '/tapi:context/tapi:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
                 }
                 config false;
                 description "none";
             }
-            container _state {
+            container state {
                 config false;
-                uses Tapi:OperationalStatePac;
+                uses tapi-common:operational-state-pac;
                 description "none";
             }
-            leaf direction {
-                type Tapi:TerminationDirection;
+            leaf termination-direction {
+                type tapi-common:termination-direction;
                 config false;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
-            description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
-                The structure of LTP supports all transport protocols including circuit and packet forms.";
-        }
-        grouping ConnectionPort {
-            container _connectionEndPoint {
-                config false;
-                uses ConnectionEndPoint;
-                description "none";
-            }
-            leaf role {
-                type Tapi:PortRole;
-                config false;
-                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
-            }
-            leaf direction {
-                type Tapi:PortDirection;
+            leaf connection-port-direction {
+                type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
             }
-            uses Tapi:LocalClass;
-            description "The association of the FC to LTPs is made via EndPoints.
-                The EndPoint (EP) object class models the access to the FC function. 
-                The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
-                In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. 
-                It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
-                The EP replaces the Protection Unit of a traditional protection model. 
-                The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
+            leaf connection-port-role {
+                type tapi-common:port-role;
+                config false;
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            }
+            uses tapi-common:resource-spec;
+            description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
+                The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
-        grouping ConnectivityConstraint {
-            leaf serviceType {
-                type ServiceType;
+        container connectivity-constraint {
+            uses connectivity-constraint;
+            description "none";
+        }
+        grouping connectivity-constraint {
+            leaf service-type {
+                type service-type;
                 config false;
                 description "none";
             }
-            leaf serviceLevel {
+            leaf service-level {
                 type string;
                 config false;
                 description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
             }
-            leaf-list serviceLayer {
-                type Tapi:LayerProtocolName;
+            leaf-list preferred-transport-layer {
+                type tapi-common:layer-protocol-name;
                 config false;
+                description "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers";
+            }
+            container requested-capacity {
+                config false;
+                uses tapi-topology:capacity;
                 description "none";
             }
-            container requestedCapacity {
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
                 config false;
-                uses TapiTopology:Capacity;
-                description "none";
-            }
-            list costCharacteristic {
-                key 'costName costValue costAlgorithm';
-                config false;
-                uses TapiTopology:CostCharacteristic;
+                uses tapi-topology:cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
-            list latencyCharacteristic {
-                key 'trafficPropertyName trafficPropertyQueingLatency';
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
                 config false;
-                uses TapiTopology:LatencyCharacteristic;
+                uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
-            leaf-list _diversityExclusion {
+            leaf coroute-inclusion {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_connectivityService/Tapi:uuid';
+                    path '/tapi:context/tapi:connectivity-service/tapi:uuid';
                 }
                 description "none";
             }
-            leaf-list _corouteInclusion {
+            leaf-list diversity-exclusion {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_connectivityService/Tapi:uuid';
+                    path '/tapi:context/tapi:connectivity-service/tapi:uuid';
                 }
                 description "none";
             }
-            leaf-list _includeTopology {
+            leaf-list include-topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
-                }
-                config false;
-                description "none";
-            }
-            leaf-list _avoidTopology {
-                type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            list _includePath {
-                key 'localId';
+            leaf-list avoid-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
                 config false;
-                uses TapiTopology:TeLink;
                 description "none";
             }
-            list _excludePath {
-                key 'localId';
-                config false;
-                uses TapiTopology:TeLink;
+            leaf-list include-path {
+                type leafref {
+                    path '/tapi:context/tapi:path/tapi:uuid';
+                }
                 description "none";
             }
-            uses Tapi:LocalClass;
+            leaf-list exclude-path {
+                type leafref {
+                    path '/tapi:context/tapi:path/tapi:uuid';
+                }
+                description "none";
+            }
+            list include-route {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            list exclude-route {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            uses tapi-common:local-class;
             description "none";
         }
-        grouping ConnectivityService {
-            leaf-list _connection {
+        list connectivity-service {
+            key 'uuid';
+            uses connectivity-service;
+            description "none";
+        }
+        grouping connectivity-service {
+            leaf-list connection {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_connection/Tapi:uuid';
+                    path '/tapi:context/tapi:connection/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            list _servicePort {
-                key 'localId';
-                uses ConnectivityServicePort;
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                uses connectivity-service-port;
                 description "none";
             }
-            container _connConstraint {
-                uses ConnectivityConstraint;
+            container conn-constraint {
+                uses connectivity-constraint;
                 description "none";
             }
-            container _schedule {
-                uses Tapi:TimeRange;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
-            container _state {
-                uses Tapi:AdminStatePac;
+            container state {
+                uses tapi-common:admin-state-pac;
                 description "none";
             }
             leaf direction {
-                type Tapi:ForwardingDirection;
+                type tapi-common:forwarding-direction;
                 description "none";
             }
-            leaf layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 description "none";
             }
-            uses Tapi:ServiceSpec;
+            uses tapi-common:service-spec;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        grouping ConnectivityServicePort {
-            leaf _serviceEndPoint {
+        list connectivity-service-port {
+            key 'local-id';
+            uses connectivity-service-port;
+            description "none";
+        }
+        grouping connectivity-service-port {
+            leaf service-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf role {
-                type Tapi:PortRole;
+                type tapi-common:port-role;
                 config false;
                 description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
             }
             leaf direction {
-                type Tapi:PortDirection;
+                type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
             }
-            leaf serviceLayer {
-                type Tapi:LayerProtocolName;
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "The association of the FC to LTPs is made via EndPoints.
                 The EndPoint (EP) object class models the access to the FC function. 
                 The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
@@ -280,178 +305,174 @@ module TapiConnectivity {
                 The EP replaces the Protection Unit of a traditional protection model. 
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
-        grouping Route {
-            leaf-list _lowerConnection {
+        list route {
+            key 'local-id';
+            uses route;
+            description "none";
+        }
+        grouping route {
+            leaf-list lower-connection {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_connection/Tapi:uuid';
+                    path '/tapi:context/tapi:connection/tapi:uuid';
                 }
                 config false;
                 min-elements 1;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "The FC Route (FcRoute) object class models the individual routes of an FC. 
                 The route of an FC object is represented by a list of FCs at a lower level. 
                 Note that depending on the service supported by an FC, an the FC can have multiple routes.";
         }
-    
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        typedef ServiceType {
+        typedef service-type {
             type enumeration {
-                enum POINT_TO_POINT_CONNECTIVITY {
+                enum point-to-point-connectivity {
                     description "none";
                 }
-                enum POINT_TO_MULTIPOINT_CONNECTIVITY {
+                enum point-to-multipoint-connectivty {
                     description "none";
                 }
-                enum MULTIPOINT_CONNECTIVITY {
+                enum multipoint-connectivity {
                     description "none";
                 }
             }
             description "none";
         }
-    
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc getConnectionList {
-            description "none";
-            output {
-                list connection {
-                    uses Connection;
-                    description "none";
-                }
-            }
-        }
-        rpc getConnectionDetails {
+        rpc get-connection-details {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf connectionIdOrName {
+                leaf connection-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
                 container connection {
-                    uses Connection;
+                    uses connection;
                     description "none";
                 }
             }
         }
-        rpc getConnectivityServiceList {
+        rpc get-connectivity-service-list {
             description "none";
             output {
-                list connService {
-                    uses ConnectivityService;
+                list conn-service {
+                    uses connectivity-service;
                     description "none";
                 }
             }
         }
-        rpc getConnectionEndPointDetails {
+        rpc get-connection-end-point-details {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf connectionIdOrName {
+                leaf connection-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf connEPIdOrName {
-                    type string;
-                    description "none";
-                }
-            }
-            output {
-                container connEP {
-                    uses ConnectionEndPoint;
-                    description "none";
-                }
-            }
-        }
-        rpc getConnectivityServiceDetails {
-            description "none";
-            input {
-                leaf serviceIdOrName {
+                leaf conn-epid-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container connService {
-                    uses ConnectivityService;
+                container conn-ep {
+                    uses connection-end-point;
                     description "none";
                 }
             }
         }
-        rpc createConnectivityService {
+        rpc get-connectivity-service-details {
             description "none";
             input {
-                list servicePort {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+        rpc create-connectivity-service {
+            description "none";
+            input {
+                list service-port {
                     min-elements 2;
-                    uses ConnectivityServicePort;
+                    uses connectivity-service-port;
                     description "none";
                 }
-                container connConstraint {
-                    uses ConnectivityConstraint;
+                container conn-constraint {
+                    uses connectivity-constraint;
                     description "none";
                 }
-                leaf connSchedule {
+                leaf conn-schedule {
                     type string;
                     description "none";
                 }
             }
             output {
-                container connService {
-                    uses ConnectivityService;
+                container conn-service {
+                    uses connectivity-service;
                     description "none";
                 }
             }
         }
-        rpc updateConnectivityService {
+        rpc update-connectivity-service {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
-                container connConstraint {
-                    uses ConnectivityConstraint;
+                container conn-constraint {
+                    uses connectivity-constraint;
                     description "none";
                 }
-                leaf connSchedule {
+                leaf conn-schedule {
                     type string;
                     description "none";
                 }
             }
             output {
-                container connService {
-                    uses ConnectivityService;
+                container conn-service {
+                    uses connectivity-service;
                     description "none";
                 }
             }
         }
-        rpc deleteConnectivityService {
+        rpc delete-connectivity-service {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container connService {
-                    uses ConnectivityService;
+                container conn-service {
+                    uses connectivity-service;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -1,59 +1,64 @@
-module TapiEth {
+module tapi-eth {
     namespace "urn:onf:params:xml:ns:yang:TapiEth";
-    prefix TapiEth;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    import TapiTopology {
-        prefix TapiTopology;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    import TapiConnectivity {
-        prefix TapiConnectivity;
+    import tapi-connectivity {
+        prefix tapi-connectivity;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
-        uses ConnectionEndPointLpSpec;
+        uses connection-end-point-lp-spec;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
-        uses NodeEdgePointLpSpec;
+        uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping ConnectionPointAndAdapterPac {
-            leaf-list auxiliaryFunctionPositionSequence {
+        container connection-point-and-adapter-pac {
+            uses connection-point-and-adapter-pac;
+            description "none";
+        }
+        grouping connection-point-and-adapter-pac {
+            leaf-list auxiliary-function-position-sequence {
                 type uint64;
                 description "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.";
             }
-            leaf vlanConfig {
+            leaf vlan-config {
                 type uint64;
                 description "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.
                     range of type : -1, 0, 1..4094";
             }
-            leaf csfRdiFdiEnable {
+            leaf csf-rdi-fdi-enable {
                 type boolean;
                 description "This attribute models the MI_CSFrdifdiEnable information defined in G.8021.";
             }
-            leaf csfReport {
+            leaf csf-report {
                 type boolean;
                 description "This attribute models the MI_CSF_Reported information defined in G.8021.
                     range of type : true, false";
             }
-            leaf-list filterConfigSnk {
-                type MacAddress;
+            leaf-list filter-config-snk {
+                type mac-address;
+                min-elements 33;
+                max-elements 33;
                 description "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:
                     01-80-C2-00-00-10, 
                     01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and 
@@ -62,14 +67,14 @@ module TapiEth {
                     If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. 
                     If none of the above addresses match, the ETH_CI_D is passed.";
             }
-            leaf macLength {
+            leaf mac-length {
                 type uint64;
                 default "2000";
                 description "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.
                     range of type : 1518, 1522, 2000";
             }
-            container filterConfig {
-                uses ControlFrameFilter;
+            container filter-config {
+                uses control-frame-filter;
                 description "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:
                     - All bridges address: 01-80-C2-00-00-10,
                     - Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,
@@ -78,17 +83,17 @@ module TapiEth {
                     If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. 
                     If none of the above addresses match, the ETH_CI_D is passed.";
             }
-            leaf isSsfReported {
+            leaf is-ssf-reported {
                 type boolean;
                 description "This attribute provisions whether the SSF defect should be reported as fault cause or not.
                     It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.";
             }
-            leaf pllThr {
+            leaf pll-thr {
                 type uint64;
                 description "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.
                     range of type : 0..number of ports";
             }
-            leaf actorOperKey {
+            leaf actor-oper-key {
                 type uint64;
                 config false;
                 description "See 802.1AX:
@@ -96,79 +101,89 @@ module TapiEth {
                     The meaning of particular Key values is of local significance.
                     range of type : 16 bit";
             }
-            leaf actorSystemId {
-                type MacAddress;
+            leaf actor-system-id {
+                type mac-address;
                 description "See 802.1AX:
                     A MAC address used as a unique identifier for the System that contains this Aggregator.";
             }
-            leaf actorSystemPriority {
+            leaf actor-system-priority {
                 type uint64;
                 description "See 802.1AX:
                     Indicating the priority associated with the Actor’s System ID.
                     range of type : 2-octet";
             }
-            leaf collectorMaxDelay {
+            leaf collector-max-delay {
                 type uint64;
                 description "See 802.1AX:
                     The value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).
                     range of type : 16-bit";
             }
-            leaf dataRate {
+            leaf data-rate {
                 type uint64;
                 config false;
                 description "See 802.1AX:
                     The current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links.";
             }
-            leaf partnerOperKey {
+            leaf partner-oper-key {
                 type uint64;
                 config false;
                 description "See 802.1AX:
                     The current operational value of the Key for the Aggregator’s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.
                     range of type : 16-bit";
             }
-            leaf partnerSystemId {
-                type MacAddress;
+            leaf partner-system-id {
+                type mac-address;
                 config false;
                 description "See 802.1AX:
                     A MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System.";
             }
-            leaf partnerSystemPriority {
+            leaf partner-system-priority {
                 type uint64;
                 config false;
                 description "See 802.1AX:
                     Indicates the priority associated with the Partner’s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.
                     range of type : 2-octet";
             }
-            leaf csfConfig {
-                type CsfConfig;
+            leaf csf-config {
+                type csf-config;
                 description "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.
                     range of type : true, false";
             }
             description "none";
         }
-        grouping ConnectionEndPointLpSpec {
-            container _terminationSpec {
-                uses EthTerminationPac;
-                description "none";
-            }
-            container _adapterSpec {
-                uses ConnectionPointAndAdapterPac;
-                description "none";
-            }
-            uses Tapi:ExtensionsSpec;
+        container connection-end-point-lp-spec {
+            uses connection-end-point-lp-spec;
             description "none";
         }
-        grouping EthTerminationPac {
-            container priorityRegenerate {
-                uses PriorityMapping;
+        grouping connection-end-point-lp-spec {
+            container termination-spec {
+                uses eth-termination-pac;
+                description "none";
+            }
+            container adapter-spec {
+                uses connection-point-and-adapter-pac;
+                description "none";
+            }
+            uses tapi-common:extensions-spec;
+            description "none";
+        }
+        container eth-termination-pac {
+            uses eth-termination-pac;
+            description "none";
+        }
+        grouping eth-termination-pac {
+            container priority-regenerate {
+                uses priority-mapping;
                 description "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.";
             }
-            leaf etherType {
-                type VlanType;
+            leaf ether-type {
+                type vlan-type;
                 description "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.";
             }
-            leaf-list filterConfig {
-                type MacAddress;
+            leaf-list filter-config {
+                type mac-address;
+                min-elements 33;
+                max-elements 33;
                 description "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.
                     It indicates the configured filter action for each of the 33 group MAC addresses for control frames.
                     The 33 MAC addresses are:
@@ -187,58 +202,68 @@ module TapiEth {
                     ActionEnum:
                     PASS, BLOCK";
             }
-            leaf frametypeConfig {
-                type FrameType;
+            leaf frametype-config {
+                type frame-type;
                 description "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.
                     range of type : see Enumeration";
             }
-            leaf portVid {
-                type Vid;
+            leaf port-vid {
+                type vid {
+                    range "0..4095";
+                }
                 default "1";
                 description "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021.";
             }
-            leaf priorityCodePointConfig {
-                type PcpCoding;
+            leaf priority-code-point-config {
+                type pcp-coding;
                 default "8P0D";
                 description "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.
                     range of type : see Enumeration";
             }
             description "This object class models the Ethernet Flow Termination function located at a layer boundary.";
         }
-        grouping EtyTerminationPac {
-            leaf isFtsEnabled {
+        container ety-termination-pac {
+            uses ety-termination-pac;
+            description "none";
+        }
+        grouping ety-termination-pac {
+            leaf is-fts-enabled {
                 type boolean;
                 description "This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information.";
             }
-            leaf isTxPauseEnabled {
+            leaf is-tx-pause-enabled {
                 type boolean;
                 description "This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021.";
             }
-            leaf phyType {
-                type ETY_PhyType;
+            leaf phy-type {
+                type ety-phy-type;
                 config false;
                 description "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.";
             }
-            leaf-list phyTypeList {
-                type ETY_PhyType;
+            leaf-list phy-type-list {
+                type ety-phy-type;
                 config false;
                 description "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.";
             }
             description "none";
         }
-        container TrafficConditioningPac {
-            list prioConfigList {
+        container traffic-conditioning-pac {
+            uses traffic-conditioning-pac;
+            description "none";
+        }
+        grouping traffic-conditioning-pac {
+            list prio-config-list {
                 config false;
                 min-elements 1;
                 max-elements 8;
-                uses PriorityConfiguration;
+                uses priority-configuration;
                 description "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
             }
-            list condConfigList {
+            list cond-config-list {
                 config false;
                 min-elements 1;
                 max-elements 8;
-                uses TrafficConditioningConfiguration;
+                uses traffic-conditioning-configuration;
                 description "This attribute indicates for the conditioner process the conditioning parameters:
                     - Queue ID: Indicates the Queue ID
                     - Committed Information Rate (CIR): number of bits per second
@@ -256,23 +281,27 @@ module TapiEth {
             description "This object class models the ETH traffic conditioning function as defined in G.8021.
                 Basic attributes: codirectional, condConfigList, prioConfigList";
         }
-        container TrafficShapingPac {
-            list prioConfigList {
+        container traffic-shaping-pac {
+            uses traffic-shaping-pac;
+            description "none";
+        }
+        grouping traffic-shaping-pac {
+            list prio-config-list {
                 config false;
                 min-elements 1;
                 max-elements 8;
-                uses PriorityConfiguration;
+                uses priority-configuration;
                 description "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
             }
-            list queueConfigList {
+            list queue-config-list {
                 config false;
                 min-elements 1;
                 max-elements 8;
-                uses QueueConfiguration;
+                uses queue-configuration;
                 description "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.";
             }
-            leaf schedConfig {
-                type SchedulingConfiguration;
+            leaf sched-config {
+                type scheduling-configuration;
                 config false;
                 description "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.
                     Scheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).
@@ -286,26 +315,34 @@ module TapiEth {
             description "This object class models the ETH traffic shaping function as defined in G.8021.
                 Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
         }
-        grouping NodeEdgePointLpSpec {
-            container _terminationSpec {
-                uses EtyTerminationPac;
-                description "none";
-            }
-            uses Tapi:ExtensionsSpec;
+        container node-edge-point-lp-spec {
+            uses node-edge-point-lp-spec;
             description "none";
         }
-    
+        grouping node-edge-point-lp-spec {
+            container termination-spec {
+                uses ety-termination-pac;
+                description "none";
+            }
+            uses tapi-common:extensions-spec;
+            description "none";
+        }
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        grouping PriorityConfiguration {
+        list priority-configuration {
+            uses priority-configuration;
+            description "none";
+        }
+        grouping priority-configuration {
             leaf priority {
                 type uint64 {
                     range "0..7";
                 }
                 description "none";
             }
-            leaf queueId {
+            leaf queue-id {
                 type uint64 {
                     range "1..8";
                 }
@@ -313,22 +350,30 @@ module TapiEth {
             }
             description "none";
         }
-        grouping QueueConfiguration {
-            leaf queueId {
+        list queue-configuration {
+            uses queue-configuration;
+            description "none";
+        }
+        grouping queue-configuration {
+            leaf queue-id {
                 type uint64;
                 description "This attribute indicates the queue id.";
             }
-            leaf queueDepth {
+            leaf queue-depth {
                 type uint64;
                 description "This attribute defines the depth of the queue in bytes.";
             }
-            leaf queueThreshold {
+            leaf queue-threshold {
                 type uint64;
                 description "This attribute defines the threshold of the queue in bytes.";
             }
             description "none";
         }
-        grouping TrafficConditioningConfiguration {
+        list traffic-conditioning-configuration {
+            uses traffic-conditioning-configuration;
+            description "none";
+        }
+        grouping traffic-conditioning-configuration {
             leaf cir {
                 type uint64;
                 description "This attribute indicates the Committed Information Rate in bits/s.";
@@ -345,15 +390,15 @@ module TapiEth {
                 type uint64;
                 description "This attribute indicates the Excess Burst Size in bytes.";
             }
-            leaf couplingFlag {
+            leaf coupling-flag {
                 type boolean;
                 description "This attribute indicates the coupling flag.";
             }
-            leaf colourMode {
-                type ColourMode;
+            leaf colour-mode {
+                type colour-mode;
                 description "This attribute indicates the colour mode.";
             }
-            leaf queueId {
+            leaf queue-id {
                 type uint64 {
                     range "1..8";
                 }
@@ -361,60 +406,64 @@ module TapiEth {
             }
             description "none";
         }
-        typedef MacAddress {
+        typedef mac-address {
             type string;
             description "This primitive data type contains an Ethernet MAC address defined by IEEE 802a. The format of the address consists of 12 hexadecimal characters, grouped in pairs and separated by '-' (e.g., 03-27-AC-75-3E-1D).";
         }
-        grouping PriorityMapping {
-            leaf Priority0 {
+        container priority-mapping {
+            uses priority-mapping;
+            description "none";
+        }
+        grouping priority-mapping {
+            leaf priority0 {
                 type uint64 {
                     range "0..7";
                 }
                 description "This attribute defines the new priority value for the old priority value 0.";
             }
-            leaf Priority1 {
+            leaf priority1 {
                 type uint64 {
                     range "0..7";
                 }
                 default "1";
                 description "This attribute defines the new priority value for the old priority value 1.";
             }
-            leaf Priority2 {
+            leaf priority2 {
                 type uint64 {
                     range "0..7";
                 }
                 default "2";
                 description "This attribute defines the new priority value for the old priority value 2.";
             }
-            leaf Priority3 {
+            leaf priority3 {
                 type uint64 {
                     range "0..7";
                 }
                 default "3";
                 description "This attribute defines the new priority value for the old priority value 3.";
             }
-            leaf Priority4 {
+            leaf priority4 {
                 type uint64 {
                     range "0..7";
                 }
                 default "4";
                 description "This attribute defines the new priority value for the old priority value 4.";
             }
-            leaf Priority5 {
+            leaf priority5 {
                 type uint64 {
                     range "0..7";
                 }
                 default "5";
                 description "This attribute defines the new priority value for the old priority value 5.";
             }
-            leaf Priority6 {
+            leaf priority6 {
                 type uint64 {
                     range "0..7";
                 }
                 default "6";
                 description "This attribute defines the new priority value for the old priority value 6.";
             }
-            leaf Priority7 {
+            leaf priority7 {
                 type uint64 {
                     range "0..7";
                 }
@@ -423,159 +472,167 @@ module TapiEth {
             }
             description "This data type provides the priority mapping done in the 'P Regenerate' process defined in G.8021.";
         }
-        typedef Vid {
+        typedef vid {
             type string;
             description "This primitive type models the 12 Bit VLAN identifier of a VLAN tag.";
         }
-        typedef ModifyCrossConnectionData {
+        typedef modify-cross-connection-data {
             type string;
             description "none";
         }
-        grouping AddressTuple {
+        container address-tuple {
+            uses address-tuple;
+            description "none";
+        }
+        grouping address-tuple {
             leaf address {
-                type MacAddress;
+                type mac-address;
                 description "This attribute contains the MAC address of the address tuple.";
             }
-            leaf-list portList {
-                type MacAddress;
+            leaf-list port-list {
+                type mac-address;
                 description "This attribute contains the ports associated to the MAC address in the address tuple.";
             }
             description "This data type contains an address tuple consisting of a MAC address and a corresponding port list.";
         }
-        typedef SchedulingConfiguration {
+        typedef scheduling-configuration {
             type string;
             description "The syntax of this dataType is pending on the specification in G.8021, which is for further study.";
         }
-        grouping ControlFrameFilter {
-            leaf C2_00_00_10 {
+        container control-frame-filter {
+            uses control-frame-filter;
+            description "none";
+        }
+        grouping control-frame-filter {
+            leaf c2-00-00-10 {
                 type boolean;
                 description "This attribute identifies the 'All LANs Bridge Management Group Address'.";
             }
-            leaf C2_00_00_00 {
+            leaf c2-00-00-00 {
                 type boolean;
                 description "This attribute identifies the STP/RSTP/MSTP protocol address.";
             }
-            leaf C2_00_00_01 {
+            leaf c2-00-00-01 {
                 type boolean;
                 description "This attribute identifies the IEEE MAC-specific Control Protocols group address (PAUSE protocol).";
             }
-            leaf C2_00_00_02 {
+            leaf c2-00-00-02 {
                 type boolean;
                 description "This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast address (LACP/LAMP or Link OAM protocols).";
             }
-            leaf C2_00_00_03 {
+            leaf c2-00-00-03 {
                 type boolean;
                 description "This attribute identifies the Nearest non-TPMR Bridge group address (Port Authentication protocol).";
             }
-            leaf C2_00_00_04 {
+            leaf c2-00-00-04 {
                 type boolean;
                 description "This attribute identifies the IEEE MAC-specific Control Protocols group address.";
             }
-            leaf C2_00_00_05 {
+            leaf c2-00-00-05 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_06 {
+            leaf c2-00-00-06 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_07 {
+            leaf c2-00-00-07 {
                 type boolean;
                 description "This attribute identifies the Metro Ethernet Forum E-LMI protocol group address.";
             }
-            leaf C2_00_00_08 {
+            leaf c2-00-00-08 {
                 type boolean;
                 description "This attribute identifies the Provider Bridge Group address.";
             }
-            leaf C2_00_00_09 {
+            leaf c2-00-00-09 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_0A {
+            leaf c2-00-00-0a {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_0B {
+            leaf c2-00-00-0b {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_0C {
+            leaf c2-00-00-0c {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_0D {
+            leaf c2-00-00-0d {
                 type boolean;
                 description "This attribute identifies the Provider Bridge MVRP address.";
             }
-            leaf C2_00_00_0E {
+            leaf c2-00-00-0e {
                 type boolean;
                 description "This attribute identifies the Individual LAN Scope group address, Nearest Bridge group address (LLDP protocol).";
             }
-            leaf C2_00_00_0F {
+            leaf c2-00-00-0f {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_20 {
+            leaf c2-00-00-20 {
                 type boolean;
                 description "This attribute identifies the Customer and Provider Bridge MMRP address.";
             }
-            leaf C2_00_00_21 {
+            leaf c2-00-00-21 {
                 type boolean;
                 description "This attribute identifies the Customer Bridge MVRP address.";
             }
-            leaf C2_00_00_22 {
+            leaf c2-00-00-22 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_23 {
+            leaf c2-00-00-23 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_24 {
+            leaf c2-00-00-24 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_25 {
+            leaf c2-00-00-25 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_26 {
+            leaf c2-00-00-26 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_27 {
+            leaf c2-00-00-27 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_28 {
+            leaf c2-00-00-28 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_29 {
+            leaf c2-00-00-29 {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2A {
+            leaf c2-00-00-2a {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2B {
+            leaf c2-00-00-2b {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2C {
+            leaf c2-00-00-2c {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2D {
+            leaf c2-00-00-2d {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2E {
+            leaf c2-00-00-2e {
                 type boolean;
                 description "Reserved for future standardization.";
             }
-            leaf C2_00_00_2F {
+            leaf c2-00-00-2f {
                 type boolean;
                 description "Reserved for future standardization.";
             }
@@ -583,74 +640,78 @@ module TapiEth {
                 Value 'false' means block: The frame is discarded by the filter process.
                 Value 'true' means pass: The frame is passed unchanged through the filter process.";
         }
-        grouping BandwidthReport {
-            leaf sourceMacAddress {
-                type MacAddress;
+        container bandwidth-report {
+            uses bandwidth-report;
+            description "none";
+        }
+        grouping bandwidth-report {
+            leaf source-mac-address {
+                type mac-address;
                 description "The sourceMacAddress is the address from the far end.";
             }
-            leaf portId {
+            leaf port-id {
                 type uint64;
                 description "This attribute returns the far end port identifier.";
             }
-            leaf nominalBandwidth {
+            leaf nominal-bandwidth {
                 type uint64;
                 description "This attribute returns the configured bandwidth";
             }
-            leaf currentBandwidth {
+            leaf current-bandwidth {
                 type uint64;
                 description "This attribute returns the current bandwidth.";
             }
             description "Data type for the bandwidth report.";
         }
-        typedef AdminState {
+        typedef admin-state {
             type enumeration {
-                enum LOCK {
+                enum lock {
                     description "none";
                 }
-                enum NORMAL {
+                enum normal {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef ColourMode {
+        typedef colour-mode {
             type enumeration {
-                enum COLOUR_BLIND {
+                enum colour-blind {
                     description "none";
                 }
-                enum COLOUR_AWARE {
+                enum colour-aware {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef CsfConfig {
+        typedef csf-config {
             type enumeration {
-                enum DISABLED {
+                enum disabled {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is false
                         - MI_CSFrdifdi_Enable is false
                         - MI_CSFdci_Enable is false.";
                 }
-                enum ENABLED {
+                enum enabled {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is false
                         - MI_CSFdci_Enable is false.";
                 }
-                enum ENABLED_WITH_RDI_FDI {
+                enum enabled-with-rdi-fdi {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is true
                         - MI_CSFdci_Enable is false.";
                 }
-                enum ENABLED_WITH_RDI_FDI_DCI {
+                enum enabled-with-rdi-fdi-dci {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is true
                         - MI_CSFdci_Enable is true.";
                 }
-                enum ENABLED_WITH_DCI {
+                enum enabled-with-dci {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is false
@@ -659,127 +720,127 @@ module TapiEth {
             }
             description "none";
         }
-        typedef ETY_PhyType {
+        typedef ety-phy-type {
             type enumeration {
-                enum OTHER {
+                enum other {
                     description "none";
                 }
-                enum UNKNOWN {
+                enum unknown {
                     description "none";
                 }
-                enum NONE {
+                enum none {
                     description "none";
                 }
-                enum 2BASE_TL {
+                enum 2base-tl {
                     description "none";
                 }
-                enum 10MBIT_S {
+                enum 10mbit-s {
                     description "none";
                 }
-                enum 10PASS_TS {
+                enum 10pass-ts {
                     description "none";
                 }
-                enum 100BASE_T4 {
+                enum 100base-t4 {
                     description "none";
                 }
-                enum 100BASE_X {
+                enum 100base-x {
                     description "none";
                 }
-                enum 100BASE_T2 {
+                enum 100base-t2 {
                     description "none";
                 }
-                enum 1000BASE_X {
+                enum 1000base-x {
                     description "none";
                 }
-                enum 1000BASE_T {
+                enum 1000base-t {
                     description "none";
                 }
-                enum 10GBASE_X {
+                enum 10gbase-x {
                     description "none";
                 }
-                enum 10GBASE_R {
+                enum 10gbase-r {
                     description "none";
                 }
-                enum 10GBASE_W {
+                enum 10gbase-w {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef FrameType {
+        typedef frame-type {
             type enumeration {
-                enum ADMIT_ONLY_VLAN_TAGGED_FRAMES {
+                enum admit-only-vlan-tagged-frames {
                     description "none";
                 }
-                enum ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES {
+                enum admit-only-untagged-and-priority-tagged-frames {
                     description "none";
                 }
-                enum ADMIT_ALL_FRAMES {
+                enum admit-all-frames {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef OamPeriod {
+        typedef oam-period {
             type enumeration {
-                enum 3_33MS {
+                enum 3-33ms {
                     description "Default for protection.";
                 }
-                enum 10MS {
+                enum 10ms {
                     description "none";
                 }
-                enum 100MS {
+                enum 100ms {
                     description "none";
                 }
-                enum 1S {
+                enum 1s {
                     description "none";
                 }
-                enum 10S {
+                enum 10s {
                     description "none";
                 }
-                enum 1MIN {
+                enum 1min {
                     description "none";
                 }
-                enum 10MIN {
+                enum 10min {
                     description "none";
                 }
             }
             description "Provides the frequency for the OAM PDU insertion.";
         }
-        typedef PcpCoding {
+        typedef pcp-coding {
             type enumeration {
-                enum 8P0D {
+                enum 8p0d {
                     description "none";
                 }
-                enum 7P1D {
+                enum 7p1d {
                     description "none";
                 }
-                enum 6P2D {
+                enum 6p2d {
                     description "none";
                 }
-                enum 5P3D {
+                enum 5p3d {
                     description "none";
                 }
-                enum DEI {
+                enum dei {
                     description "This enumeration value means that all priorities should be drop eligible.
                         DEI = Drop Eligibility Indicator";
                 }
             }
             description "This enum models the coding of the Priority Code Point as defined in section 'Priority Code Point encoding' of IEEE 802.1Q.";
         }
-        typedef VlanType {
+        typedef vlan-type {
             type enumeration {
-                enum C_Tag {
+                enum c-tag {
                     description "0x8100";
                 }
-                enum S_Tag {
+                enum s-tag {
                     description "0x88a8";
                 }
-                enum I_Tag {
+                enum i-tag {
                     description "88-e7";
                 }
             }
             description "This enumeration contains the Ethertypes defined in IEEE 802.1Q.";
         }
-    
+
 }

--- a/YANG/tapi-notification.yang
+++ b/YANG/tapi-notification.yang
@@ -1,379 +1,399 @@
-module TapiNotification {
+module tapi-notification {
     namespace "urn:onf:params:xml:ns:yang:TapiNotification";
-    prefix TapiNotification;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-21 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_notifSubscription" {
-        uses NotificationSubscriptionService;
+        uses notification-subscription-service;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_notification" {
-        uses Notification;
+        uses notification;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping NotificationSubscriptionService {
-            list _notification {
-                key 'uuid';
-                config false;
-                uses Notification;
-                description "none";
-            }
-            container _notificationChannel {
-                uses NotificationChannel;
-                description "none";
-            }
-            container _subscriptionFilter {
-                uses SubscriptionFilter;
-                description "none";
-            }
-            leaf subscriptionState {
-                type SubscriptionState;
-                description "none";
-            }
-            leaf-list supportedNotificationTypes {
-                type NotificationType;
-                config false;
-                description "none";
-            }
-            leaf-list supportedObjectTypes {
-                type ObjectType;
-                config false;
-                description "none";
-            }
-            uses Tapi:ServiceSpec;
+        list notification-subscription-service {
+            key 'uuid';
+            uses notification-subscription-service;
             description "none";
         }
-        grouping SubscriptionFilter {
-            leaf-list requestedNotificationTypes {
-                type NotificationType;
+        grouping notification-subscription-service {
+            list notification {
+                key 'uuid';
+                config false;
+                uses notification;
+                description "none";
+            }
+            container notification-channel {
+                uses notification-channel;
+                description "none";
+            }
+            container subscription-filter {
+                uses subscription-filter;
+                description "none";
+            }
+            leaf subscription-state {
+                type subscription-state;
+                description "none";
+            }
+            leaf-list supported-notification-types {
+                type notification-type;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            leaf-list supported-object-types {
+                type object-type;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi-common:service-spec;
+            description "none";
+        }
+        container subscription-filter {
+            uses subscription-filter;
+            description "none";
+        }
+        grouping subscription-filter {
+            leaf-list requested-notification-types {
+                type notification-type;
                 config false;
                 description "none";
             }
-            leaf-list requestedObjectTypes {
-                type ObjectType;
+            leaf-list requested-object-types {
+                type object-type;
                 config false;
                 description "none";
             }
-            leaf-list requestedLayerProtocols {
-                type Tapi:LayerProtocolName;
+            leaf-list requested-layer-protocols {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
-            leaf-list requestedObjectIdentifier {
-                type Tapi:UniversalId;
+            leaf-list requested-object-identifier {
+                type tapi-common:universal-id;
                 config false;
                 description "none";
             }
-            leaf includeContent {
+            leaf include-content {
                 type boolean;
                 config false;
                 description "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "none";
         }
-        notification Notification {
-            uses Notification;
+        notification notification {
+            uses notification;
             description "none";
         }
-        grouping Notification {
-            leaf notificationType {
-                type NotificationType;
+        grouping notification {
+            leaf notification-type {
+                type notification-type;
                 description "none";
             }
-            leaf targetObjectType {
-                type ObjectType;
+            leaf target-object-type {
+                type object-type;
                 description "none";
             }
-            leaf targetObjectIdentifier {
-                type Tapi:UniversalId;
+            leaf target-object-identifier {
+                type tapi-common:universal-id;
                 description "none";
             }
-            list targetObjectName {
-                key 'valueName';
-                uses Tapi:NameAndValue;
+            list target-object-name {
+                key 'value-name';
+                min-elements 1;
+                uses tapi-common:name-and-value;
                 description "none";
             }
-            leaf eventTimeStamp {
-                type Tapi:DateAndTime;
+            leaf event-time-stamp {
+                type tapi-common:date-and-time;
                 description "none";
             }
-            leaf sequenceNumber {
+            leaf sequence-number {
                 type uint64;
                 config false;
                 description "A monotonous increasing sequence number associated with the notification.
                     The exact semantics of how this sequence number is assigned (per channel or subscription or source or system) is left undefined.";
             }
-            leaf sourceIndicator {
-                type SourceIndicator;
+            leaf source-indicator {
+                type source-indicator;
                 description "none";
             }
-            leaf layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 description "none";
             }
-            list changedAttributes {
-            	key 'valueName';
-                uses NameAndValueChange;
+            list changed-attributes {
+                key 'value-name';
+                uses name-and-value-change;
                 description "none";
             }
-            list additionalInfo {
-                key 'valueName';
-                uses Tapi:NameAndValue;
+            list additional-info {
+                key 'value-name';
+                uses tapi-common:name-and-value;
                 description "none";
             }
-            leaf additionalText {
+            leaf additional-text {
                 type string;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "none";
         }
-        grouping NotificationChannel {
-            leaf streamAddress {
+        container notification-channel {
+            uses notification-channel;
+            description "none";
+        }
+        grouping notification-channel {
+            leaf stream-address {
                 type string;
                 config false;
                 description "The address/location/URI of the channel/stream to which the subscribed notifications are published.
                     This specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string.";
             }
-            leaf nextSequenceNo {
+            leaf next-sequence-no {
                 type uint64;
                 config false;
                 description "The sequence number of the next notification that will be published on the channel";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "none";
         }
-    
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        grouping NameAndValueChange {
-            leaf valueName {
+        list name-and-value-change {
+            key 'value-name';
+            uses name-and-value-change;
+            description "none";
+        }
+        grouping name-and-value-change {
+            leaf value-name {
                 type string;
                 description "The name of the value. The value need not have a name.";
             }
-            leaf oldValue {
+            leaf old-value {
                 type string;
                 description "The value";
             }
-            leaf newValue {
+            leaf new-value {
                 type string;
                 description "The value";
             }
             description "A scoped name-value triple, including old value and new value";
         }
-        typedef NotificationType {
+        typedef notification-type {
             type enumeration {
-                enum OBJECT_CREATION {
+                enum object-creation {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
-                enum OBJECT_DELETION {
+                enum object-deletion {
                     description "none";
                 }
-                enum ATTRIBUTE_VALUE_CHANGE {
-                    description "none";
-                }
-            }
-            description "The orientation of flow at the Port of a Forwarding entity";
-        }
-        typedef ObjectType {
-            type enumeration {
-                enum TOPOLOGY {
-                    description "none";
-                }
-                enum NODE {
-                    description "none";
-                }
-                enum LINK {
-                    description "none";
-                }
-                enum CONNECTION {
-                    description "none";
-                }
-                enum PATH {
-                    description "none";
-                }
-                enum CONNECTIVITY_SERVICE {
-                    description "none";
-                }
-                enum VIRTUAL_NETWORK_SERVICE {
-                    description "none";
-                }
-                enum PATH_COMPUTATION_SERVICE {
-                    description "none";
-                }
-                enum NODE_EDGE_POINT {
-                    description "none";
-                }
-                enum SERVICE_END_POINT {
-                    description "none";
-                }
-                enum CONNECTION_END_POINT {
+                enum attribute-value-change {
                     description "none";
                 }
             }
             description "The orientation of flow at the Port of a Forwarding entity";
         }
-        typedef SourceIndicator {
+        typedef object-type {
             type enumeration {
-                enum RESOURCE_OPERATION {
+                enum topology {
                     description "none";
                 }
-                enum MANAGEMENT_OPERATION {
+                enum node {
                     description "none";
                 }
-                enum UNKNOWN {
+                enum link {
+                    description "none";
+                }
+                enum connection {
+                    description "none";
+                }
+                enum path {
+                    description "none";
+                }
+                enum connectivity-service {
+                    description "none";
+                }
+                enum virtual-network-service {
+                    description "none";
+                }
+                enum path-computation-service {
+                    description "none";
+                }
+                enum node-edge-point {
+                    description "none";
+                }
+                enum service-end-point {
+                    description "none";
+                }
+                enum connection-end-point {
+                    description "none";
+                }
+            }
+            description "The orientation of flow at the Port of a Forwarding entity";
+        }
+        typedef source-indicator {
+            type enumeration {
+                enum resource-operation {
+                    description "none";
+                }
+                enum management-operation {
+                    description "none";
+                }
+                enum unknown {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef SubscriptionState {
+        typedef subscription-state {
             type enumeration {
-                enum SUSPENDED {
+                enum suspended {
                     description "none";
                 }
-                enum ACTIVE {
+                enum active {
                     description "none";
                 }
             }
             description "none";
         }
-    
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc getSupportedNotificationTypes {
+        rpc get-supported-notification-types {
             description "none";
             output {
-                leaf-list supportedNotificationTypes {
+                leaf-list supported-notification-types {
                     type NotificationType;
                     min-elements 1;
                     description "none";
                 }
-                leaf-list supportedObjectTypes {
+                leaf-list supported-object-types {
                     type ObjectType;
                     min-elements 1;
                     description "none";
                 }
             }
         }
-        rpc createNotificationSubscriptionService {
+        rpc create-notification-subscription-service {
             description "none";
             input {
-                container subscriptionFilter {
-                    uses SubscriptionFilter;
+                container subscription-filter {
+                    uses subscription-filter;
                     description "none";
                 }
-                leaf subscriptionState {
+                leaf subscription-state {
                     type SubscriptionState;
                     description "none";
                 }
             }
             output {
-                container subscriptionService {
-                    uses NotificationSubscriptionService;
+                container subscription-service {
+                    uses notification-subscription-service;
                     description "none";
                 }
             }
         }
-        rpc updateNotificationSubscriptionService {
+        rpc update-notification-subscription-service {
             description "none";
             input {
-                leaf subscriptionIdOrName {
+                leaf subscription-id-or-name {
                     type string;
                     description "none";
                 }
-                container subscriptionFilter {
-                    uses SubscriptionFilter;
+                container subscription-filter {
+                    uses subscription-filter;
                     description "none";
                 }
-                leaf subscriptionState {
+                leaf subscription-state {
                     type SubscriptionState;
                     description "none";
                 }
             }
             output {
-                container subscriptionService {
-                    uses NotificationSubscriptionService;
+                container subscription-service {
+                    uses notification-subscription-service;
                     description "none";
                 }
             }
         }
-        rpc deleteNotificationSubscriptionService {
+        rpc delete-notification-subscription-service {
             description "none";
             input {
-                leaf subscriptionIdOrName {
+                leaf subscription-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container subscriptionService {
-                    uses NotificationSubscriptionService;
+                container subscription-service {
+                    uses notification-subscription-service;
                     description "none";
                 }
             }
         }
-        rpc getNotificationSubscriptionServiceDetails {
+        rpc get-notification-subscription-service-details {
             description "none";
             input {
-                leaf subscriptionIdOrName {
+                leaf subscription-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container subscriptionService {
-                    uses NotificationSubscriptionService;
+                container subscription-service {
+                    uses notification-subscription-service;
                     description "none";
                 }
             }
         }
-        rpc getNotificationSubscriptionServiceList {
+        rpc get-notification-subscription-service-list {
             description "none";
             output {
-                list subscriptionService {
-                    uses NotificationSubscriptionService;
+                list subscription-service {
+                    uses notification-subscription-service;
                     description "none";
                 }
             }
         }
-        rpc getNotificationList {
+        rpc get-notification-list {
             description "none";
             input {
-                leaf subscriptionIdOrName {
+                leaf subscription-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf timePeriod {
+                leaf time-period {
                     type string;
                     description "none";
                 }
             }
             output {
                 list notification {
-                    uses Notification;
+                    uses notification;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/tapi-och.yang
+++ b/YANG/tapi-och.yang
@@ -1,131 +1,158 @@
-module TapiOch {
+module tapi-och {
     namespace "urn:onf:params:xml:ns:yang:TapiOch";
-    prefix TapiOch;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    import TapiConnectivity {
-        prefix TapiConnectivity;
+    import tapi-connectivity {
+        prefix tapi-connectivity;
     }
-    import TapiTopology {
-        prefix TapiTopology;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
-        uses ConnectionEndPointLpSpec;
+        uses connection-end-point-lp-spec;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
-        uses NodeEdgePointLpSpec;
+        uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping AdapterAndConnectionPointPac {
-            leaf monitoredDirection {
-                type MonitoredDirection;
+        container adapter-and-connection-point-pac {
+            uses adapter-and-connection-point-pac;
+            description "none";
+        }
+        grouping adapter-and-connection-point-pac {
+            leaf monitored-direction {
+                type monitored-direction;
                 config false;
                 description "This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK.";
             }
             description "none";
         }
-        grouping ConnectionEndPointLpSpec {
-            container _adapterSpec {
-                uses AdapterAndConnectionPointPac;
-                description "none";
-            }
-            container _terminationSpec {
-                uses TerminationPac;
-                description "none";
-            }
-            uses Tapi:ExtensionsSpec;
+        container connection-end-point-lp-spec {
+            uses connection-end-point-lp-spec;
             description "none";
         }
-        grouping TerminationPac {
-            container selectedApplicationIdentifier {
-                uses ApplicationIdentifier;
+        grouping connection-end-point-lp-spec {
+            container adapter-spec {
+                uses adapter-and-connection-point-pac;
+                description "none";
+            }
+            container termination-spec {
+                uses termination-pac;
+                description "none";
+            }
+            uses tapi-common:extensions-spec;
+            description "none";
+        }
+        container termination-pac {
+            uses termination-pac;
+            description "none";
+        }
+        grouping termination-pac {
+            container selected-application-identifier {
+                uses application-identifier;
                 description "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.";
             }
-            container nominalCentralFrequencyOrWavelength {
-                uses NominalCentralFrequencyOrWavelength;
+            container nominal-central-frequency-or-wavelength {
+                uses nominal-central-frequency-or-wavelength;
                 description "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.
                     This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.
                     ";
             }
             description "none";
         }
-        grouping PoolPropertyPac {
-            leaf clientCapacity {
+        container pool-property-pac {
+            uses pool-property-pac;
+            description "none";
+        }
+        grouping pool-property-pac {
+            leaf client-capacity {
                 type uint64;
                 description "none";
             }
-            leaf maxClientInstances {
+            leaf max-client-instances {
                 type uint64;
                 description "none";
             }
-            leaf maxClientSize {
+            leaf max-client-size {
                 type uint64;
                 description "none";
             }
             description "none";
         }
-        grouping NodeEdgePointLpSpec {
-            container _ochPoolPropertySpec {
+        container node-edge-point-lp-spec {
+            uses node-edge-point-lp-spec;
+            description "none";
+        }
+        grouping node-edge-point-lp-spec {
+            container och-pool-property-spec {
                 config false;
-                uses PoolPropertyPac;
+                uses pool-property-pac;
                 description "none";
             }
-            uses Tapi:ExtensionsSpec;
+            uses tapi-common:extensions-spec;
             description "none";
         }
-    
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        grouping ApplicationIdentifier {
-            leaf applicationIdentifierType {
+        container application-identifier {
+            uses application-identifier;
+            description "none";
+        }
+        grouping application-identifier {
+            leaf application-identifier-type {
                 type string;
                 description "none";
             }
-            leaf applicationIdentifierValue {
+            leaf application-identifier-value {
                 type string;
                 description "none";
             }
             description "none";
         }
-        typedef MonitoredDirection {
+        typedef monitored-direction {
             type enumeration {
-                enum SINK {
+                enum sink {
                     description "none";
                 }
-                enum SOURCE {
+                enum source {
                     description "none";
                 }
             }
             description "The enumeration with the options for directionality for nonintrusive monitoring.";
         }
-        grouping NominalCentralFrequencyOrWavelength {
-            leaf linkType {
+        container nominal-central-frequency-or-wavelength {
+            uses nominal-central-frequency-or-wavelength;
+            description "none";
+        }
+        grouping nominal-central-frequency-or-wavelength {
+            leaf link-type {
                 type string;
                 description "none";
             }
-            leaf nominalCentralFrequencyOrWavelength {
+            leaf nominal-central-frequency-or-wavelength {
                 type string;
                 description "none";
             }
             description "none";
         }
-    
+
 }

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -1,67 +1,70 @@
-module TapiOdu {
+module tapi-odu {
     namespace "urn:onf:params:xml:ns:yang:TapiOdu";
-    prefix TapiOdu;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    import TapiConnectivity {
-        prefix TapiConnectivity;
+    import tapi-connectivity {
+        prefix tapi-connectivity;
     }
-    import TapiTopology {
-        prefix TapiTopology;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
-        uses ConnectionEndPointLpSpec;
+        uses connection-end-point-lp-spec;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
-        uses NodeEdgePointLpSpec;
+        uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping AdapterAndConnectionPointPac {
-            leaf adaptationActive {
+        container adapter-and-connection-point-pac {
+            uses adapter-and-connection-point-pac;
+            description "none";
+        }
+        grouping adapter-and-connection-point-pac {
+            leaf adaptation-active {
                 type boolean;
                 config false;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point.";
             }
-            leaf apsEnable {
+            leaf aps-enable {
                 type boolean;
                 default "true";
                 description "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.";
             }
-            leaf apsLevel {
+            leaf aps-level {
                 type uint64;
                 description "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.";
             }
             leaf k {
-                type ODUk_CtpKBitRate;
+                type oduk-ctp-kbit-rate;
                 config false;
                 description "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.
                     When the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.
                     When the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.
                     ";
             }
-            leaf oduTypeAndRate {
+            leaf odu-type-and-rate {
                 type uint64;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G";
             }
-            leaf-list positionSeq {
-                type ODUk_TcmOrGccChoice;
+            leaf-list position-seq {
+                type oduk-tcm-or-gcc-choice;
                 config false;
                 description "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.
                     The order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.
@@ -71,46 +74,48 @@ module TapiOdu {
                     If a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.
                     ";
             }
-            leaf-list tributarySlotList {
+            leaf-list tributary-slot-list {
                 type uint64;
                 config false;
+                min-elements 1;
                 description "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).";
             }
-            leaf applicableProblems {
-                type ODUk_CtpProblemList;
+            leaf applicable-problems {
+                type oduk-ctp-problem-list;
                 config false;
                 description "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList.";
             }
-            leaf expectedMSI {
+            leaf expected-msi {
                 type string;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. ";
             }
-            leaf acceptedMSI {
+            leaf accepted-msi {
                 type string;
                 config false;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. ";
             }
-            leaf acceptedPayloadType {
+            leaf accepted-payload-type {
                 type string;
                 config false;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. ";
             }
-            leaf transmittedMSI {
+            leaf transmitted-msi {
                 type string;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function.";
             }
-            leaf autoPayloadType {
+            leaf auto-payload-type {
                 type boolean;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. ";
             }
-            leaf insertedPayloadType {
+            leaf inserted-payload-type {
                 type string;
                 config false;
                 description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. ";
             }
-            leaf-list currentNumberOfTributarySlots {
+            leaf-list current-number-of-tributary-slots {
                 type uint64;
                 config false;
+                min-elements 1;
                 description "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. 
                     The upper bound of this attribute is dependent on the HO-ODUk server layer. 
                     When the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):
@@ -119,119 +124,139 @@ module TapiOdu {
                     This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
                     ";
             }
-            container nominalBitRateAndTolerance {
-                uses ODUk_h_nominalBitRateAndTolerance;
+            container nominal-bit-rate-and-tolerance {
+                uses oduk-h-nominal-bit-rate-and-tolerance;
                 description "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
             }
             description "none";
         }
-        grouping TerminationPac {
+        container termination-pac {
+            uses termination-pac;
+            description "none";
+        }
+        grouping termination-pac {
             leaf rate {
                 type string;
                 config false;
                 description "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
                     ";
             }
-            leaf dmSource {
+            leaf dm-source {
                 type boolean;
                 description "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue.";
             }
-            leaf dmValue {
+            leaf dm-value {
                 type boolean;
                 description "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1.";
             }
             leaf acti {
-                type BitString;
+                type bit-string;
                 config false;
                 description "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.";
             }
-            leaf degM {
+            leaf deg-m {
                 type uint64;
                 description "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.";
             }
-            container degThr {
-                uses DegThr;
+            container deg-thr {
+                uses deg-thr;
                 description "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.";
             }
-            leaf exDapi {
-                type BitString;
+            leaf ex-dapi {
+                type bit-string;
                 description "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
             }
-            leaf exSapi {
-                type BitString;
+            leaf ex-sapi {
+                type bit-string;
                 description "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
             }
-            leaf timActDisabled {
+            leaf tim-act-disabled {
                 type boolean;
                 description "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled.";
             }
-            leaf timDetMode {
-                type TimDetMo;
+            leaf tim-det-mode {
+                type tim-det-mo;
                 description "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI";
             }
             leaf txti {
-                type BitString;
+                type bit-string;
                 description "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.";
             }
             description "none";
         }
-        grouping ConnectionEndPointLpSpec {
-            container _terminationSpec {
-                uses TerminationPac;
-                description "none";
-            }
-            container _adapterSpec {
-                uses AdapterAndConnectionPointPac;
-                description "none";
-            }
-            uses Tapi:ExtensionsSpec;
+        container connection-end-point-lp-spec {
+            uses connection-end-point-lp-spec;
             description "none";
         }
-        grouping PoolPropertyPac {
-            leaf clientCapacity {
+        grouping connection-end-point-lp-spec {
+            container termination-spec {
+                uses termination-pac;
+                description "none";
+            }
+            container adapter-spec {
+                uses adapter-and-connection-point-pac;
+                description "none";
+            }
+            uses tapi-common:extensions-spec;
+            description "none";
+        }
+        container pool-property-pac {
+            uses pool-property-pac;
+            description "none";
+        }
+        grouping pool-property-pac {
+            leaf client-capacity {
                 type uint64;
                 description "none";
             }
-            leaf maxClientInstances {
+            leaf max-client-instances {
                 type uint64;
                 config false;
                 description "none";
             }
-            leaf maxClientSize {
+            leaf max-client-size {
                 type uint64;
                 config false;
                 description "none";
             }
             description "none";
         }
-        grouping NodeEdgePointLpSpec {
-            container _oduPoolPropertySpec {
-                uses PoolPropertyPac;
-                description "none";
-            }
-            uses Tapi:ExtensionsSpec;
+        container node-edge-point-lp-spec {
+            uses node-edge-point-lp-spec;
             description "none";
         }
-    
+        grouping node-edge-point-lp-spec {
+            container odu-pool-property-spec {
+                uses pool-property-pac;
+                description "none";
+            }
+            uses tapi-common:extensions-spec;
+            description "none";
+        }
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        typedef BitString {
+        typedef bit-string {
             type string;
             description "This primitive type defines a bit oriented string.
                 The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).
                 The semantic of each bit position will be defined in the Documentation field of the attribute.";
         }
-        grouping DegThr {
-            leaf degThrValue {
+        container deg-thr {
+            uses deg-thr;
+            description "none";
+        }
+        grouping deg-thr {
+            leaf deg-thr-value {
                 type string;
                 description "Percentage of detected errored blocks";
             }
-            leaf degThrType {
+            leaf deg-thr-type {
                 type string;
                 description "Number of errored blocks";
             }
-            leaf percentageGranularity {
+            leaf percentage-granularity {
                 type string;
                 description "none";
             }
@@ -243,120 +268,124 @@ module TapiOdu {
                 degThrValue when type is NUMBER_ERROR_BLOCKS:
                 Number of Errored Blocks is captured in an integer value.";
         }
-        typedef ODUk_TtpKBitRate {
+        typedef oduk-ttp-kbit-rate {
             type enumeration {
-                enum 1_25_G {
+                enum 1.25-g {
                     description "none";
                 }
-                enum 2_5_G {
+                enum 2.5-g {
                     description "none";
                 }
-                enum 10_G {
+                enum 10-g {
                     description "none";
                 }
-                enum 10_G_2E {
+                enum 10-g-2e {
                     description "none";
                 }
-                enum 40_G {
+                enum 40-g {
                     description "none";
                 }
-                enum 100_G {
+                enum 100-g {
                     description "none";
                 }
-                enum FLEX_CBR {
+                enum flex-cbr {
                     description "Represents ODUflex connection which carry a CBR client";
                 }
-                enum FLEX_GFP {
+                enum flex-gfp {
                     description "Represents ODUflex connection which carry packet traffic";
                 }
             }
             description "Provides an enumeration with the meaning of each k value.";
         }
-        typedef ODUk_TcmOrGccChoice {
+        typedef oduk-tcm-or-gcc-choice {
             type string;
             description "A data type to constrain the values to particular types of ODUk CTPs.";
         }
-        typedef TimDetMo {
+        typedef tim-det-mo {
             type enumeration {
-                enum DAPI {
+                enum dapi {
                     description "none";
                 }
-                enum SAPI {
+                enum sapi {
                     description "none";
                 }
-                enum BOTH {
+                enum both {
                     description "none";
                 }
             }
             description "List of modes for trace identifier mismatch detection.";
         }
-        typedef ODUk_h_ResizingProtocolStatus {
+        typedef oduk-h-resizing-protocol-status {
             type enumeration {
-                enum LCR_INITIATED {
+                enum lcr-initiated {
                     description "none";
                 }
-                enum LCR_FAILED {
+                enum lcr-failed {
                     description "none";
                 }
-                enum LCR_COMPLETED {
+                enum lcr-completed {
                     description "none";
                 }
-                enum BWR_INITIATED {
+                enum bwr-initiated {
                     description "none";
                 }
-                enum BWR_COMPLETED {
+                enum bwr-completed {
                     description "none";
                 }
             }
             description "The valid status' of the resizing protocol.";
         }
-        typedef ODUk_CtpProblemList {
+        typedef oduk-ctp-problem-list {
             type enumeration {
-                enum PLM {
+                enum plm {
                     description "Payload Mismatch";
                 }
-                enum MSIM {
+                enum msim {
                     description "MultiplexStructureIdentifier Mismatch, per time slot";
                 }
-                enum LOF_LOM {
+                enum lof-lom {
                     description "Loss of Frame, Loss of Multiframe, per time slot";
                 }
-                enum LOOMFI {
+                enum loomfi {
                     description "Loss of OPU Multiframe Indicator";
                 }
             }
             description "The valid list of problems for the entity.";
         }
-        typedef ODUk_CtpKBitRate {
+        typedef oduk-ctp-kbit-rate {
             type enumeration {
-                enum 1_25_G {
+                enum 1.25-g {
                     description "none";
                 }
-                enum 2_5_G {
+                enum 2.5-g {
                     description "none";
                 }
-                enum 10_G {
+                enum 10-g {
                     description "none";
                 }
-                enum 10_G_2E {
+                enum 10-g-2e {
                     description "2e represents an approximate bit rate of 10 Gbit/s as a logical wrapper 10GBASE-R";
                 }
-                enum 40_G {
+                enum 40-g {
                     description "none";
                 }
-                enum 100_G {
+                enum 100-g {
                     description "none";
                 }
-                enum FLEX_CBR {
+                enum flex-cbr {
                     description "Represents ODUflex connection which carry a CBR client";
                 }
-                enum FLEX_GFP {
+                enum flex-gfp {
                     description "Represents ODUflex connection which carry packet traffic";
                 }
             }
             description "Provides an enumeration with the meaning of each k value.";
         }
-        grouping ODUk_h_nominalBitRateAndTolerance {
+        container oduk-h-nominal-bit-rate-and-tolerance {
+            uses oduk-h-nominal-bit-rate-and-tolerance;
+            description "none";
+        }
+        grouping oduk-h-nominal-bit-rate-and-tolerance {
             leaf tolerance {
                 type uint64;
                 description "tolerance in ppm";
@@ -367,73 +396,73 @@ module TapiOdu {
             }
             description "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
         }
-        typedef TcmMode {
+        typedef tcm-mode {
             type enumeration {
-                enum OPERATIONAL {
+                enum operational {
                     description "none";
                 }
-                enum TRANSPARENT {
+                enum transparent {
                     description "none";
                 }
-                enum MONITOR {
+                enum monitor {
                     description "none";
                 }
             }
             description "List of value modes for the sink side of the tandem connection monitoring function.";
         }
-        typedef ODUkT_tcmExtension {
+        typedef oduk-t-tcm-extension {
             type enumeration {
-                enum NORMAL {
+                enum normal {
                     description "none";
                 }
-                enum PASS_THROUGH {
+                enum pass-through {
                     description "none";
                 }
-                enum ERASE {
+                enum erase {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef ODUkT_AdministrationState {
+        typedef oduk-t-administration-state {
             type enumeration {
-                enum LOCKED {
+                enum locked {
                     description "none";
                 }
-                enum NORMAL {
+                enum normal {
                     description "none";
                 }
             }
             description "The list of valid adminstration states.";
         }
-        typedef ODUk_TcmStatus {
+        typedef oduk-tcm-status {
             type enumeration {
-                enum NO_SOURCE_TC {
+                enum no-source-tc {
                     description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
                 }
-                enum IN_USE_WITHOUT_IAE {
+                enum in-use-without-iae {
                     description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
                 }
-                enum IN_USE_WITH_IAE {
+                enum in-use-with-iae {
                     description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
                 }
-                enum RESERVED_1 {
+                enum reserved-1 {
                     description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
                 }
-                enum RESERVED_2 {
+                enum reserved-2 {
                     description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
                 }
-                enum LCK {
+                enum lck {
                     description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODUk-LCK";
                 }
-                enum OCI {
+                enum oci {
                     description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODUk-OCI";
                 }
-                enum AIS {
+                enum ais {
                     description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODUk-AIS";
                 }
             }
             description "See Table 15-5/G.709/Y.1331 ";
         }
-    
+
 }

--- a/YANG/tapi-path-computation.yang
+++ b/YANG/tapi-path-computation.yang
@@ -1,74 +1,84 @@
-module TapiPathComputation {
+module tapi-path-computation {
     namespace "urn:onf:params:xml:ns:yang:TapiPathComputation";
-    prefix TapiPathComputation;
-    import TapiTopology {
-        prefix TapiTopology;
+    prefix tapi-abc;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    import Tapi {
-        prefix Tapi;
+    import tapi-common {
+        prefix tapi-common;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_path" {
-        uses Path;
+        uses path;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_pathCompService" {
-        uses PathComputationService;
+        uses path-computation-service;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping Path {
-            list _telink {
-                key 'localId';
+        list path {
+            key 'uuid';
+            uses path;
+            description "none";
+        }
+        grouping path {
+            list telink {
+                key 'local-id';
                 config false;
-                uses TapiTopology:TeLink;
+                min-elements 1;
+                uses tapi-topology:te-link;
                 description "none";
             }
-            container _routingConstraint {
+            container routing-constraint {
                 config false;
-                uses RoutingConstraint;
+                uses routing-constraint;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes";
         }
-        grouping PathCompServicePort {
-            leaf _serviceEndPoint {
+        list path-comp-service-port {
+            key 'local-id';
+            uses path-comp-service-port;
+            description "none";
+        }
+        grouping path-comp-service-port {
+            leaf service-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf role {
-                type Tapi:PortRole;
+                type tapi-common:port-role;
                 config false;
                 description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
             }
             leaf direction {
-                type Tapi:PortDirection;
+                type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
             }
-            leaf serviceLayer {
-                type Tapi:LayerProtocolName;
+            leaf service-layer {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "The association of the FC to LTPs is made via EndPoints.
                 The EndPoint (EP) object class models the access to the FC function. 
                 The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
@@ -77,199 +87,218 @@ module TapiPathComputation {
                 The EP replaces the Protection Unit of a traditional protection model. 
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
-        grouping PathComputationService {
-            leaf-list _path {
+        container path-computation-service {
+            uses path-computation-service;
+            description "none";
+        }
+        grouping path-computation-service {
+            leaf-list path {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_path/Tapi:uuid';
+                    path '/tapi:context/tapi:path/tapi:uuid';
                 }
                 config false;
+                min-elements 1;
                 description "none";
             }
-            list _servicePort {
-                key 'localId';
-                uses PathCompServicePort;
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                max-elements 2;
+                uses path-comp-service-port;
                 description "none";
             }
-            container _routingConstraint {
-                uses RoutingConstraint;
+            container routing-constraint {
+                uses routing-constraint;
                 description "none";
             }
-            container _objectiveFunction {
-                uses PathObjectiveFunction;
+            container objective-function {
+                uses path-objective-function;
                 description "none";
             }
-            container _optimizationConstraint {
-                uses PathOptimizationConstraint;
+            container optimization-constraint {
+                uses path-optimization-constraint;
                 description "none";
             }
-            uses Tapi:ServiceSpec;
+            uses tapi-common:service-spec;
             description "none";
         }
-        grouping PathObjectiveFunction {
-            leaf bandwidthOptimization {
-                type Tapi:DirectiveValue;
-                config false;
-                description "none";
-            }
-            leaf concurrentPaths {
-                type Tapi:DirectiveValue;
-                config false;
-                description "none";
-            }
-            leaf costOptimization {
-                type Tapi:DirectiveValue;
-                config false;
-                description "none";
-            }
-            leaf linkUtilization {
-                type Tapi:DirectiveValue;
-                config false;
-                description "none";
-            }
-            leaf resourceSharing {
-                type Tapi:DirectiveValue;
-                config false;
-                description "none";
-            }
-            uses Tapi:LocalClass;
+        container path-objective-function {
+            uses path-objective-function;
             description "none";
         }
-        grouping PathOptimizationConstraint {
-            leaf trafficInterruption {
-                type Tapi:DirectiveValue;
+        grouping path-objective-function {
+            leaf bandwidth-optimization {
+                type tapi-common:directive-value;
                 config false;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            leaf concurrent-paths {
+                type tapi-common:directive-value;
+                config false;
+                description "none";
+            }
+            leaf cost-optimization {
+                type tapi-common:directive-value;
+                config false;
+                description "none";
+            }
+            leaf link-utilization {
+                type tapi-common:directive-value;
+                config false;
+                description "none";
+            }
+            leaf resource-sharing {
+                type tapi-common:directive-value;
+                config false;
+                description "none";
+            }
+            uses tapi-common:local-class;
             description "none";
         }
-        grouping RoutingConstraint {
-            container requestedCapacity {
+        container path-optimization-constraint {
+            uses path-optimization-constraint;
+            description "none";
+        }
+        grouping path-optimization-constraint {
+            leaf traffic-interruption {
+                type tapi-common:directive-value;
                 config false;
-                uses TapiTopology:Capacity;
                 description "none";
             }
-            leaf serviceLevel {
+            uses tapi-common:local-class;
+            description "none";
+        }
+        container routing-constraint {
+            uses routing-constraint;
+            description "none";
+        }
+        grouping routing-constraint {
+            container requested-capacity {
+                config false;
+                uses tapi-topology:capacity;
+                description "none";
+            }
+            leaf service-level {
                 type string;
                 config false;
                 description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
             }
-            leaf-list pathLayer {
-                type Tapi:LayerProtocolName;
+            leaf-list path-layer {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
-            list costCharacteristic {
-                key 'costName costValue costAlgorithm';
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
                 config false;
-                uses TapiTopology:CostCharacteristic;
+                uses tapi-topology:cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
-            list latencyCharacteristic {
-                key 'trafficPropertyName trafficPropertyQueingLatency';
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
                 config false;
-                uses TapiTopology:LatencyCharacteristic;
+                uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
-            leaf-list _includeTopology {
+            leaf-list include-topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf-list _avoidTopology {
+            leaf-list avoid-topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            list _includePath {
-                key 'localId';
+            list include-path {
+                key 'local-id';
                 config false;
-                uses TapiTopology:TeLink;
+                uses tapi-topology:te-link;
                 description "none";
             }
-            list _excludePath {
-                key 'localId';
+            list exclude-path {
+                key 'local-id';
                 config false;
-                uses TapiTopology:TeLink;
+                uses tapi-topology:te-link;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "none";
         }
-    
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc computeP2PPath {
+        rpc compute-p2ppath {
             description "none";
             input {
-                list servicePort {
+                list service-port {
                     min-elements 2;
                     max-elements 2;
-                    uses PathCompServicePort;
+                    uses path-comp-service-port;
                     description "none";
                 }
-                container routingConstraint {
-                    uses RoutingConstraint;
+                container routing-constraint {
+                    uses routing-constraint;
                     description "none";
                 }
-                container objectiveFunction {
-                    uses PathObjectiveFunction;
+                container objective-function {
+                    uses path-objective-function;
                     description "none";
                 }
             }
             output {
-                container pathCompService {
-                    uses PathComputationService;
+                container path-comp-service {
+                    uses path-computation-service;
                     description "none";
                 }
             }
         }
-        rpc optimizeP2PPath {
+        rpc optimize-p2ppath {
             description "none";
             input {
-                leaf pathIdOrName {
+                leaf path-id-or-name {
                     type string;
                     description "none";
                 }
-                container routingConstraint {
-                    uses RoutingConstraint;
+                container routing-constraint {
+                    uses routing-constraint;
                     description "none";
                 }
-                container optimizationConstraint {
-                    uses PathOptimizationConstraint;
+                container optimization-constraint {
+                    uses path-optimization-constraint;
                     description "none";
                 }
-                container objectiveFunction {
-                    uses PathObjectiveFunction;
+                container objective-function {
+                    uses path-objective-function;
                     description "none";
                 }
             }
             output {
-                container pathCompService {
-                    uses PathComputationService;
+                container path-comp-service {
+                    uses path-computation-service;
                     description "none";
                 }
             }
         }
-        rpc deleteP2PPath {
+        rpc delete-p2ppath {
             description "none";
             input {
-                leaf pathIdOrName {
+                leaf path-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container pathCompService {
-                    uses PathComputationService;
+                container path-comp-service {
+                    uses path-computation-service;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -1,191 +1,212 @@
-module TapiTopology {
+module tapi-topology {
     namespace "urn:onf:params:xml:ns:yang:TapiTopology";
-    prefix TapiTopology;
-    import Tapi {
-        prefix Tapi;
+    prefix tapi-abc;
+    import tapi-common {
+        prefix tapi-common;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_topology" {
-        uses Topology;
+        uses topology;
         description "none";
     }
     augment "/Tapi:Context/Tapi:_nwTopologyService" {
-        uses NetworkTopologyService;
+        uses network-topology-service;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping Link {
-            list _linkPort {
-                key 'localId';
-                config false;
-                min-elements 2;
-                uses LinkPort;
-                description "none";
-            }
-            leaf-list _node {
+        list link {
+            key 'uuid';
+            uses link;
+            description "none";
+        }
+        grouping link {
+            leaf-list node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 min-elements 2;
                 description "none";
             }
-            container _state {
+            leaf-list node {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                }
                 config false;
-                uses Tapi:AdminStatePac;
+                min-elements 2;
                 description "none";
             }
-            container _transferCapacity {
+            container state {
                 config false;
-                uses TransferCapacityPac;
+                uses tapi-common:admin-state-pac;
                 description "none";
             }
-            container _transferCost {
+            container transfer-capacity {
                 config false;
-                uses TransferCostPac;
+                uses transfer-capacity-pac;
                 description "none";
             }
-            container _transferIntegrity {
+            container transfer-cost {
                 config false;
-                uses TransferIntegrityPac;
+                uses transfer-cost-pac;
                 description "none";
             }
-            container _transferTiming {
+            container transfer-integrity {
                 config false;
-                uses TransferTimingPac;
+                uses transfer-integrity-pac;
                 description "none";
             }
-            container _riskParameter {
+            container transfer-timing {
                 config false;
-                uses RiskParameterPac;
+                uses transfer-timing-pac;
                 description "none";
             }
-            container _validation {
+            container risk-parameter {
                 config false;
-                uses ValidationPac;
+                uses risk-parameter-pac;
                 description "none";
             }
-            container _lpTransition {
+            container validation {
                 config false;
-                uses LayerProtocolTransitionPac;
+                uses validation-pac;
                 description "none";
             }
-            leaf-list layerProtocolName {
-                type Tapi:LayerProtocolName;
+            container lp-transition {
+                config false;
+                uses layer-protocol-transition-pac;
+                description "none";
+            }
+            leaf-list layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
                 min-elements 1;
                 description "none";
             }
             leaf direction {
-                type Tapi:ForwardingDirection;
+                type tapi-common:forwarding-direction;
                 config false;
                 description "The directionality of the Link. 
                     Is applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). 
                     Is not present in more complex cases.";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
         }
-        grouping Node {
-            list _ownedNodeEdgePoint {
+        list node {
+            key 'uuid';
+            min-elements 1;
+            uses node;
+            description "none";
+        }
+        grouping node {
+            list owned-node-edge-point {
                 key 'uuid';
                 config false;
-                uses NodeEdgePoint;
+                uses node-edge-point;
                 description "none";
             }
-            leaf-list _aggregatedNodeEdgePoint {
+            leaf-list aggregated-node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf _encapTopology {
+            leaf encap-topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            container _state {
+            container state {
                 config false;
-                uses Tapi:AdminStatePac;
+                uses tapi-common:admin-state-pac;
                 description "none";
             }
-            container _transferCapacity {
+            container transfer-capacity {
                 config false;
-                uses TransferCapacityPac;
+                uses transfer-capacity-pac;
                 description "none";
             }
-            container _transferCost {
+            container transfer-cost {
                 config false;
-                uses TransferCostPac;
+                uses transfer-cost-pac;
                 description "none";
             }
-            container _transferIntegrity {
+            container transfer-integrity {
                 config false;
-                uses TransferIntegrityPac;
+                uses transfer-integrity-pac;
                 description "none";
             }
-            container _transferTiming {
+            container transfer-timing {
                 config false;
-                uses TransferTimingPac;
+                uses transfer-timing-pac;
                 description "none";
             }
-            leaf-list layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf-list layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
                 min-elements 1;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
                 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
         }
-        grouping Topology {
-            list _node {
+        list topology {
+            key 'uuid';
+            uses topology;
+            description "none";
+        }
+        grouping topology {
+            list node {
                 key 'uuid';
                 config false;
-                uses Node;
+                uses node;
                 description "none";
             }
-            list _link {
+            list link {
                 key 'uuid';
                 config false;
-                uses Link;
+                uses link;
                 description "none";
             }
-            leaf-list layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf-list layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
+                min-elements 1;
                 description "none";
             }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
                 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
         }
-        grouping LayerProtocolTransitionPac {
-            leaf-list transitionedLayerProtocolName {
+        container layer-protocol-transition-pac {
+            uses layer-protocol-transition-pac;
+            description "none";
+        }
+        grouping layer-protocol-transition-pac {
+            leaf-list transitioned-layer-protocol-name {
                 type string;
                 min-elements 1;
                 description "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.";
             }
-            leaf-list _nodeEdgePoint {
+            leaf-list node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 min-elements 1;
                 description "Lists the LTPs that define the layer protocol transition of the transitional link.";
@@ -196,72 +217,66 @@ module TapiTopology {
                 This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.
                 Links that included details in this Pac are often referred to as Transitional Links.";
         }
-        grouping LinkPort {
-            leaf _nodeEdgePoint {
+        list node-edge-point {
+            key 'uuid';
+            uses node-edge-point;
+            description "none";
+        }
+        grouping node-edge-point {
+            list layer-protocol {
+                key 'local-id';
+                config false;
+                min-elements 1;
+                uses tapi-common:layer-protocol;
+                description "none";
+            }
+            leaf-list client-node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf role {
-                type Tapi:PortRole;
-                config false;
-                description "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ";
+            leaf-list mapped-service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                description "none";
             }
-            leaf direction {
-                type Tapi:PortDirection;
+            container state {
+                config false;
+                uses tapi-common:admin-state-pac;
+                description "none";
+            }
+            leaf termination-direction {
+                type tapi-common:termination-direction;
+                config false;
+                description "none";
+            }
+            leaf link-port-direction {
+                type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the LinkEnd.";
             }
-            uses Tapi:LocalClass;
-            description "The association of the Link to LTPs is made via LinkEnd.
-                The LinkEnd object class models the access to the Link function. 
-                The traffic forwarding between the associated LinkEnds of the Link depends upon the type of Link.  
-                In cases where there is resilience the LinkEnd may convey the resilience role of the access to the Link. 
-                The Link can be considered as a component and the LinkEnd as a Port on that component";
-        }
-        grouping NodeEdgePoint {
-            list _layerProtocol {
-                key 'localId';
+            leaf link-port-role {
+                type tapi-common:port-role;
                 config false;
-                min-elements 1;
-                uses Tapi:LayerProtocol;
-                description "none";
+                description "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ";
             }
-            leaf-list _clientNodeEdgePoint {
-                type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
-                }
-                config false;
-                description "none";
-            }
-            leaf-list _mappedServiceEndPoint {
-                type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
-                }
-                description "none";
-            }
-            container _state {
-                config false;
-                uses Tapi:AdminStatePac;
-                description "none";
-            }
-            leaf direction {
-                type Tapi:TerminationDirection;
-                config false;
-                description "none";
-            }
-            uses Tapi:ResourceSpec;
+            uses tapi-common:resource-spec;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
-        grouping RiskParameterPac {
-            list riskCharacteristic {
-                key 'riskCharacteristicName';
+        container risk-parameter-pac {
+            uses risk-parameter-pac;
+            description "none";
+        }
+        grouping risk-parameter-pac {
+            list risk-characteristic {
+                key 'risk-characteristic-name';
                 config false;
                 min-elements 1;
-                uses RiskCharacteristic;
+                uses risk-characteristic;
                 description "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.";
             }
             description "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. 
@@ -277,24 +292,28 @@ module TapiTopology {
                 Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.
                 Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.";
         }
-        grouping TransferCapacityPac {
-            container totalPotentialCapacity {
+        container transfer-capacity-pac {
+            uses transfer-capacity-pac;
+            description "none";
+        }
+        grouping transfer-capacity-pac {
+            container total-potential-capacity {
                 config false;
-                uses Capacity;
+                uses capacity;
                 description "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.";
             }
-            container availableCapacity {
+            container available-capacity {
                 config false;
-                uses Capacity;
+                uses capacity;
                 description "Capacity available to be assigned.";
             }
-            list capacityAssignedToUserView {
-                key 'totalSize';
+            list capacity-assigned-to-user-view {
+                key 'total-size';
                 config false;
-                uses Capacity;
+                uses capacity;
                 description "Capacity already assigned";
             }
-            leaf capacityInteractionAlgorithm {
+            leaf capacity-interaction-algorithm {
                 type string;
                 config false;
                 description "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)";
@@ -306,12 +325,16 @@ module TapiTopology {
                 Represents the capacity available to user (client) along with client interaction and usage. 
                 A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
         }
-        grouping TransferCostPac {
-            list costCharacteristic {
-                key 'costName costValue costAlgorithm';
+        container transfer-cost-pac {
+            uses transfer-cost-pac;
+            description "none";
+        }
+        grouping transfer-cost-pac {
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
                 config false;
                 min-elements 1;
-                uses CostCharacteristic;
+                uses cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
             description "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. 
@@ -319,37 +342,41 @@ module TapiTopology {
                 There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. 
                 Using an entity will incur a cost. ";
         }
-        grouping TransferIntegrityPac {
-            leaf errorCharacteristic {
+        container transfer-integrity-pac {
+            uses transfer-integrity-pac;
+            description "none";
+        }
+        grouping transfer-integrity-pac {
+            leaf error-characteristic {
                 type string;
                 config false;
                 description "Describes the degree to which the signal propagated can be errored. 
                     Applies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.";
             }
-            leaf lossCharacteristic {
+            leaf loss-characteristic {
                 type string;
                 config false;
                 description "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.
                     Applies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).";
             }
-            leaf repeatDeliveryCharacteristic {
+            leaf repeat-delivery-characteristic {
                 type string;
                 config false;
                 description "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). 
                     It can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.";
             }
-            leaf deliveryOrderCharacteristic {
+            leaf delivery-order-characteristic {
                 type string;
                 config false;
                 description "Describes the degree to which packets will be delivered out of sequence.
                     Does not apply to TDM as the TDM protocols maintain strict order.";
             }
-            leaf unavailableTimeCharacteristic {
+            leaf unavailable-time-characteristic {
                 type string;
                 config false;
                 description "Describes the duration for which there may be no valid signal propagated.";
             }
-            leaf serverIntegrityProcessCharacteristic {
+            leaf server-integrity-process-characteristic {
                 type string;
                 config false;
                 description "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.";
@@ -358,312 +385,354 @@ module TapiTopology {
                 It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.
                 Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.";
         }
-        grouping TransferTimingPac {
-            list latencyCharacteristic {
-                key 'trafficPropertyName trafficPropertyQueingLatency';
+        container transfer-timing-pac {
+            uses transfer-timing-pac;
+            description "none";
+        }
+        grouping transfer-timing-pac {
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
                 config false;
                 min-elements 1;
-                uses LatencyCharacteristic;
+                uses latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
             description "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.";
         }
-        grouping ValidationPac {
-            list validationMechanism {
-                key 'validationMechanism layerProtocolAdjacencyValidated validationRobustness';
+        container validation-pac {
+            uses validation-pac;
+            description "none";
+        }
+        grouping validation-pac {
+            list validation-mechanism {
+                key 'validation-mechanism layer-protocol-adjacency-validated validation-robustness';
                 config false;
                 min-elements 1;
-                uses ValidationMechanism;
+                uses validation-mechanism;
                 description "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.";
             }
             description "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.";
         }
-        grouping TeLink {
-            leaf-list _node {
+        list te-link {
+            key 'local-id';
+            uses te-link;
+            description "none";
+        }
+        grouping te-link {
+            leaf-list node {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 min-elements 2;
                 max-elements 2;
                 description "none";
             }
-            leaf-list _nodeEdgePoint {
+            leaf-list node-edge-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:uuid';
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 max-elements 2;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
         }
-        grouping NetworkTopologyService {
-            leaf-list _topology {
+        container network-topology-service {
+            uses network-topology-service;
+            description "none";
+        }
+        grouping network-topology-service {
+            leaf-list topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            uses Tapi:ServiceSpec;
+            uses tapi-common:service-spec;
             description "none";
         }
-    
+
     /***********************
-    * package TypeDefinitions
+    * package type-definitions
     **********************/ 
-        grouping Capacity {
-            leaf totalSize {
-                type FixedCapacityValue;
+        list capacity {
+            key 'total-size';
+            uses capacity;
+            description "none";
+        }
+        grouping capacity {
+            leaf total-size {
+                type fixed-capacity-value;
                 description "Total capacity of the TopologicalEntity in MB/s";
             }
-            leaf packetBwProfileType {
-                type BandwidthProfileType;
+            leaf packet-bw-profile-type {
+                type bandwidth-profile-type;
                 description "none";
             }
-            leaf committedInformationRate {
+            leaf committed-information-rate {
                 type uint64;
                 description "none";
             }
-            leaf committedBurstSize {
+            leaf committed-burst-size {
                 type uint64;
                 description "none";
             }
-            leaf peakInformationRate {
+            leaf peak-information-rate {
                 type uint64;
                 description "none";
             }
-            leaf peakBurstSize {
+            leaf peak-burst-size {
                 type uint64;
                 description "none";
             }
-            leaf colorAware {
+            leaf color-aware {
                 type boolean;
                 description "none";
             }
-            leaf couplingFlag {
+            leaf coupling-flag {
                 type boolean;
                 description "none";
             }
             description "Information on capacity of a particular TopologicalEntity.";
         }
-        grouping CostCharacteristic {
-            leaf costName {
+        list cost-characteristic {
+            key 'cost-name cost-value cost-algorithm';
+            uses cost-characteristic;
+            description "none";
+        }
+        grouping cost-characteristic {
+            leaf cost-name {
                 type string;
                 description "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.";
             }
-            leaf costValue {
+            leaf cost-value {
                 type string;
                 description "The specific cost.";
             }
-            leaf costAlgorithm {
+            leaf cost-algorithm {
                 type string;
                 description "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.";
             }
             description "The information for a particular cost characteristic.";
         }
-        typedef FixedCapacityValue {
+        typedef fixed-capacity-value {
             type enumeration {
-                enum NOT_APPLICABLE {
+                enum not-applicable {
                     description "none";
                 }
-                enum 10MBPS {
+                enum 10mbps {
                     description "none";
                 }
-                enum 100MBPS {
+                enum 100mbps {
                     description "none";
                 }
-                enum 1GBPS {
+                enum 1gbps {
                     description "none";
                 }
-                enum 2_4GBPS {
+                enum 2.4gbps {
                     description "none";
                 }
-                enum 10GBPS {
+                enum 10gbps {
                     description "none";
                 }
-                enum 40GBPS {
+                enum 40gbps {
                     description "none";
                 }
-                enum 100GBPS {
+                enum 100gbps {
                     description "none";
                 }
-                enum 200GBPS {
+                enum 200gbps {
                     description "none";
                 }
-                enum 400GBPS {
+                enum 400gbps {
                     description "none";
                 }
             }
             description "The Capacity (Bandwidth) values that are applicable for digital layers. ";
         }
-        grouping LatencyCharacteristic {
-            leaf fixedLatencyCharacteristic {
+        list latency-characteristic {
+            key 'traffic-property-name traffic-property-queing-latency';
+            uses latency-characteristic;
+            description "none";
+        }
+        grouping latency-characteristic {
+            leaf fixed-latency-characteristic {
                 type string;
                 config false;
                 description "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity";
             }
-            leaf jitterCharacteristic {
+            leaf jitter-characteristic {
                 type string;
                 config false;
                 description "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.
                     Applies to TDM systems (and not packet).";
             }
-            leaf wanderCharacteristic {
+            leaf wander-characteristic {
                 type string;
                 config false;
                 description "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.
                     Applies to TDM systems (and not packet).";
             }
-            leaf trafficPropertyName {
+            leaf traffic-property-name {
                 type string;
                 description "The identifier of the specific traffic property to which the queuing latency applies.";
             }
-            leaf trafficPropertyQueingLatency {
+            leaf traffic-property-queing-latency {
                 type string;
                 description "The specific queuing latency for the traffic property.";
             }
             description "Provides information on latency characteristic for a particular stated trafficProperty.";
         }
-        grouping RiskCharacteristic {
-            leaf riskCharacteristicName {
+        list risk-characteristic {
+            key 'risk-characteristic-name';
+            uses risk-characteristic;
+            description "none";
+        }
+        grouping risk-characteristic {
+            leaf risk-characteristic-name {
                 type string;
                 description "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. 
                     For example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).
                     Depending upon the importance of the traffic being routed different risk characteristics will be evaluated.";
             }
-            leaf-list riskIdentifierList {
+            leaf-list risk-identifier-list {
                 type string;
                 min-elements 1;
                 description "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.";
             }
             description "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.";
         }
-        grouping ValidationMechanism {
-            leaf validationMechanism {
+        list validation-mechanism {
+            key 'validation-mechanism layer-protocol-adjacency-validated validation-robustness';
+            uses validation-mechanism;
+            description "none";
+        }
+        grouping validation-mechanism {
+            leaf validation-mechanism {
                 type string;
                 description "Name of mechanism used to validate adjacency";
             }
-            leaf layerProtocolAdjacencyValidated {
+            leaf layer-protocol-adjacency-validated {
                 type string;
                 description "State of validatiion";
             }
-            leaf validationRobustness {
+            leaf validation-robustness {
                 type string;
                 description "Quality of validation (i.e. how likely is the stated validation to be invalid)";
             }
             description "Identifies the validation mechanism and describes the characteristics of that mechanism";
         }
-        typedef BandwidthProfileType {
+        typedef bandwidth-profile-type {
             type enumeration {
-                enum NOT_APPLICABLE {
+                enum not-applicable {
                     description "none";
                 }
-                enum MEF_10_x {
+                enum mef-10.x {
                     description "none";
                 }
-                enum RFC_2697 {
+                enum rfc-2697 {
                     description "none";
                 }
-                enum RFC_2698 {
+                enum rfc-2698 {
                     description "none";
                 }
-                enum RFC_4115 {
+                enum rfc-4115 {
                     description "none";
                 }
             }
             description "none";
         }
-    
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc getTopologyDetails {
+        rpc get-topology-details {
             description "none";
             input {
-                leaf topologyIdOrName {
+                leaf topology-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
                 container topology {
-                    uses Topology;
+                    uses topology;
                     description "none";
                 }
             }
         }
-        rpc getNodeDetails {
+        rpc get-node-details {
             description "none";
             input {
-                leaf topologyIdOrName {
+                leaf topology-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf nodeIdOrName {
+                leaf node-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
                 container node {
-                    uses Node;
+                    uses node;
                     description "none";
                 }
             }
         }
-        rpc getNodeEdgePointDetails {
+        rpc get-node-edge-point-details {
             description "none";
             input {
-                leaf topologyIdOrName {
+                leaf topology-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf nodeIdOrName {
+                leaf node-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf epIdOrName {
+                leaf ep-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container nodeEdgePoint {
-                    uses NodeEdgePoint;
+                container node-edge-point {
+                    uses node-edge-point;
                     description "none";
                 }
             }
         }
-        rpc getLinkDetails {
+        rpc get-link-details {
             description "none";
             input {
-                leaf topologyIdOrName {
+                leaf topology-id-or-name {
                     type string;
                     description "none";
                 }
-                leaf linkIdOrName {
+                leaf link-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
                 container link {
-                    uses Link;
+                    uses link;
                     description "none";
                 }
             }
         }
-        rpc getTopologyList {
+        rpc get-topology-list {
             description "none";
             output {
                 list topology {
-                    uses Topology;
+                    uses topology;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/tapi-virtual-network.yang
+++ b/YANG/tapi-virtual-network.yang
@@ -1,135 +1,152 @@
-module TapiVirtualNetwork {
+module tapi-virtual-network {
     namespace "urn:onf:params:xml:ns:yang:TapiVirtualNetwork";
-    prefix TapiVirtualNetwork;
-    import TapiTopology {
-        prefix TapiTopology;
+    prefix tapi-abc;
+    import tapi-topology {
+        prefix tapi-topology;
     }
-    import Tapi {
-        prefix Tapi;
+    import tapi-common {
+        prefix tapi-common;
     }
-    organization "ONF (Open Networking Foundation) IMP Working Group";
-    contact "WG Web: <https://www.opennetworking.org/technical-communities/areas/services/>
-        WG List: <mailto: <wg list name>@opennetworking.org>
-        WG Chair: your-WG-chair
-                <mailto:your-WG-chair@example.com>
-        Editor: your-name
-                <mailto:your-email@example.com>";
+    organization "Open Networking Foundation (ONF) / Open Transport Working Group(OTWG) / Transport API (TAPI) Project";
+    contact "
+        WG Web: TAPI SDK Project <http://opensourcesdn.org/projects/project-snowmass/>
+        WG List: TAPI Discussion list <mailto: transport-api@login.opennetworking.org>,
+        WG Chair: Karthik Sethuraman <mailto:karthik.sethuraman@necam.com>,
+        Editor: Ricard Vilalta <mailto:ricard.vilalta@cttc.es>";
     description "none";
-    revision 2016-07-19 {
-        description "Latest revision";
-        reference "RFC 6020 and RFC 6087";
+    revision 2016-12-15 {
+        description "TAPI SDK 1.1.alpha";
+        reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
     augment "/Tapi:Context/Tapi:_vnwService" {
-        uses VirtualNetworkService;
+        uses virtual-network-service;
         description "none";
     }
     /***********************
-    * package ObjectClasses
+    * package object-classes
     **********************/ 
-        grouping VirtualNetworkConstraint {
-            leaf _srcServiceEndPoint {
+        list virtual-network-constraint {
+            key 'local-id';
+            uses virtual-network-constraint;
+            description "none";
+        }
+        grouping virtual-network-constraint {
+            leaf src-service-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf _sinkServiceEndPoint {
+            leaf sink-service-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            leaf-list _diversityExclusion {
+            leaf-list diversity-exclusion {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_vnwService/TapiVirtualNetwork:_vnwConstraint/TapiVirtualNetwork:localId';
+                    path '/tapi:context/tapi:vnw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id';
                 }
                 description "none";
             }
-            container requestedCapacity {
-                uses TapiTopology:Capacity;
+            container requested-capacity {
+                uses tapi-topology:capacity;
                 description "none";
             }
-            leaf serviceLevel {
+            leaf service-level {
                 type string;
                 description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
             }
-            leaf-list serviceLayer {
-                type Tapi:LayerProtocolName;
+            leaf-list service-layer {
+                type tapi-common:layer-protocol-name;
                 description "none";
             }
-            list costCharacteristic {
-                key 'costName costValue costAlgorithm';
-                uses TapiTopology:CostCharacteristic;
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
+                uses tapi-topology:cost-characteristic;
                 description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
             }
-            list latencyCharacteristic {
-                key 'trafficPropertyName trafficPropertyQueingLatency';
-                uses TapiTopology:LatencyCharacteristic;
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
+                uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "none";
         }
-        grouping VirtualNetworkService {
-            leaf _topology {
+        list virtual-network-service {
+            key 'uuid';
+            uses virtual-network-service;
+            description "none";
+        }
+        grouping virtual-network-service {
+            leaf topology {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_topology/Tapi:uuid';
+                    path '/tapi:context/tapi:topology/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
-            list _servicePort {
-                key 'localId';
-                uses VirtualNetworkServicePort;
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                uses virtual-network-service-port;
                 description "none";
             }
-            list _vnwConstraint {
-                key 'localId';
-                uses VirtualNetworkConstraint;
+            list vnw-constraint {
+                key 'local-id';
+                min-elements 1;
+                uses virtual-network-constraint;
                 description "none";
             }
-            container _schedule {
-                uses Tapi:TimeRange;
+            container schedule {
+                uses tapi-common:time-range;
                 description "none";
             }
-            container _state {
-                uses Tapi:AdminStatePac;
+            container state {
+                uses tapi-common:admin-state-pac;
                 description "none";
             }
-            leaf-list layerProtocolName {
-                type Tapi:LayerProtocolName;
+            leaf-list layer-protocol-name {
+                type tapi-common:layer-protocol-name;
+                min-elements 1;
                 description "none";
             }
-            uses Tapi:ServiceSpec;
+            uses tapi-common:service-spec;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        grouping VirtualNetworkServicePort {
-            leaf _serviceEndPoint {
+        list virtual-network-service-port {
+            key 'local-id';
+            uses virtual-network-service-port;
+            description "none";
+        }
+        grouping virtual-network-service-port {
+            leaf service-end-point {
                 type leafref {
-                    path '/Tapi:Context/Tapi:_serviceEndPoint/Tapi:uuid';
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf role {
-                type Tapi:PortRole;
+                type tapi-common:port-role;
                 config false;
                 description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
             }
             leaf direction {
-                type Tapi:PortDirection;
+                type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
             }
-            leaf serviceLayer {
-                type Tapi:LayerProtocolName;
+            leaf service-layer {
+                type tapi-common:layer-protocol-name;
                 config false;
                 description "none";
             }
-            uses Tapi:LocalClass;
+            uses tapi-common:local-class;
             description "The association of the FC to LTPs is made via EndPoints.
                 The EndPoint (EP) object class models the access to the FC function. 
                 The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
@@ -138,72 +155,72 @@ module TapiVirtualNetwork {
                 The EP replaces the Protection Unit of a traditional protection model. 
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
-    
+
     /***********************
-    * package Interfaces
+    * package interfaces
     **********************/ 
-        rpc createVirtualNetworkService {
+        rpc create-virtual-network-service {
             description "none";
             input {
-                list servicePort {
+                list service-port {
                     min-elements 2;
-                    uses VirtualNetworkServicePort;
+                    uses virtual-network-service-port;
                     description "none";
                 }
-                container vnwConstraint {
-                    uses VirtualNetworkConstraint;
+                container vnw-constraint {
+                    uses virtual-network-constraint;
                     description "none";
                 }
-                leaf connSchedule {
+                leaf conn-schedule {
                     type string;
                     description "none";
                 }
             }
             output {
-                container vnwService {
-                    uses VirtualNetworkService;
+                container vnw-service {
+                    uses virtual-network-service;
                     description "none";
                 }
             }
         }
-        rpc deleteVirtualNetworkService {
+        rpc delete-virtual-network-service {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container vnwService {
-                    uses VirtualNetworkService;
+                container vnw-service {
+                    uses virtual-network-service;
                     description "none";
                 }
             }
         }
-        rpc getVirtualNetworkServiceDetails {
+        rpc get-virtual-network-service-details {
             description "none";
             input {
-                leaf serviceIdOrName {
+                leaf service-id-or-name {
                     type string;
                     description "none";
                 }
             }
             output {
-                container vnwService {
-                    uses VirtualNetworkService;
+                container vnw-service {
+                    uses virtual-network-service;
                     description "none";
                 }
             }
         }
-        rpc getVirtualNetworkServiceList {
+        rpc get-virtual-network-service-list {
             description "none";
             output {
-                list vnwService {
-                    uses VirtualNetworkService;
+                list vnw-service {
+                    uses virtual-network-service;
                     description "none";
                 }
             }
         }
-    
+
 }

--- a/YANG/yangen.sh
+++ b/YANG/yangen.sh
@@ -1,5 +1,5 @@
 #! bash
-find ../UML/ -maxdepth 1 -name "*.uml" ! -name "*Model*" -exec cp -t project {} \;
+find ../UML/ -maxdepth 1 -name "*.uml" ! -name "*TapiOverview*" -exec cp -t project {} \;
 node ../../EAGLEUmlYangTools/xmi2yang\ tool-v2.0/main.js
 mv project/*.yang .
-rm project/*
+rm project/*.uml


### PR DESCRIPTION
This change mainly relates to the naming of modules, grouping, properties, etc as per YANG naming convention.
These generated files need now to be inspected, compared with the previous version (which was fixed by hand) and updated.