### PR TITLE
Generated TAPI Yang files after patching the xmi2yang tool

### DIFF
--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -839,7 +839,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_cKrDfDNtEea0Br-ajMxp_A" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_cKrDfTNtEea0Br-ajMxp_A" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cKrDfjNtEea0Br-ajMxp_A" x="-25" y="22"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cKrDfjNtEea0Br-ajMxp_A" x="-33" y="14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_cKrDcTNtEea0Br-ajMxp_A"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_cKFNkDNtEea0Br-ajMxp_A"/>
@@ -1639,25 +1639,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__w77VE0WEeaqn4OIuRCwEg" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__w77VU0WEeaqn4OIuRCwEg" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_RhRT8E0YEeaqn4OIuRCwEg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_K6JEQMPPEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_qG8wcETZEead1bezhJG4aw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RhRT8U0YEeaqn4OIuRCwEg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6JEQcPPEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RhRT8k0YEeaqn4OIuRCwEg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_K6S1QMPPEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_wsEqUETZEead1bezhJG4aw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RhRT800YEeaqn4OIuRCwEg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1QcPPEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RhRT9E0YEeaqn4OIuRCwEg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_K6S1QsPPEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_aFAUM9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RhRT9U0YEeaqn4OIuRCwEg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1Q8PPEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RhRT9k0YEeaqn4OIuRCwEg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_K6S1RMPPEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RhRT900YEeaqn4OIuRCwEg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1RcPPEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RhRT-E0YEeaqn4OIuRCwEg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_K6S1RsPPEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_9hsOkKU7EeWkWNPM1BHzGA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RhRT-U0YEeaqn4OIuRCwEg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1R8PPEeaiK6pYrNo12g"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__w77Vk0WEeaqn4OIuRCwEg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__w77V00WEeaqn4OIuRCwEg"/>
@@ -1797,7 +1797,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9k00YEeaqn4OIuRCwEg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9gU0YEeaqn4OIuRCwEg" x="599" y="246" height="83"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9gU0YEeaqn4OIuRCwEg" x="718" y="240" height="83"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dEVum00YEeaqn4OIuRCwEg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_dEVunE0YEeaqn4OIuRCwEg" showTitle="true"/>
@@ -1825,7 +1825,7 @@
         <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dFOfWE0YEeaqn4OIuRCwEg" x="448" y="301" width="135" height="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dFOfWE0YEeaqn4OIuRCwEg" x="552" y="303" width="135" height="35"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dvx4ME0YEeaqn4OIuRCwEg" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_dvx4Mk0YEeaqn4OIuRCwEg" type="5029"/>
@@ -1855,7 +1855,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dvx4Q00YEeaqn4OIuRCwEg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dvx4MU0YEeaqn4OIuRCwEg" x="607" y="160" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dvx4MU0YEeaqn4OIuRCwEg" x="721" y="164" height="64"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dv7pS00YEeaqn4OIuRCwEg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_dv7pTE0YEeaqn4OIuRCwEg" showTitle="true"/>
@@ -1883,7 +1883,7 @@
         <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dwrQGE0YEeaqn4OIuRCwEg" x="451" y="122" height="35"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dwrQGE0YEeaqn4OIuRCwEg" x="553" y="121" height="35"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Oi63AE0ZEeaqn4OIuRCwEg" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_Oi63Ak0ZEeaqn4OIuRCwEg" type="5029"/>
@@ -2084,8 +2084,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_dE7kYU0YEeaqn4OIuRCwEg"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dE7kYk0YEeaqn4OIuRCwEg" points="[0, 0, -22, -179]$[22, 179, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dE7kb00YEeaqn4OIuRCwEg" id="(0.0,0.3373493975903614)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dE7kYk0YEeaqn4OIuRCwEg" points="[0, -1, 191, 0]$[0, -1, 191, 0]$[-191, -1, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dE7kb00YEeaqn4OIuRCwEg" id="(0.0,0.42168674698795183)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dE7kcE0YEeaqn4OIuRCwEg" id="(1.0,0.8407079646017699)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dFOfWk0YEeaqn4OIuRCwEg" type="StereotypeCommentLink" source="_dE7kYE0YEeaqn4OIuRCwEg" target="_dFOfVk0YEeaqn4OIuRCwEg">
@@ -2096,7 +2096,7 @@
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dFOfXE0YEeaqn4OIuRCwEg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dFOfXU0YEeaqn4OIuRCwEg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dFOfXk0YEeaqn4OIuRCwEg" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dFOfXk0YEeaqn4OIuRCwEg" id="(0.4962962962962963,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dv7pT00YEeaqn4OIuRCwEg" type="StereotypeCommentLink" source="_dvx4ME0YEeaqn4OIuRCwEg" target="_dv7pS00YEeaqn4OIuRCwEg">
       <styles xmi:type="notation:FontStyle" xmi:id="_dv7pUE0YEeaqn4OIuRCwEg"/>
@@ -2130,7 +2130,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_dwhfEU0YEeaqn4OIuRCwEg"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dwhfEk0YEeaqn4OIuRCwEg" points="[0, 0, -22, -179]$[22, 179, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfH00YEeaqn4OIuRCwEg" id="(0.0,0.578125)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfH00YEeaqn4OIuRCwEg" id="(0.0,0.515625)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfIE0YEeaqn4OIuRCwEg" id="(1.0,0.1592920353982301)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dwrQGk0YEeaqn4OIuRCwEg" type="StereotypeCommentLink" source="_dwhfEE0YEeaqn4OIuRCwEg" target="_dwrQFk0YEeaqn4OIuRCwEg">

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -144,7 +144,7 @@
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_cKOXgDNtEea0Br-ajMxp_A" name="_extensions" type="_VZkuoC6BEea0_JngOlSKcA" isReadOnly="true" aggregation="composite" association="_cKFNkDNtEea0Br-ajMxp_A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yapTUDNyEea0Br-ajMxp_A"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yapTUjNyEea0Br-ajMxp_A" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yapTUjNyEea0Br-ajMxp_A" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="LayerProtocol" isLeaf="true">
@@ -199,7 +199,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__gLXQxrpEeaeisu1tQM3_Q" name="_extensions" type="_VZkuoC6BEea0_JngOlSKcA" isReadOnly="true" aggregation="composite" association="__gLXQBrpEeaeisu1tQM3_Q">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2iUTUDNyEea0Br-ajMxp_A"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2iUTUjNyEea0Br-ajMxp_A" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2iUTUjNyEea0Br-ajMxp_A" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_TlA2gN79EeW-BtRsuJPbqg" name="OperationalStatePac" isLeaf="true" isAbstract="true">
@@ -241,7 +241,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wuyz8PEjEeWIT-EHROE-tg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wuyz8fEjEeWIT-EHROE-tg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GeUhU_TbEeWQB8HQFBfkJQ" name="_vnwService" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_GeUhUPTbEeWQB8HQFBfkJQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GeUhU_TbEeWQB8HQFBfkJQ" name="_virtualNwService" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_GeUhUPTbEeWQB8HQFBfkJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Md-9sPTbEeWQB8HQFBfkJQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Md-9sfTbEeWQB8HQFBfkJQ" value="*"/>
         </ownedAttribute>
@@ -300,11 +300,11 @@ The structure of LTP supports all transport protocols including circuit and pack
         <generalization xmi:type="uml:Generalization" xmi:id="_6frNwO_nEeWLlrwIF3w0vA" general="_tjWBYD3fEea-1_BGg-qcjQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_qG8wcETZEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true" redefinedProperty="_WjwG4D3kEea-1_BGg-qcjQ">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_qG8wcUTZEead1bezhJG4aw" value="/Tapi:ServiceEndPoint"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_qG8wcUTZEead1bezhJG4aw" value="/tapi-common:service-end-point"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_wsEqUETZEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true" redefinedProperty="_-nYf4EJuEea-2Meh9kw1kA">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_wsEqUUTZEead1bezhJG4aw" value="/Tapi:Context/Tapi:_serviceEndPoint"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_wsEqUUTZEead1bezhJG4aw" value="/tapi-common:context/tapi-common:service-end-point"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aFAUM9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" isReadOnly="true" aggregation="composite" association="_aFAUMNnYEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c7QIkNnYEeWIOYiRCk5bbQ" value="1"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -254,12 +254,12 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_NmluUETZEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NmluUUTZEead1bezhJG4aw" value="/TapiConnectivity:Connection"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NmluUUTZEead1bezhJG4aw" value="/tapi-connectivity:connection"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_UkkNEETZEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_UkkNEUTZEead1bezhJG4aw" value="/Tapi:Context/Tapi:_connection"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_UkkNEUTZEead1bezhJG4aw" value="/tapi-common:context/tapi-common:connection"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ijcPo2kHEeWZEqTYAF8eqA" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" aggregation="composite" association="_ijcPoGkHEeWZEqTYAF8eqA">
@@ -297,7 +297,7 @@ The structure of LTP supports all transport protocols including circuit and pack
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_28FwsET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_28FwsUT2Eead1bezhJG4aw" value="/TapiConnectivity:ConnectionEndPoint"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_28FwsUT2Eead1bezhJG4aw" value="/tapi-connectivity:connection-end-point"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7siA4ET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
@@ -434,12 +434,12 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_zPdpkETYEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_zPdpkUTYEead1bezhJG4aw" value="/TapiConnectivity:ConnectivityService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_zPdpkUTYEead1bezhJG4aw" value="/tapi-connectivity:connectivity-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_36HEED3jEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7PT1AETYEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7PT1AUTYEead1bezhJG4aw" value="/Tapi:Context/Tapi:_connectivityService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7PT1AUTYEead1bezhJG4aw" value="/tapi-common:context/tapi-common:connectivity-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_4oopgEJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_4EtL4EUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_4ErWsEUcEeWEwNCluy4jrw">

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -52,21 +52,21 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_T7esEzN7Eea40e5DA9KE3w" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_T7esFDN7Eea40e5DA9KE3w" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_RiEpYEW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_5rjJ8MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_xTg3MEW9EeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RiEpYUW-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5rjJ8cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RiEpYkW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_5rjJ8sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_03vL4EW9EeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RiEpY0W-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5rjJ88PREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RiEpZEW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_5rjJ9MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#__18Z0jN9Eea40e5DA9KE3w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RiEpZUW-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5rjJ9cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RiEpZkW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_5rjJ9sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_ITjfUjN-Eea40e5DA9KE3w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RiEpZ0W-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_5rjJ98PREeaiK6pYrNo12g"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_T7esFTN7Eea40e5DA9KE3w"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_T7esFjN7Eea40e5DA9KE3w"/>
@@ -720,17 +720,17 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Co1CZEWsEeaB8vMnkFQLXQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_Co1CZUWsEeaB8vMnkFQLXQ" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_Qb1aEEW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_UuCf4MPSEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_fcjcsEW9EeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Qb1aEUW-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UuCf4cPSEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Qb_LEEW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_UuCf4sPSEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_koShwEW9EeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Qb_LEUW-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UuCf48PSEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Qb_LEkW-EeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_UuCf5MPSEeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiEth.uml#_IyOCgkWsEeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Qb_LE0W-EeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UuCf5cPSEeaiK6pYrNo12g"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Co1CZkWsEeaB8vMnkFQLXQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Co1CZ0WsEeaB8vMnkFQLXQ"/>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -199,6 +199,14 @@ Indicates the priority associated with the Partner’s System ID. If the aggrega
             <body>This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.</body>
           </ownedComment>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AbyakjO6Eea40e5DA9KE3w" name="_trafficShaping" type="_8QIrYK4wEeGjbtFXtCFKWg" aggregation="composite" association="_AbxMcDO6Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C7qWUDO6Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C7ySIDO6Eea40e5DA9KE3w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3D1zwTO5Eea40e5DA9KE3w" name="_trafficConditioning" type="_8QR1UK4wEeGjbtFXtCFKWg" aggregation="composite" association="_3Dz-kDO5Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pTncDO5Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_T7cP0DN7Eea40e5DA9KE3w" name="ConnectionEndPointLpSpec">
         <generalization xmi:type="uml:Generalization" xmi:id="_zsepwEWpEeaB8vMnkFQLXQ">
@@ -206,12 +214,12 @@ Indicates the priority associated with the Partner’s System ID. If the aggrega
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xTg3MEW9EeaB8vMnkFQLXQ" name="extensionsSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Kjj_IEW-EeaB8vMnkFQLXQ" value="/TapiEth:ConnectionEndPointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Kjj_IEW-EeaB8vMnkFQLXQ" value="/tapi-eth:connection-end-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_03vL4EW9EeaB8vMnkFQLXQ" name="extensionsSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_G88dwEW-EeaB8vMnkFQLXQ" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_G88dwEW-EeaB8vMnkFQLXQ" value="/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__18Z0jN9Eea40e5DA9KE3w" name="_terminationSpec" type="_ACUEMOxFEeGzwM2Uvwf5Xw" aggregation="composite" association="__17LsDN9Eea40e5DA9KE3w">
@@ -426,12 +434,12 @@ Note that the only significance of the GTCS function defined in G.8021 is the us
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_fcjcsEW9EeaB8vMnkFQLXQ" name="extensionsSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Oh75MEW-EeaB8vMnkFQLXQ" value="/TapiEth:NodeEdgePointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Oh75MEW-EeaB8vMnkFQLXQ" value="/tapi-eth:node-edge-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_koShwEW9EeaB8vMnkFQLXQ" name="extensionsSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_B8c_YEW-EeaB8vMnkFQLXQ" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_B8c_YEW-EeaB8vMnkFQLXQ" value="/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IyOCgkWsEeaB8vMnkFQLXQ" name="_terminationSpec" type="_fzLz0OxQEeGzwM2Uvwf5Xw" aggregation="composite" association="_IyE4kEWsEeaB8vMnkFQLXQ">
@@ -1149,25 +1157,17 @@ DEI = Drop Eligibility Indicator</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_ITkGYDN-Eea40e5DA9KE3w" name="_lpSpec" type="_T7cP0DN7Eea40e5DA9KE3w" association="_ITi4QDN-Eea40e5DA9KE3w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_3Dz-kDO5Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficCondPac" memberEnd="_3D1zwTO5Eea40e5DA9KE3w _3D3B4DO5Eea40e5DA9KE3w" navigableOwnedEnd="_3D1zwTO5Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_3Dz-kDO5Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficCondPac" memberEnd="_3D1zwTO5Eea40e5DA9KE3w _3D3B4DO5Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3D1MsDO5Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3D1zwDO5Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_3D3B4DO5Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_3Dz-kDO5Eea40e5DA9KE3w"/>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_3D1zwTO5Eea40e5DA9KE3w" name="_trafficConditioning" type="_8QR1UK4wEeGjbtFXtCFKWg" aggregation="composite" association="_3Dz-kDO5Eea40e5DA9KE3w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pTncDO5Eea40e5DA9KE3w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
-        </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_AbxMcDO6Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficShapingPac" memberEnd="_AbyakjO6Eea40e5DA9KE3w _AbzosDO6Eea40e5DA9KE3w" navigableOwnedEnd="_AbyakjO6Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_AbxMcDO6Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficShapingPac" memberEnd="_AbyakjO6Eea40e5DA9KE3w _AbzosDO6Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AbyakDO6Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AbyakTO6Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_AbzosDO6Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_AbxMcDO6Eea40e5DA9KE3w"/>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_AbyakjO6Eea40e5DA9KE3w" name="_trafficShaping" type="_8QIrYK4wEeGjbtFXtCFKWg" aggregation="composite" association="_AbxMcDO6Eea40e5DA9KE3w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C7qWUDO6Eea40e5DA9KE3w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C7ySIDO6Eea40e5DA9KE3w" value="1"/>
-        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="__17LsDN9Eea40e5DA9KE3w" name="LpSpecHasTerminationPac" memberEnd="__18Z0jN9Eea40e5DA9KE3w __19A4DN9Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__18Z0DN9Eea40e5DA9KE3w" source="org.eclipse.papyrus">

--- a/UML/TapiNotification.notation
+++ b/UML/TapiNotification.notation
@@ -24,7 +24,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCh8DBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_hZotgCzcEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiAzBHEeam35bpdXJzEw" x="778" y="605"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiAzBHEeam35bpdXJzEw" x="856" y="608"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whCiBDBHEeam35bpdXJzEw" type="2006">
     <children xmi:type="notation:DecorationNode" xmi:id="_whCiBTBHEeam35bpdXJzEw" type="5023"/>
@@ -50,7 +50,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiEjBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_bgwjsCzeEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiJTBHEeam35bpdXJzEw" x="728" y="501" height="91"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCiJTBHEeam35bpdXJzEw" x="806" y="504" height="91"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whCiJjBHEeam35bpdXJzEw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_whCiJzBHEeam35bpdXJzEw" type="5029"/>
@@ -146,37 +146,37 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_whMS-jBHEeam35bpdXJzEw" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_whMS-zBHEeam35bpdXJzEw" type="7017">
-      <children xmi:type="notation:Shape" xmi:id="_fXApQE8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ8MPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_QAttwEThEead1bezhJG4aw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApQU8cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ8cPQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApQk8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ8sPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_aE3TQEThEead1bezhJG4aw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApQ08cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ88PQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApRE8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ9MPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_5oI2dC1sEeair-8ZDvf8jw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApRU8cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ9cPQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApRk8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ9sPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_Nsg9dE8cEea3rq3M7G3w3w"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApR08cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ98PQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApSE8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ-MPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_rZ7rxCzyEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApSU8cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ-cPQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApSk8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ-sPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_BeqnEC0bEeah7qIgVNfKeA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApS08cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ-8PQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApTE8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ_MPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_0iGcECzwEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApTU8cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ_cPQEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_fXApTk8cEea3rq3M7G3w3w" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_Z1XQ_sPQEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiNotification.uml#_4HEXoCzwEeaYO8M_h7XJ5A"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_fXApT08cEea3rq3M7G3w3w"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1XQ_8PQEeaiK6pYrNo12g"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_whMTnDBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_whMTnTBHEeam35bpdXJzEw"/>
@@ -218,7 +218,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMT7jBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Enumeration" href="TapiNotification.uml#_Rjd84C0aEeah7qIgVNfKeA"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUATBHEeam35bpdXJzEw" x="947" y="498" height="82"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMUATBHEeam35bpdXJzEw" x="1025" y="501" height="82"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMUAjBHEeam35bpdXJzEw" type="2006">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMUAzBHEeam35bpdXJzEw" type="5023"/>
@@ -342,7 +342,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMVsDBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMV2jBHEeam35bpdXJzEw" x="334" y="469"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMV2jBHEeam35bpdXJzEw" x="322" y="474"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMV2zBHEeam35bpdXJzEw" type="2004">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMV3DBHEeam35bpdXJzEw" type="5011"/>
@@ -678,8 +678,8 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_whMUQTBHEeam35bpdXJzEw"/>
     <element xmi:type="uml:Association" href="TapiNotification.uml#_5oI2cC1sEeair-8ZDvf8jw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_whMURTBHEeam35bpdXJzEw" points="[0, 2, -3, -136]$[-11, 124, -14, -14]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whMURjBHEeam35bpdXJzEw" id="(0.8141025641025641,1.0)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whMURzBHEeam35bpdXJzEw" id="(0.2925531914893617,0.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whMURjBHEeam35bpdXJzEw" id="(0.8116935483870967,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whMURzBHEeam35bpdXJzEw" id="(0.28959660297239914,0.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_whyIzjBHEeam35bpdXJzEw" type="StereotypeCommentLink" source="_whMS4DBHEeam35bpdXJzEw" target="_whyIyjBHEeam35bpdXJzEw">
     <styles xmi:type="notation:FontStyle" xmi:id="_whyIzzBHEeam35bpdXJzEw"/>
@@ -823,8 +823,8 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_kYjcEU8SEea3rq3M7G3w3w"/>
     <element xmi:type="uml:Association" href="TapiNotification.uml#_kFsxgE8SEea3rq3M7G3w3w"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kYjcEk8SEea3rq3M7G3w3w" points="[0, -20, -3, 193]$[14, -207, 11, 6]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEE8SEea3rq3M7G3w3w" id="(0.8776595744680851,0.0)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEU8SEea3rq3M7G3w3w" id="(0.37055837563451777,1.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEE8SEea3rq3M7G3w3w" id="(0.8738853503184714,0.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEU8SEea3rq3M7G3w3w" id="(0.36243654822335025,1.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_kaZPIE8SEea3rq3M7G3w3w" type="StereotypeCommentLink" source="_kYjcEE8SEea3rq3M7G3w3w" target="_kaYoEE8SEea3rq3M7G3w3w">
     <styles xmi:type="notation:FontStyle" xmi:id="_kaZPIU8SEea3rq3M7G3w3w"/>

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -103,12 +103,12 @@
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_QAttwEThEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_QAttwUThEead1bezhJG4aw" value="/TapiNotification:NotificationSubscriptionService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_QAttwUThEead1bezhJG4aw" value="/tapi-notification:notification-subscription-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_36HEED3jEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aE3TQEThEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_aE3TQUThEead1bezhJG4aw" value="/Tapi:Context/Tapi:_notifSubscription"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_aE3TQUThEead1bezhJG4aw" value="/tapi-common:context/tapi-common:notif-subscription"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_4oopgEJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_5oI2dC1sEeair-8ZDvf8jw" name="_notification" type="_7CEIsC1qEeair-8ZDvf8jw" isReadOnly="true" aggregation="shared" association="_5oI2cC1sEeair-8ZDvf8jw">
@@ -165,12 +165,12 @@
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_oMeHIEThEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_oMeHIUThEead1bezhJG4aw" value="/TapiNotification:Notification"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_oMeHIUThEead1bezhJG4aw" value="/tapi-notification:notification"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_vow5kEThEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_vow5kUThEead1bezhJG4aw" value="/Tapi:Context/Tapi:_notification"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_vow5kUThEead1bezhJG4aw" value="/tapi-common:context/tapi-common:notification"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__HbVoCzoEeaYO8M_h7XJ5A" name="notificationType" type="_hZotgCzcEeaYO8M_h7XJ5A"/>

--- a/UML/TapiOch.notation
+++ b/UML/TapiOch.notation
@@ -36,21 +36,21 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_KjZa3RKOEeajhbtskMXJfw" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_KjZa3hKOEeajhbtskMXJfw" type="7017">
-      <children xmi:type="notation:Shape" xmi:id="_oJhEgEUHEead1bezhJG4aw" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_jxVDcMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_AICzUDK2Eeau3Z0jZdArnw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oJhEgUUHEead1bezhJG4aw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jxVDccPTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_oJhEgkUHEead1bezhJG4aw" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_jxVDcsPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_sPQsIDOTEeansfg7-s4Unw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oJhEg0UHEead1bezhJG4aw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jxVDc8PTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_oJhEhEUHEead1bezhJG4aw" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_jxVDdMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_KjQ3rhKOEeajhbtskMXJfw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oJhEhUUHEead1bezhJG4aw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jxVDdcPTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_oJhEhkUHEead1bezhJG4aw" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_jxVDdsPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_KjQ3sRKOEeajhbtskMXJfw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_oJhEh0UHEead1bezhJG4aw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jxVDd8PTEeaiK6pYrNo12g"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_KjaBrRKOEeajhbtskMXJfw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_KjaBrhKOEeajhbtskMXJfw"/>
@@ -70,7 +70,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KjaBuhKOEeajhbtskMXJfw"/>
     </children>
     <element xmi:type="uml:Class" href="TapiOch.uml#_KjQ3rRKOEeajhbtskMXJfw"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KjaB5BKOEeajhbtskMXJfw" x="2" y="-171" width="820" height="92"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KjaB5BKOEeajhbtskMXJfw" x="2" y="-171" width="1214" height="92"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_KjaB5RKOEeajhbtskMXJfw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_KjaB5hKOEeajhbtskMXJfw" type="5029"/>
@@ -390,17 +390,17 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_YMSWUkUIEead1bezhJG4aw" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_YMSWU0UIEead1bezhJG4aw" type="7017">
-      <children xmi:type="notation:Shape" xmi:id="_nQ9w0EWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_6saUkMPSEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_2EvMwEUIEead1bezhJG4aw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nQ9w0UWUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6saUkcPSEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_nRG6wEWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_6sjegMPSEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_QVdmMEUXEead1bezhJG4aw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nRG6wUWUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6sjegcPSEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_nRG6wkWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_6sjegsPSEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOch.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nRG6w0WUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6sjeg8PSEeaiK6pYrNo12g"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_YMSWVEUIEead1bezhJG4aw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_YMSWVUUIEead1bezhJG4aw"/>
@@ -420,7 +420,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YMSWYUUIEead1bezhJG4aw"/>
     </children>
     <element xmi:type="uml:Class" href="TapiOch.uml#_VvSIYEUIEead1bezhJG4aw"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YMIlUUUIEead1bezhJG4aw" x="-170" y="-267" height="82"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YMIlUUUIEead1bezhJG4aw" x="-192" y="-265" height="82"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_YMbgW0UIEead1bezhJG4aw" type="StereotypeComment">
     <styles xmi:type="notation:TitleStyle" xmi:id="_YMbgXEUIEead1bezhJG4aw" showTitle="true"/>
@@ -792,6 +792,22 @@
     <element xsi:nil="true"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U9UC-02aEeaVmblocARh6A" x="77" y="-371"/>
   </children>
+  <children xmi:type="notation:Shape" xmi:id="_ppHysMPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_ppHyscPSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppHys8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Generalization" href="TapiOch.uml#_hgaisDK1Eeau3Z0jZdArnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ppHyssPSEeaiK6pYrNo12g" x="202" y="-271"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_ppRkG8PSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_ppRkHMPSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppRkHsPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ppRkHcPSEeaiK6pYrNo12g" x="77" y="-371"/>
+  </children>
   <styles xmi:type="notation:StringValueStyle" xmi:id="_KjapNBKOEeajhbtskMXJfw" name="diagram_compatibility_version" stringValue="1.1.0"/>
   <styles xmi:type="notation:DiagramStyle" xmi:id="_KjapNRKOEeajhbtskMXJfw"/>
   <styles xmi:type="style:PapyrusViewStyle" xmi:id="_KjapNhKOEeajhbtskMXJfw">
@@ -1101,7 +1117,7 @@
     <element xmi:type="uml:Association" href="TapiOch.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wYVu0kUBEead1bezhJG4aw" points="[0, 0, 394, -9]$[-394, 9, 0, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVu30UBEead1bezhJG4aw" id="(0.43147208121827413,0.0)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVu4EUBEead1bezhJG4aw" id="(0.09652076318742986,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wYVu4EUBEead1bezhJG4aw" id="(0.09611829944547134,1.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_YMbgX0UIEead1bezhJG4aw" type="StereotypeCommentLink" source="_YMIlUEUIEead1bezhJG4aw" target="_YMbgW0UIEead1bezhJG4aw">
     <styles xmi:type="notation:FontStyle" xmi:id="_YMbgYEUIEead1bezhJG4aw"/>
@@ -1120,7 +1136,7 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_iYCYoUUIEead1bezhJG4aw"/>
     <element xmi:type="uml:Generalization" href="TapiOch.uml#_iXciwEUIEead1bezhJG4aw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iYCYokUIEead1bezhJG4aw" points="[0, 0, 87, -49]$[-86, 49, 1, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZhmYEUIEead1bezhJG4aw" id="(0.11784511784511785,0.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZhmYEUIEead1bezhJG4aw" id="(0.11737523105360444,0.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iZhmYUUIEead1bezhJG4aw" id="(0.228,1.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_iYx_h0UIEead1bezhJG4aw" type="StereotypeCommentLink" source="_iYCYoEUIEead1bezhJG4aw" target="_iYx_g0UIEead1bezhJG4aw">
@@ -1555,5 +1571,25 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U9UC_02aEeaVmblocARh6A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9UDAE2aEeaVmblocARh6A"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U9UDAU2aEeaVmblocARh6A"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ppHytMPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_hg3OoDK1Eeau3Z0jZdArnw" target="_ppHysMPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_ppHytcPSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppHyucPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Generalization" href="TapiOch.uml#_hgaisDK1Eeau3Z0jZdArnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ppHytsPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppHyt8PSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppHyuMPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ppRkH8PSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_gQo84DK1Eeau3Z0jZdArnw" target="_ppRkG8PSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_ppRkIMPSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ppRkJMPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ppRkIcPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppRkIsPSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ppRkI8PSEeaiK6pYrNo12g"/>
   </edges>
 </notation:Diagram>

--- a/UML/TapiOch.uml
+++ b/UML/TapiOch.uml
@@ -36,12 +36,12 @@
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AICzUDK2Eeau3Z0jZdArnw" name="extensionsSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_AICzUTK2Eeau3Z0jZdArnw" value="/TapiOch:ConnectionEndPointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_AICzUTK2Eeau3Z0jZdArnw" value="/tapi-och:connection-end-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_sPQsIDOTEeansfg7-s4Unw" name="extensionsSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_sPQsITOTEeansfg7-s4Unw" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_sPQsITOTEeansfg7-s4Unw" value="/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3rhKOEeajhbtskMXJfw" name="_adapterSpec" type="_KjQ3qhKOEeajhbtskMXJfw" aggregation="composite" association="_KjQ3ohKOEeajhbtskMXJfw">
@@ -84,12 +84,12 @@ This attribute is required for the OCh Trial Termination Point Source at the tra
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_2EvMwEUIEead1bezhJG4aw" name="extensionsSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_2EvMwUUIEead1bezhJG4aw" value="/TapiOch:NodeEdgePointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_2EvMwUUIEead1bezhJG4aw" value="/tapi-och:node-edge-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_QVdmMEUXEead1bezhJG4aw" name="extensionsSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_WOQlkEUXEead1bezhJG4aw" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_WOQlkEUXEead1bezhJG4aw" value="/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_ochPoolPropertySpec" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -105,21 +105,21 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_sY0nHh3BEea2UIYIpgn3Zw" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_sY0nHx3BEea2UIYIpgn3Zw" type="7017">
-      <children xmi:type="notation:Shape" xmi:id="_mXmnsEKmEea-2Meh9kw1kA" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_SiJaoMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#__8RGQDNnEea2QIuFbbE3OA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mXmnsUKmEea-2Meh9kw1kA"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SiJaocPTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_mXmnskKmEea-2Meh9kw1kA" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_SiSkkMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#_JjnkgDQ4EeanX4TaGUWPQA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mXmns0KmEea-2Meh9kw1kA"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SiSkkcPTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_mXmntEKmEea-2Meh9kw1kA" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_SiSkksPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#_sYxjIx3BEea2UIYIpgn3Zw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mXmntUKmEea-2Meh9kw1kA"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SiSkk8PTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_mXmntkKmEea-2Meh9kw1kA" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_SiSklMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#_sYxjIh3BEea2UIYIpgn3Zw"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mXmnt0KmEea-2Meh9kw1kA"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SiSklcPTEeaiK6pYrNo12g"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_sY0nIB3BEea2UIYIpgn3Zw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_sY0nIR3BEea2UIYIpgn3Zw"/>
@@ -142,7 +142,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sY0nLR3BEea2UIYIpgn3Zw"/>
     </children>
     <element xmi:type="uml:Class" href="TapiOdu.uml#_sYxjIR3BEea2UIYIpgn3Zw"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sY0nTB3BEea2UIYIpgn3Zw" x="52" y="-183" width="895" height="94"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sY0nTB3BEea2UIYIpgn3Zw" x="15" y="-182" width="1211" height="94"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_sY0nTR3BEea2UIYIpgn3Zw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_sY0nTh3BEea2UIYIpgn3Zw" type="5029">
@@ -312,7 +312,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C8QWwzIOEeaBg9FoTfINnA"/>
     </children>
     <element xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C8QWsTIOEeaBg9FoTfINnA" x="-35" y="-20" width="224" height="85"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C8QWsTIOEeaBg9FoTfINnA" x="-74" y="-23" width="224" height="85"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_Q7grEDNnEea2QIuFbbE3OA" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_Q7qcEDNnEea2QIuFbbE3OA" type="5029"/>
@@ -370,17 +370,17 @@
       <layoutConstraint xmi:type="notation:Location" xmi:id="_Ye9PJEKhEea-2Meh9kw1kA" y="5"/>
     </children>
     <children xmi:type="notation:BasicCompartment" xmi:id="_Ye9PJUKhEea-2Meh9kw1kA" type="7017">
-      <children xmi:type="notation:Shape" xmi:id="_kUxFcEWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_EyBSoMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#__VK1UEKiEea-2Meh9kw1kA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kUxFcUWUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EyBSocPTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_kUxFckWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_EyBSosPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#_NkIOYEKjEea-2Meh9kw1kA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kUxFc0WUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EyBSo8PTEeaiK6pYrNo12g"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_kUxFdEWUEeaB8vMnkFQLXQ" type="3012">
+      <children xmi:type="notation:Shape" xmi:id="_EyBSpMPTEeaiK6pYrNo12g" type="3012">
         <element xmi:type="uml:Property" href="TapiOdu.uml#_cOYiRDIOEeaBg9FoTfINnA"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_kUxFdUWUEeaB8vMnkFQLXQ"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_EyBSpcPTEeaiK6pYrNo12g"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_Ye9PJkKhEea-2Meh9kw1kA"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_Ye9PJ0KhEea-2Meh9kw1kA"/>
@@ -400,7 +400,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ye9PM0KhEea-2Meh9kw1kA"/>
     </children>
     <element xmi:type="uml:Class" href="TapiOdu.uml#_Um-Q8EKhEea-2Meh9kw1kA"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ye9PIUKhEea-2Meh9kw1kA" x="-35" y="-285" width="981" height="89"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ye9PIUKhEea-2Meh9kw1kA" x="-73" y="-284" width="1085" height="89"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_YfGZK0KhEea-2Meh9kw1kA" type="StereotypeComment">
     <styles xmi:type="notation:TitleStyle" xmi:id="_YfGZLEKhEea-2Meh9kw1kA" showTitle="true"/>
@@ -1300,6 +1300,54 @@
     <element xsi:nil="true"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VxmBJsJFEea9PNIEUiwEBg" x="165" y="-385"/>
   </children>
+  <children xmi:type="notation:Shape" xmi:id="_9OgeAsPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9OgeA8PSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9OgeBcPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9OgeBMPSEeaiK6pYrNo12g" x="716" y="-21"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_9PGUTMPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9PGUTcPSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PGUT8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9PGUTsPSEeaiK6pYrNo12g" x="252" y="-283"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_9PQExsPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9PQEx8PSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PQEycPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7tR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9PQEyMPSEeaiK6pYrNo12g" x="252" y="-283"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_9PZO4cPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9PZO4sPSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PZO5MPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxi9R3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9PZO48PSEeaiK6pYrNo12g" x="453" y="-22"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_9P16oMPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9P16ocPSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9P16o8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9P16osPSEeaiK6pYrNo12g" x="165" y="-20"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_9QSnKsPSEeaiK6pYrNo12g" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_9QSnK8PSEeaiK6pYrNo12g" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9QSnLcPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9QSnLMPSEeaiK6pYrNo12g" x="165" y="-385"/>
+  </children>
   <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.1.0"/>
   <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
   <styles xmi:type="style:PapyrusViewStyle" xmi:id="_sZDP5h3BEea2UIYIpgn3Zw">
@@ -1343,7 +1391,7 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_sZDP9B3BEea2UIYIpgn3Zw"/>
     <element xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sZDP9R3BEea2UIYIpgn3Zw" points="[21, -2, -716, 0]$[700, -11, -37, -9]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDP9h3BEea2UIYIpgn3Zw" id="(0.7575418994413408,1.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDP9h3BEea2UIYIpgn3Zw" id="(0.5887696118909992,1.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDP9x3BEea2UIYIpgn3Zw" id="(0.5011709601873536,0.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_sZDP-B3BEea2UIYIpgn3Zw" type="4001" source="_sY0nGx3BEea2UIYIpgn3Zw" target="_sY0nTR3BEea2UIYIpgn3Zw">
@@ -1383,7 +1431,7 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_sZDQBR3BEea2UIYIpgn3Zw"/>
     <element xmi:type="uml:Association" href="TapiOdu.uml#_sYw7tR3BEea2UIYIpgn3Zw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sZDQBh3BEea2UIYIpgn3Zw" points="[11, 3, -267, -88]$[266, 98, -12, 7]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDQBx3BEea2UIYIpgn3Zw" id="(0.3664804469273743,1.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDQBx3BEea2UIYIpgn3Zw" id="(0.3022295623451693,1.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sZDQCB3BEea2UIYIpgn3Zw" id="(0.5182186234817814,0.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_sZDQ7R3BEea2UIYIpgn3Zw" type="StereotypeCommentLink" target="_sZA0QB3BEea2UIYIpgn3Zw">
@@ -1511,7 +1559,7 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_cO-YITIOEeaBg9FoTfINnA"/>
     <element xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cO-YIjIOEeaBg9FoTfINnA" points="[-2, 13, 8, -73]$[-1, 71, 9, -15]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQwg0DIOEeaBg9FoTfINnA" id="(0.0581039755351682,1.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQwg0DIOEeaBg9FoTfINnA" id="(0.05806451612903226,1.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cQwg0TIOEeaBg9FoTfINnA" id="(0.2544642857142857,0.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_cPt_BDIOEeaBg9FoTfINnA" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA">
@@ -1571,7 +1619,7 @@
     <styles xmi:type="notation:FontStyle" xmi:id="_c2M8MUKhEea-2Meh9kw1kA"/>
     <element xmi:type="uml:Generalization" href="TapiOdu.uml#_c1dVUEKhEea-2Meh9kw1kA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c2M8MkKhEea-2Meh9kw1kA" points="[-4, -2, 77, 36]$[-68, -37, 13, 1]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c3_E4EKhEea-2Meh9kw1kA" id="(0.059123343527013254,0.0)"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c3_E4EKhEea-2Meh9kw1kA" id="(0.08940092165898618,0.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c3_E4UKhEea-2Meh9kw1kA" id="(0.1261682242990654,1.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_c3GUF0KhEea-2Meh9kw1kA" type="StereotypeCommentLink" source="_c2M8MEKhEea-2Meh9kw1kA" target="_c3GUE0KhEea-2Meh9kw1kA">
@@ -2616,5 +2664,65 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VxmBKsJFEea9PNIEUiwEBg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VxmBK8JFEea9PNIEUiwEBg"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VxmBLMJFEea9PNIEUiwEBg"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9OgeBsPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_9OgeAsPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9OgeB8PSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9OgeC8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9OgeCMPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9OgeCcPSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9OgeCsPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9PGUUMPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_sZDP5x3BEea2UIYIpgn3Zw" target="_9PGUTMPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9PGUUcPSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PGUVcPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9PGUUsPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PGUU8PSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PGUVMPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9PQEysPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_sZDP-B3BEea2UIYIpgn3Zw" target="_9PQExsPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9PQEy8PSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PQEz8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7tR3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9PQEzMPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PQEzcPSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PQEzsPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9PZO5cPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_sY0nTR3BEea2UIYIpgn3Zw" target="_9PZO4cPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9PZO5sPSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9PZO6sPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxi9R3BEea2UIYIpgn3Zw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9PZO58PSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PZO6MPSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9PZO6cPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9P16pMPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_9P16oMPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9P16pcPSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9P16qcPSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9P16psPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9P16p8PSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9P16qMPSEeaiK6pYrNo12g"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9QSnLsPSEeaiK6pYrNo12g" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA" target="_9QSnKsPSEeaiK6pYrNo12g">
+    <styles xmi:type="notation:FontStyle" xmi:id="_9QSnL8PSEeaiK6pYrNo12g"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9QSnM8PSEeaiK6pYrNo12g" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9QSnMMPSEeaiK6pYrNo12g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9QSnMcPSEeaiK6pYrNo12g"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9QSnMsPSEeaiK6pYrNo12g"/>
   </edges>
 </notation:Diagram>

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -216,12 +216,12 @@ This attribute applies only to ODUflex(CBR) connections only. The value of this 
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__8RGQDNnEea2QIuFbbE3OA" name="extensionsSpecification">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="__8RGQTNnEea2QIuFbbE3OA" value="/TapiOdu:ConnectionEndPointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="__8RGQTNnEea2QIuFbbE3OA" value="/tapi-odu:connection-end-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_JjnkgDQ4EeanX4TaGUWPQA" name="extensionsSpecTarget">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_JjnkgTQ4EeanX4TaGUWPQA" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_JjnkgTQ4EeanX4TaGUWPQA" value="/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjIx3BEea2UIYIpgn3Zw" name="_terminationSpec" type="_sYxi9R3BEea2UIYIpgn3Zw" aggregation="composite" association="_sYw7tR3BEea2UIYIpgn3Zw">
@@ -250,12 +250,12 @@ This attribute applies only to ODUflex(CBR) connections only. The value of this 
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="__VK1UEKiEea-2Meh9kw1kA" name="extensionsSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="__VK1UUKiEea-2Meh9kw1kA" value="/TapiOdu:NodeEdgePointLpSpec"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="__VK1UUKiEea-2Meh9kw1kA" value="/tapi-odu:node-edge-point-lp-spec"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_VZkuoS6BEea0_JngOlSKcA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_NkIOYEKjEea-2Meh9kw1kA" name="extensionsSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NkIOYUKjEea-2Meh9kw1kA" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NkIOYUKjEea-2Meh9kw1kA" value="/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_EGSwgDOFEeansfg7-s4Unw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_cOYiRDIOEeaBg9FoTfINnA" name="_oduPoolPropertySpec" type="_CJrDMDIOEeaBg9FoTfINnA" aggregation="composite" association="_cOYiQDIOEeaBg9FoTfINnA">

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -121,12 +121,12 @@
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_h65Q0ETgEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_h65Q0UTgEead1bezhJG4aw" value="/TapiPathComputation:Path"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_h65Q0UTgEead1bezhJG4aw" value="/tapi-path-computation:path"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_prXjgETgEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_prXjgUTgEead1bezhJG4aw" value="/Tapi:Context/Tapi:_path"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_prXjgUTgEead1bezhJG4aw" value="/tapi-common:context/tapi-common:path"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_eMyr8t6ZEeWd9KDn6x5Skg" name="_telink" isReadOnly="true" aggregation="composite" association="_eMpiAN6ZEeWd9KDn6x5Skg">
@@ -180,12 +180,12 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_D3E34ETgEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_D3E34UTgEead1bezhJG4aw" value="/TapiPathComputation:PathComputationService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_D3E34UTgEead1bezhJG4aw" value="/tapi-path-computation:path-computation-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_36HEED3jEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_LHJMMETgEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LHJMMUTgEead1bezhJG4aw" value="/Tapi:Context/Tapi:_pathCompService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LHJMMUTgEead1bezhJG4aw" value="/tapi-common:context/tapi-common:path-comp-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_4oopgEJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_1EaBNC2bEeair-8ZDvf8jw" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" isReadOnly="true" aggregation="composite" association="_1EaBMC2bEeair-8ZDvf8jw">

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -263,7 +263,7 @@
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_LErsEET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LErsEUT2Eead1bezhJG4aw" value="/TapiTopology:Link"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LErsEUT2Eead1bezhJG4aw" value="/tapi-topology:link"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_V5vxIET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
@@ -315,7 +315,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7GUK4ET1Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7GUK4UT1Eead1bezhJG4aw" value="/TapiTopology:Node"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7GUK4UT1Eead1bezhJG4aw" value="/tapi-topology:node"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_BCToMET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
@@ -358,12 +358,12 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_rS5u4ENoEeaF1NC7HRCQgw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_rS5u4UNoEeaF1NC7HRCQgw" value="/TapiTopology:Topology"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_rS5u4UNoEeaF1NC7HRCQgw" value="/tapi-topology:topology"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ywQ4UENoEeaF1NC7HRCQgw" name="resourceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_6v0v4ENoEeaF1NC7HRCQgw" value="/Tapi:Context/Tapi:_topology"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_6v0v4ENoEeaF1NC7HRCQgw" value="/tapi-common:context/tapi-common:topology"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9-Bkkj_KEeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_9-A9gD_KEeWNAdBR30aJhw">
@@ -414,7 +414,7 @@ The structure of LTP supports all transport protocols including circuit and pack
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_fJEncET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_fJEncUT2Eead1bezhJG4aw" value="/TapiTopology:NodeEdgePoint"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_fJEncUT2Eead1bezhJG4aw" value="/tapi-topology:node-edge-point"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_jW1BUET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
@@ -641,12 +641,12 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ko4_wETuEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_ko4_wUTuEead1bezhJG4aw" value="/TapiTopology:NetworkTopologyService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_ko4_wUTuEead1bezhJG4aw" value="/tapi-topology:network-topology-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_36HEED3jEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_yEfCMETuEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_yEfCMUTuEead1bezhJG4aw" value="/Tapi:Context/Tapi:_nwTopologyService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_yEfCMUTuEead1bezhJG4aw" value="/tapi-common:context/tapi-common:nw-topology-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_4oopgEJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_v4NNVETtEead1bezhJG4aw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_v4NNUETtEead1bezhJG4aw">

--- a/UML/TapiVirtualNetwork.notation
+++ b/UML/TapiVirtualNetwork.notation
@@ -1217,53 +1217,37 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YOkmhEXSEeaB8vMnkFQLXQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_YOkmhUXSEeaB8vMnkFQLXQ" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_koJLQEXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA0MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_OdvxEETfEead1bezhJG4aw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koJLQUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA0cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koKZYEXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA0sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_XuLaoETfEead1bezhJG4aw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koKZYUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA08PREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koKZYkXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA1MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_oWBRA_TaEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koKZY0XSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA1cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koKZZEXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA1sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_9DOx0vTYEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koKZZUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA18PREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koMOkEXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA2MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_fr8Gs_TjEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koMOkUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA2cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koMOkkXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA2sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_--7mWvTUEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koMOk0XSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA28PREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koMOlEXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA3MPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_--7mW_TUEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koMOlUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA3cPREeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_koMOlkXSEeaB8vMnkFQLXQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_gGHA3sPREeaiK6pYrNo12g" type="3012">
           <element xmi:type="uml:Property" href="TapiVirtualNetwork.uml#_--7mXPTUEeWQB8HQFBfkJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koMOl0XSEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_koMOmEXSEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koMOmUXSEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_koNcsEXSEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koNcsUXSEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_koNcskXSEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koNcs0XSEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_koNctEXSEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_cKOXgDNtEea0Br-ajMxp_A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_koNctUXSEeaB8vMnkFQLXQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gGHA38PREeaiK6pYrNo12g"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_YOkmhkXSEeaB8vMnkFQLXQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_YOkmh0XSEeaB8vMnkFQLXQ"/>
@@ -1283,7 +1267,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmk0XSEeaB8vMnkFQLXQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiVirtualNetwork.uml#_--7mUPTUEeWQB8HQFBfkJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmgUXSEeaB8vMnkFQLXQ" x="21" y="28" height="225"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YOkmgUXSEeaB8vMnkFQLXQ" x="10" y="33" width="454" height="162"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_YOwzw0XSEeaB8vMnkFQLXQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_YOwzxEXSEeaB8vMnkFQLXQ" showTitle="true"/>
@@ -1451,7 +1435,7 @@
       <element xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_fr8GsPTjEeWQB8HQFBfkJQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YQGQgkXSEeaB8vMnkFQLXQ" points="[0, 0, 223, 57]$[-223, -57, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YQGQj0XSEeaB8vMnkFQLXQ" id="(0.0,0.2962962962962963)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YQGQkEXSEeaB8vMnkFQLXQ" id="(1.0,0.29333333333333333)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YQGQkEXSEeaB8vMnkFQLXQ" id="(1.0,0.4074074074074074)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YQHeqkXSEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_YQGQgEXSEeaB8vMnkFQLXQ" target="_YQHepkXSEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_YQHeq0XSEeaB8vMnkFQLXQ"/>
@@ -1494,9 +1478,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ZUZmIUXSEeaB8vMnkFQLXQ"/>
       <element xmi:type="uml:Association" href="TapiVirtualNetwork.uml#_9CCfAPTYEeWQB8HQFBfkJQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZUZmIkXSEeaB8vMnkFQLXQ" points="[0, 0, 418, 87]$[-418, 0, 0, 87]$[-418, -87, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZUZmIkXSEeaB8vMnkFQLXQ" points="[0, 0, 417, 150]$[-417, 6, 0, 156]$[-417, -150, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUbbXEXSEeaB8vMnkFQLXQ" id="(0.0,0.4012345679012346)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUbbXUXSEeaB8vMnkFQLXQ" id="(0.46543778801843316,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUbbXUXSEeaB8vMnkFQLXQ" id="(0.4647577092511013,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZUr6CkXSEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_ZUZmIEXSEeaB8vMnkFQLXQ" target="_ZUr6BkXSEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_ZUr6C0XSEeaB8vMnkFQLXQ"/>

--- a/UML/TapiVirtualNetwork.uml
+++ b/UML/TapiVirtualNetwork.uml
@@ -156,12 +156,12 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_OdvxEETfEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_OdvxEUTfEead1bezhJG4aw" value="/TapiVirtualNetwork:VirtualNetworkService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_OdvxEUTfEead1bezhJG4aw" value="/tapi-virtual-network:virtual-network-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_36HEED3jEea-1_BGg-qcjQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_XuLaoETfEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <defaultValue xmi:type="uml:LiteralString" xmi:id="_XuLaoUTfEead1bezhJG4aw" value="/Tapi:Context/Tapi:_vnwService"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_XuLaoUTfEead1bezhJG4aw" value="/tapi-common:context/tapi-common:virtual-nw-service"/>
           <redefinedProperty xmi:type="uml:Property" href="TapiCommon.uml#_4oopgEJuEea-2Meh9kw1kA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_oWBRA_TaEeWQB8HQFBfkJQ" name="_topology" isReadOnly="true" aggregation="composite" association="_oWBRAPTaEeWQB8HQFBfkJQ">

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -12,7 +12,7 @@ module tapi-common {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_serviceEndPoint" {
+    augment "/tapi-common:context/tapi-common:service-end-point" {
         uses service-end-point;
         description "none";
     }
@@ -51,12 +51,12 @@ module tapi-common {
                 uses name-and-value;
                 description "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.";
             }
+            container extensions {
+                config false;
+                uses extensions-spec;
+                description "none";
+            }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
-        }
-        list layer-protocol {
-            key 'local-id';
-            uses layer-protocol;
-            description "none";
         }
         grouping layer-protocol {
             leaf layer-protocol-name {
@@ -96,6 +96,11 @@ module tapi-common {
                 uses name-and-value;
                 description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
             }
+            container extensions {
+                config false;
+                uses extensions-spec;
+                description "none";
+            }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
         }
         grouping operational-state-pac {
@@ -108,10 +113,6 @@ module tapi-common {
                 description "none";
             }
             description "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.";
-        }
-        container time-range {
-            uses time-range;
-            description "none";
         }
         grouping time-range {
             leaf end-time {
@@ -127,12 +128,67 @@ module tapi-common {
         grouping extensions-spec {
             description "none";
         }
-        list context {
-            key 'uuid';
+        container context {
             uses context;
             description "none";
         }
         grouping context {
+            container nw-topology-service {
+                config false;
+                uses service-spec;
+                description "none";
+            }
+            list connectivity-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list virtual-nw-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list path-comp-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list notif-subscription {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list service-end-point {
+                key 'uuid';
+                config false;
+                min-elements 2;
+                uses resource-spec;
+                description "none";
+            }
+            list topology {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list connection {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list path {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list notification {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
             uses global-class;
             description "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).";
         }
@@ -142,11 +198,6 @@ module tapi-common {
         }
         grouping service-spec {
             uses global-class;
-            description "none";
-        }
-        list service-end-point {
-            key 'uuid';
-            uses service-end-point;
             description "none";
         }
         grouping service-end-point {
@@ -276,11 +327,6 @@ module tapi-common {
                 }
             }
             description "The possible values of the lifecycleState.";
-        }
-        list name-and-value {
-            key 'value-name';
-            uses name-and-value;
-            description "none";
         }
         grouping name-and-value {
             leaf value-name {

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -21,22 +21,17 @@ module tapi-connectivity {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_connection" {
+    augment "/tapi-common:context/tapi-common:connection" {
         uses connection;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_connectivityService" {
+    augment "/tapi-common:context/tapi-common:connectivity-service" {
         uses connectivity-service;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        list connection {
-            key 'uuid';
-            uses connection;
-            description "none";
-        }
         grouping connection {
             list connection-end-point {
                 key 'uuid';
@@ -53,7 +48,7 @@ module tapi-connectivity {
             }
             leaf node {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
@@ -77,11 +72,6 @@ module tapi-connectivity {
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        list connection-end-point {
-            key 'uuid';
-            uses connection-end-point;
-            description "none";
-        }
         grouping connection-end-point {
             list layer-protocol {
                 key 'local-id';
@@ -92,21 +82,21 @@ module tapi-connectivity {
             }
             leaf-list client-node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf server-node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf peer-connection-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
+                    path '/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
                 }
                 config false;
                 description "none";
@@ -134,10 +124,6 @@ module tapi-connectivity {
             uses tapi-common:resource-spec;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
-        }
-        container connectivity-constraint {
-            uses connectivity-constraint;
-            description "none";
         }
         grouping connectivity-constraint {
             leaf service-type {
@@ -174,39 +160,39 @@ module tapi-connectivity {
             }
             leaf coroute-inclusion {
                 type leafref {
-                    path '/tapi:context/tapi:connectivity-service/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:connectivity-service/tapi-common:uuid';
                 }
                 description "none";
             }
             leaf-list diversity-exclusion {
                 type leafref {
-                    path '/tapi:context/tapi:connectivity-service/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:connectivity-service/tapi-common:uuid';
                 }
                 description "none";
             }
             leaf-list include-topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf-list avoid-topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf-list include-path {
                 type leafref {
-                    path '/tapi:context/tapi:path/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:path/tapi-common:uuid';
                 }
                 description "none";
             }
             leaf-list exclude-path {
                 type leafref {
-                    path '/tapi:context/tapi:path/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:path/tapi-common:uuid';
                 }
                 description "none";
             }
@@ -225,15 +211,10 @@ module tapi-connectivity {
             uses tapi-common:local-class;
             description "none";
         }
-        list connectivity-service {
-            key 'uuid';
-            uses connectivity-service;
-            description "none";
-        }
         grouping connectivity-service {
             leaf-list connection {
                 type leafref {
-                    path '/tapi:context/tapi:connection/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:connection/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -268,15 +249,10 @@ module tapi-connectivity {
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        list connectivity-service-port {
-            key 'local-id';
-            uses connectivity-service-port;
-            description "none";
-        }
         grouping connectivity-service-port {
             leaf service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -305,15 +281,10 @@ module tapi-connectivity {
                 The EP replaces the Protection Unit of a traditional protection model. 
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
-        list route {
-            key 'local-id';
-            uses route;
-            description "none";
-        }
         grouping route {
             leaf-list lower-connection {
                 type leafref {
-                    path '/tapi:context/tapi:connection/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:connection/tapi-common:uuid';
                 }
                 config false;
                 min-elements 1;

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -21,21 +21,17 @@ module tapi-eth {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+    augment "/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions" {
         uses connection-end-point-lp-spec;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+    augment "/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions" {
         uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        container connection-point-and-adapter-pac {
-            uses connection-point-and-adapter-pac;
-            description "none";
-        }
         grouping connection-point-and-adapter-pac {
             leaf-list auxiliary-function-position-sequence {
                 type uint64;
@@ -149,10 +145,14 @@ module tapi-eth {
                 description "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.
                     range of type : true, false";
             }
-            description "none";
-        }
-        container connection-end-point-lp-spec {
-            uses connection-end-point-lp-spec;
+            container traffic-shaping {
+                uses traffic-shaping-pac;
+                description "none";
+            }
+            container traffic-conditioning {
+                uses traffic-conditioning-pac;
+                description "none";
+            }
             description "none";
         }
         grouping connection-end-point-lp-spec {
@@ -165,10 +165,6 @@ module tapi-eth {
                 description "none";
             }
             uses tapi-common:extensions-spec;
-            description "none";
-        }
-        container eth-termination-pac {
-            uses eth-termination-pac;
             description "none";
         }
         grouping eth-termination-pac {
@@ -222,10 +218,6 @@ module tapi-eth {
             }
             description "This object class models the Ethernet Flow Termination function located at a layer boundary.";
         }
-        container ety-termination-pac {
-            uses ety-termination-pac;
-            description "none";
-        }
         grouping ety-termination-pac {
             leaf is-fts-enabled {
                 type boolean;
@@ -245,10 +237,6 @@ module tapi-eth {
                 config false;
                 description "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.";
             }
-            description "none";
-        }
-        container traffic-conditioning-pac {
-            uses traffic-conditioning-pac;
             description "none";
         }
         grouping traffic-conditioning-pac {
@@ -281,10 +269,6 @@ module tapi-eth {
             description "This object class models the ETH traffic conditioning function as defined in G.8021.
                 Basic attributes: codirectional, condConfigList, prioConfigList";
         }
-        container traffic-shaping-pac {
-            uses traffic-shaping-pac;
-            description "none";
-        }
         grouping traffic-shaping-pac {
             list prio-config-list {
                 config false;
@@ -315,10 +299,6 @@ module tapi-eth {
             description "This object class models the ETH traffic shaping function as defined in G.8021.
                 Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
         }
-        container node-edge-point-lp-spec {
-            uses node-edge-point-lp-spec;
-            description "none";
-        }
         grouping node-edge-point-lp-spec {
             container termination-spec {
                 uses ety-termination-pac;
@@ -331,10 +311,6 @@ module tapi-eth {
     /***********************
     * package type-definitions
     **********************/ 
-        list priority-configuration {
-            uses priority-configuration;
-            description "none";
-        }
         grouping priority-configuration {
             leaf priority {
                 type uint64 {
@@ -350,10 +326,6 @@ module tapi-eth {
             }
             description "none";
         }
-        list queue-configuration {
-            uses queue-configuration;
-            description "none";
-        }
         grouping queue-configuration {
             leaf queue-id {
                 type uint64;
@@ -367,10 +339,6 @@ module tapi-eth {
                 type uint64;
                 description "This attribute defines the threshold of the queue in bytes.";
             }
-            description "none";
-        }
-        list traffic-conditioning-configuration {
-            uses traffic-conditioning-configuration;
             description "none";
         }
         grouping traffic-conditioning-configuration {
@@ -409,10 +377,6 @@ module tapi-eth {
         typedef mac-address {
             type string;
             description "This primitive data type contains an Ethernet MAC address defined by IEEE 802a. The format of the address consists of 12 hexadecimal characters, grouped in pairs and separated by '-' (e.g., 03-27-AC-75-3E-1D).";
-        }
-        container priority-mapping {
-            uses priority-mapping;
-            description "none";
         }
         grouping priority-mapping {
             leaf priority0 {
@@ -480,10 +444,6 @@ module tapi-eth {
             type string;
             description "none";
         }
-        container address-tuple {
-            uses address-tuple;
-            description "none";
-        }
         grouping address-tuple {
             leaf address {
                 type mac-address;
@@ -498,10 +458,6 @@ module tapi-eth {
         typedef scheduling-configuration {
             type string;
             description "The syntax of this dataType is pending on the specification in G.8021, which is for further study.";
-        }
-        container control-frame-filter {
-            uses control-frame-filter;
-            description "none";
         }
         grouping control-frame-filter {
             leaf c2-00-00-10 {
@@ -639,10 +595,6 @@ module tapi-eth {
             description "This data type identifies the filter action for each of the 33 group MAC addresses (control frames).
                 Value 'false' means block: The frame is discarded by the filter process.
                 Value 'true' means pass: The frame is passed unchanged through the filter process.";
-        }
-        container bandwidth-report {
-            uses bandwidth-report;
-            description "none";
         }
         grouping bandwidth-report {
             leaf source-mac-address {

--- a/YANG/tapi-notification.yang
+++ b/YANG/tapi-notification.yang
@@ -15,22 +15,17 @@ module tapi-notification {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_notifSubscription" {
+    augment "/tapi-common:context/tapi-common:notif-subscription" {
         uses notification-subscription-service;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_notification" {
+    augment "/tapi-common:context/tapi-common:notification" {
         uses notification;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        list notification-subscription-service {
-            key 'uuid';
-            uses notification-subscription-service;
-            description "none";
-        }
         grouping notification-subscription-service {
             list notification {
                 key 'uuid';
@@ -63,10 +58,6 @@ module tapi-notification {
                 description "none";
             }
             uses tapi-common:service-spec;
-            description "none";
-        }
-        container subscription-filter {
-            uses subscription-filter;
             description "none";
         }
         grouping subscription-filter {
@@ -156,10 +147,6 @@ module tapi-notification {
             uses tapi-common:resource-spec;
             description "none";
         }
-        container notification-channel {
-            uses notification-channel;
-            description "none";
-        }
         grouping notification-channel {
             leaf stream-address {
                 type string;
@@ -179,11 +166,6 @@ module tapi-notification {
     /***********************
     * package type-definitions
     **********************/ 
-        list name-and-value-change {
-            key 'value-name';
-            uses name-and-value-change;
-            description "none";
-        }
         grouping name-and-value-change {
             leaf value-name {
                 type string;

--- a/YANG/tapi-och.yang
+++ b/YANG/tapi-och.yang
@@ -21,31 +21,23 @@ module tapi-och {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+    augment "/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions" {
         uses connection-end-point-lp-spec;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+    augment "/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions" {
         uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        container adapter-and-connection-point-pac {
-            uses adapter-and-connection-point-pac;
-            description "none";
-        }
         grouping adapter-and-connection-point-pac {
             leaf monitored-direction {
                 type monitored-direction;
                 config false;
                 description "This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK.";
             }
-            description "none";
-        }
-        container connection-end-point-lp-spec {
-            uses connection-end-point-lp-spec;
             description "none";
         }
         grouping connection-end-point-lp-spec {
@@ -60,10 +52,6 @@ module tapi-och {
             uses tapi-common:extensions-spec;
             description "none";
         }
-        container termination-pac {
-            uses termination-pac;
-            description "none";
-        }
         grouping termination-pac {
             container selected-application-identifier {
                 uses application-identifier;
@@ -75,10 +63,6 @@ module tapi-och {
                     This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.
                     ";
             }
-            description "none";
-        }
-        container pool-property-pac {
-            uses pool-property-pac;
             description "none";
         }
         grouping pool-property-pac {
@@ -96,10 +80,6 @@ module tapi-och {
             }
             description "none";
         }
-        container node-edge-point-lp-spec {
-            uses node-edge-point-lp-spec;
-            description "none";
-        }
         grouping node-edge-point-lp-spec {
             container och-pool-property-spec {
                 config false;
@@ -113,10 +93,6 @@ module tapi-och {
     /***********************
     * package type-definitions
     **********************/ 
-        container application-identifier {
-            uses application-identifier;
-            description "none";
-        }
         grouping application-identifier {
             leaf application-identifier-type {
                 type string;
@@ -138,10 +114,6 @@ module tapi-och {
                 }
             }
             description "The enumeration with the options for directionality for nonintrusive monitoring.";
-        }
-        container nominal-central-frequency-or-wavelength {
-            uses nominal-central-frequency-or-wavelength;
-            description "none";
         }
         grouping nominal-central-frequency-or-wavelength {
             leaf link-type {

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -21,21 +21,17 @@ module tapi-odu {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+    augment "/tapi-common:context/tapi-common:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-connectivity:extensions" {
         uses connection-end-point-lp-spec;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+    augment "/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol/tapi-topology:extensions" {
         uses node-edge-point-lp-spec;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        container adapter-and-connection-point-pac {
-            uses adapter-and-connection-point-pac;
-            description "none";
-        }
         grouping adapter-and-connection-point-pac {
             leaf adaptation-active {
                 type boolean;
@@ -130,10 +126,6 @@ module tapi-odu {
             }
             description "none";
         }
-        container termination-pac {
-            uses termination-pac;
-            description "none";
-        }
         grouping termination-pac {
             leaf rate {
                 type string;
@@ -184,10 +176,6 @@ module tapi-odu {
             }
             description "none";
         }
-        container connection-end-point-lp-spec {
-            uses connection-end-point-lp-spec;
-            description "none";
-        }
         grouping connection-end-point-lp-spec {
             container termination-spec {
                 uses termination-pac;
@@ -198,10 +186,6 @@ module tapi-odu {
                 description "none";
             }
             uses tapi-common:extensions-spec;
-            description "none";
-        }
-        container pool-property-pac {
-            uses pool-property-pac;
             description "none";
         }
         grouping pool-property-pac {
@@ -221,10 +205,6 @@ module tapi-odu {
             }
             description "none";
         }
-        container node-edge-point-lp-spec {
-            uses node-edge-point-lp-spec;
-            description "none";
-        }
         grouping node-edge-point-lp-spec {
             container odu-pool-property-spec {
                 uses pool-property-pac;
@@ -242,10 +222,6 @@ module tapi-odu {
             description "This primitive type defines a bit oriented string.
                 The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).
                 The semantic of each bit position will be defined in the Documentation field of the attribute.";
-        }
-        container deg-thr {
-            uses deg-thr;
-            description "none";
         }
         grouping deg-thr {
             leaf deg-thr-value {
@@ -380,10 +356,6 @@ module tapi-odu {
                 }
             }
             description "Provides an enumeration with the meaning of each k value.";
-        }
-        container oduk-h-nominal-bit-rate-and-tolerance {
-            uses oduk-h-nominal-bit-rate-and-tolerance;
-            description "none";
         }
         grouping oduk-h-nominal-bit-rate-and-tolerance {
             leaf tolerance {

--- a/YANG/tapi-path-computation.yang
+++ b/YANG/tapi-path-computation.yang
@@ -18,22 +18,17 @@ module tapi-path-computation {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_path" {
+    augment "/tapi-common:context/tapi-common:path" {
         uses path;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_pathCompService" {
+    augment "/tapi-common:context/tapi-common:path-comp-service" {
         uses path-computation-service;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        list path {
-            key 'uuid';
-            uses path;
-            description "none";
-        }
         grouping path {
             list telink {
                 key 'local-id';
@@ -50,15 +45,10 @@ module tapi-path-computation {
             uses tapi-common:resource-spec;
             description "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes";
         }
-        list path-comp-service-port {
-            key 'local-id';
-            uses path-comp-service-port;
-            description "none";
-        }
         grouping path-comp-service-port {
             leaf service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -87,14 +77,10 @@ module tapi-path-computation {
                 The EP replaces the Protection Unit of a traditional protection model. 
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
-        container path-computation-service {
-            uses path-computation-service;
-            description "none";
-        }
         grouping path-computation-service {
             leaf-list path {
                 type leafref {
-                    path '/tapi:context/tapi:path/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:path/tapi-common:uuid';
                 }
                 config false;
                 min-elements 1;
@@ -120,10 +106,6 @@ module tapi-path-computation {
                 description "none";
             }
             uses tapi-common:service-spec;
-            description "none";
-        }
-        container path-objective-function {
-            uses path-objective-function;
             description "none";
         }
         grouping path-objective-function {
@@ -155,10 +137,6 @@ module tapi-path-computation {
             uses tapi-common:local-class;
             description "none";
         }
-        container path-optimization-constraint {
-            uses path-optimization-constraint;
-            description "none";
-        }
         grouping path-optimization-constraint {
             leaf traffic-interruption {
                 type tapi-common:directive-value;
@@ -166,10 +144,6 @@ module tapi-path-computation {
                 description "none";
             }
             uses tapi-common:local-class;
-            description "none";
-        }
-        container routing-constraint {
-            uses routing-constraint;
             description "none";
         }
         grouping routing-constraint {
@@ -202,14 +176,14 @@ module tapi-path-computation {
             }
             leaf-list include-topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf-list avoid-topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -15,26 +15,21 @@ module tapi-topology {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_topology" {
+    augment "/tapi-common:context/tapi-common:topology" {
         uses topology;
         description "none";
     }
-    augment "/Tapi:Context/Tapi:_nwTopologyService" {
+    augment "/tapi-common:context/tapi-common:nw-topology-service" {
         uses network-topology-service;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        list link {
-            key 'uuid';
-            uses link;
-            description "none";
-        }
         grouping link {
             leaf-list node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 min-elements 2;
@@ -42,7 +37,7 @@ module tapi-topology {
             }
             leaf-list node {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 min-elements 2;
@@ -104,12 +99,6 @@ module tapi-topology {
             uses tapi-common:resource-spec;
             description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
         }
-        list node {
-            key 'uuid';
-            min-elements 1;
-            uses node;
-            description "none";
-        }
         grouping node {
             list owned-node-edge-point {
                 key 'uuid';
@@ -119,14 +108,14 @@ module tapi-topology {
             }
             leaf-list aggregated-node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf encap-topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -166,11 +155,6 @@ module tapi-topology {
             description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
                 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
         }
-        list topology {
-            key 'uuid';
-            uses topology;
-            description "none";
-        }
         grouping topology {
             list node {
                 key 'uuid';
@@ -194,10 +178,6 @@ module tapi-topology {
             description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
                 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
         }
-        container layer-protocol-transition-pac {
-            uses layer-protocol-transition-pac;
-            description "none";
-        }
         grouping layer-protocol-transition-pac {
             leaf-list transitioned-layer-protocol-name {
                 type string;
@@ -206,7 +186,7 @@ module tapi-topology {
             }
             leaf-list node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 min-elements 1;
                 description "Lists the LTPs that define the layer protocol transition of the transitional link.";
@@ -216,11 +196,6 @@ module tapi-topology {
                 The layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.
                 This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.
                 Links that included details in this Pac are often referred to as Transitional Links.";
-        }
-        list node-edge-point {
-            key 'uuid';
-            uses node-edge-point;
-            description "none";
         }
         grouping node-edge-point {
             list layer-protocol {
@@ -232,14 +207,14 @@ module tapi-topology {
             }
             leaf-list client-node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf-list mapped-service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 description "none";
             }
@@ -267,10 +242,6 @@ module tapi-topology {
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
-        container risk-parameter-pac {
-            uses risk-parameter-pac;
-            description "none";
-        }
         grouping risk-parameter-pac {
             list risk-characteristic {
                 key 'risk-characteristic-name';
@@ -291,10 +262,6 @@ module tapi-topology {
                 A segment has one or more risk characteristic.
                 Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.
                 Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.";
-        }
-        container transfer-capacity-pac {
-            uses transfer-capacity-pac;
-            description "none";
         }
         grouping transfer-capacity-pac {
             container total-potential-capacity {
@@ -325,10 +292,6 @@ module tapi-topology {
                 Represents the capacity available to user (client) along with client interaction and usage. 
                 A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
         }
-        container transfer-cost-pac {
-            uses transfer-cost-pac;
-            description "none";
-        }
         grouping transfer-cost-pac {
             list cost-characteristic {
                 key 'cost-name cost-value cost-algorithm';
@@ -341,10 +304,6 @@ module tapi-topology {
                 They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity
                 There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. 
                 Using an entity will incur a cost. ";
-        }
-        container transfer-integrity-pac {
-            uses transfer-integrity-pac;
-            description "none";
         }
         grouping transfer-integrity-pac {
             leaf error-characteristic {
@@ -385,10 +344,6 @@ module tapi-topology {
                 It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.
                 Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.";
         }
-        container transfer-timing-pac {
-            uses transfer-timing-pac;
-            description "none";
-        }
         grouping transfer-timing-pac {
             list latency-characteristic {
                 key 'traffic-property-name traffic-property-queing-latency';
@@ -398,10 +353,6 @@ module tapi-topology {
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
             description "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.";
-        }
-        container validation-pac {
-            uses validation-pac;
-            description "none";
         }
         grouping validation-pac {
             list validation-mechanism {
@@ -413,15 +364,10 @@ module tapi-topology {
             }
             description "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.";
         }
-        list te-link {
-            key 'local-id';
-            uses te-link;
-            description "none";
-        }
         grouping te-link {
             leaf-list node {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 min-elements 2;
@@ -430,7 +376,7 @@ module tapi-topology {
             }
             leaf-list node-edge-point {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
                 max-elements 2;
@@ -439,14 +385,10 @@ module tapi-topology {
             uses tapi-common:local-class;
             description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
         }
-        container network-topology-service {
-            uses network-topology-service;
-            description "none";
-        }
         grouping network-topology-service {
             leaf-list topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -458,11 +400,6 @@ module tapi-topology {
     /***********************
     * package type-definitions
     **********************/ 
-        list capacity {
-            key 'total-size';
-            uses capacity;
-            description "none";
-        }
         grouping capacity {
             leaf total-size {
                 type fixed-capacity-value;
@@ -497,11 +434,6 @@ module tapi-topology {
                 description "none";
             }
             description "Information on capacity of a particular TopologicalEntity.";
-        }
-        list cost-characteristic {
-            key 'cost-name cost-value cost-algorithm';
-            uses cost-characteristic;
-            description "none";
         }
         grouping cost-characteristic {
             leaf cost-name {
@@ -553,11 +485,6 @@ module tapi-topology {
             }
             description "The Capacity (Bandwidth) values that are applicable for digital layers. ";
         }
-        list latency-characteristic {
-            key 'traffic-property-name traffic-property-queing-latency';
-            uses latency-characteristic;
-            description "none";
-        }
         grouping latency-characteristic {
             leaf fixed-latency-characteristic {
                 type string;
@@ -586,11 +513,6 @@ module tapi-topology {
             }
             description "Provides information on latency characteristic for a particular stated trafficProperty.";
         }
-        list risk-characteristic {
-            key 'risk-characteristic-name';
-            uses risk-characteristic;
-            description "none";
-        }
         grouping risk-characteristic {
             leaf risk-characteristic-name {
                 type string;
@@ -604,11 +526,6 @@ module tapi-topology {
                 description "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.";
             }
             description "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.";
-        }
-        list validation-mechanism {
-            key 'validation-mechanism layer-protocol-adjacency-validated validation-robustness';
-            uses validation-mechanism;
-            description "none";
         }
         grouping validation-mechanism {
             leaf validation-mechanism {

--- a/YANG/tapi-virtual-network.yang
+++ b/YANG/tapi-virtual-network.yang
@@ -18,36 +18,31 @@ module tapi-virtual-network {
         description "TAPI SDK 1.1.alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/Tapi:Context/Tapi:_vnwService" {
+    augment "/tapi-common:context/tapi-common:virtual-nw-service" {
         uses virtual-network-service;
         description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        list virtual-network-constraint {
-            key 'local-id';
-            uses virtual-network-constraint;
-            description "none";
-        }
         grouping virtual-network-constraint {
             leaf src-service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf sink-service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 config false;
                 description "none";
             }
             leaf-list diversity-exclusion {
                 type leafref {
-                    path '/tapi:context/tapi:vnw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id';
+                    path '/tapi-common:context/tapi-common:virtual-nw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id';
                 }
                 description "none";
             }
@@ -76,15 +71,10 @@ module tapi-virtual-network {
             uses tapi-common:local-class;
             description "none";
         }
-        list virtual-network-service {
-            key 'uuid';
-            uses virtual-network-service;
-            description "none";
-        }
         grouping virtual-network-service {
             leaf topology {
                 type leafref {
-                    path '/tapi:context/tapi:topology/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:topology/tapi-common:uuid';
                 }
                 config false;
                 description "none";
@@ -118,15 +108,10 @@ module tapi-virtual-network {
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
-        list virtual-network-service-port {
-            key 'local-id';
-            uses virtual-network-service-port;
-            description "none";
-        }
         grouping virtual-network-service-port {
             leaf service-end-point {
                 type leafref {
-                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                    path '/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid';
                 }
                 config false;
                 description "none";


### PR DESCRIPTION
- Fixed to NOT generate top-level containers/lists for all concrete
classes, but just for TAPI Context
- Removed code that prevented generation of attributes annotated with
"DefinedBySpec" stereotype