### PR TITLE
Fixed read-only property of the Context's resource & service attributes

### DIFF
--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -12,6 +12,25 @@
     ],
     "paths": {
         "/config/context/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_by_id",
+                "summary": "Delete context by ID",
+                "description": "Delete operation of resource: context",
+                "produces": [
+                    "application/json"
+                ]
+            },
             "put": {
                 "responses": {
                     "200": {
@@ -21,26 +40,26 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Update operation of resource: context",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_by_id",
                 "parameters": [
                     {
-                        "required": true,
-                        "description": "contextbody object",
                         "schema": {
                             "$ref": "#/definitions/context"
                         },
                         "name": "context",
+                        "description": "contextbody object",
+                        "required": true,
                         "in": "body"
                     }
                 ],
+                "summary": "Update context by ID",
+                "description": "Update operation of resource: context",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Update context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_by_id"
+                ]
             },
             "post": {
                 "responses": {
@@ -51,865 +70,526 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: context",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_by_id",
                 "parameters": [
                     {
-                        "required": true,
-                        "description": "contextbody object",
                         "schema": {
                             "$ref": "#/definitions/context"
                         },
                         "name": "context",
+                        "description": "contextbody object",
+                        "required": true,
                         "in": "body"
                     }
                 ],
+                "summary": "Create context by ID",
+                "description": "Create operation of resource: context",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_by_id"
+                ]
             },
-            "delete": {
+            "get": {
                 "responses": {
                     "200": {
+                        "schema": {
+                            "$ref": "#/definitions/context"
+                        },
                         "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "produces": [
-                    "application/json"
-                ],
-                "description": "Delete operation of resource: context",
-                "summary": "Delete context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/context"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: context",
+                "operationId": "retrieve_context",
                 "parameters": [],
+                "summary": "Retrieve context",
+                "description": "Retrieve operation of resource: context",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve context",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context"
+                ]
             }
         },
         "/config/context/service-end-point/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/"
+                                "x-path": "/context/service-end-point/{uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-end-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
+                "operationId": "retrieve_context_service-end-point_service-end-point",
+                "parameters": [],
+                "summary": "Retrieve service-end-point",
+                "description": "Retrieve operation of resource: service-end-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/service-end-point"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-end-point by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve service-end-point by ID",
+                "description": "Retrieve operation of resource: service-end-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve layer-protocol",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve layer-protocol by ID",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/lifecycle-state-pac"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                "operationId": "retrieve_context_service-end-point_state_state",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_name_name"
+                "operationId": "retrieve_context_service-end-point_name_name",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_label_label"
+                "operationId": "retrieve_context_service-end-point_label_label",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/name/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/name/{value-name}/"
+                                "x-path": "/context/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name"
+                "operationId": "retrieve_context_name_name",
+                "parameters": [],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/name/{value-name}/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_name_name_by_id",
+                "parameters": [
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
             "put": {
                 "responses": {
                     "200": {
@@ -919,33 +599,33 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Update operation of resource: name",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_name_name_by_id",
                 "parameters": [
                     {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
                         "in": "path"
                     },
                     {
-                        "required": true,
-                        "description": "namebody object",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         },
                         "name": "name",
+                        "description": "namebody object",
+                        "required": true,
                         "in": "body"
                     }
                 ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
+                ]
             },
             "post": {
                 "responses": {
@@ -956,198 +636,96 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: name",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_name_name_by_id",
                 "parameters": [
                     {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
                         "in": "path"
                     },
                     {
-                        "required": true,
-                        "description": "namebody object",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         },
                         "name": "name",
+                        "description": "namebody object",
+                        "required": true,
                         "in": "body"
                     }
                 ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
+                ]
             },
-            "delete": {
+            "get": {
                 "responses": {
                     "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
                         "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_name_name_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_name_name_by_id",
                 "parameters": [
                     {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
                         "in": "path"
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve name by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: name",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_name_name_by_id"
+                ]
             }
         },
         "/config/context/label/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/label/{value-name}/"
+                                "x-path": "/context/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label"
+                "operationId": "retrieve_context_label_label",
+                "parameters": [],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
             "delete": {
                 "responses": {
                     "200": {
@@ -1157,170 +735,193 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_label_label_by_id"
+                "operationId": "delete_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Delete label by ID",
+                "description": "Delete operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             },
-            "get": {
+            "put": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label_by_id"
+                "operationId": "update_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "name": "label",
+                        "description": "labelbody object",
+                        "required": true,
+                        "in": "body"
+                    }
+                ],
+                "summary": "Update label by ID",
+                "description": "Update operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "name": "label",
+                        "description": "labelbody object",
+                        "required": true,
+                        "in": "body"
+                    }
+                ],
+                "summary": "Create label by ID",
+                "description": "Create operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "type": "string",
+                        "required": true,
+                        "in": "path"
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/get-service-end-point-details/": {
             "post": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-service-end-point-detailsRPC_output_schema"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-service-end-point-details",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_get-service-end-point-details_by_id",
                 "parameters": [
                     {
-                        "required": true,
-                        "description": "get-service-end-point-detailsbody object",
                         "schema": {
                             "$ref": "#/definitions/get-service-end-point-detailsRPC_input_schema"
                         },
                         "name": "get-service-end-point-details",
+                        "description": "get-service-end-point-detailsbody object",
+                        "required": true,
                         "in": "body"
                     }
                 ],
+                "summary": "Create get-service-end-point-details by ID",
+                "description": "Create operation of resource: get-service-end-point-details",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-service-end-point-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-service-end-point-details_by_id"
+                ]
             }
         },
         "/operations/get-service-end-point-list/": {
             "post": {
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-service-end-point-listRPC_output_schema"
-                        }
+                        },
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-service-end-point-list",
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-service-end-point-list by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_get-service-end-point-list_by_id"
+                "operationId": "create_get-service-end-point-list_by_id",
+                "summary": "Create get-service-end-point-list by ID",
+                "description": "Create operation of resource: get-service-end-point-list",
+                "produces": [
+                    "application/json"
+                ]
             }
         }
     },
     "definitions": {
-        "context": {
-            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/global-class"
-                },
-                {
-                    "properties": {
-                        "service-end-point": {
-                            "items": {
-                                "$ref": "#/definitions/service-end-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
-        "operational-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
-            "properties": {
-                "lifecycle-state": {
-                    "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
-                    ],
-                    "type": "string"
-                },
-                "operational-state": {
-                    "enum": [
-                        "disabled",
-                        "enabled"
-                    ],
-                    "type": "string"
-                }
-            }
-        },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
-                },
-                "start-time": {
-                    "type": "string"
-                }
-            }
-        },
         "layer-protocol": {
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
@@ -1337,8 +938,8 @@
                                 "lt-permenantly-terminated",
                                 "termination-state-unknown"
                             ],
-                            "type": "string",
-                            "description": "Indicates whether the layer is terminated and if so how."
+                            "description": "Indicates whether the layer is terminated and if so how.",
+                            "type": "string"
                         },
                         "layer-protocol-name": {
                             "enum": [
@@ -1347,8 +948,8 @@
                                 "eth",
                                 "mpls-tp"
                             ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "type": "string"
                         },
                         "termination-direction": {
                             "enum": [
@@ -1357,56 +958,139 @@
                                 "source",
                                 "undefined-or-unknown"
                             ],
-                            "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows",
+                            "type": "string"
                         }
                     }
                 }
-            ]
+            ],
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
+        },
+        "global-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+            "properties": {
+                "uuid": {
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                    "type": "string"
+                },
+                "label": {
+                    "x-key": "value-name",
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "x-key": "value-name",
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "admin-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
+            "properties": {
+                "administrative-state": {
+                    "enum": [
+                        "locked",
+                        "unlocked"
+                    ],
+                    "type": "string"
+                },
+                "operational-state": {
+                    "enum": [
+                        "disabled",
+                        "enabled"
+                    ],
+                    "type": "string"
+                },
+                "lifecycle-state": {
+                    "enum": [
+                        "planned",
+                        "potential",
+                        "installed",
+                        "pending-removal"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "operational-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
+            "properties": {
+                "operational-state": {
+                    "enum": [
+                        "disabled",
+                        "enabled"
+                    ],
+                    "type": "string"
+                },
+                "lifecycle-state": {
+                    "enum": [
+                        "planned",
+                        "potential",
+                        "installed",
+                        "pending-removal"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "service-spec": {
+            "$ref": "#/definitions/global-class"
         },
         "name-and-value": {
             "description": "A scoped name-value pair",
             "properties": {
                 "value": {
-                    "type": "string",
-                    "description": "The value"
+                    "description": "The value",
+                    "type": "string"
                 },
                 "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
+                    "description": "The name of the value. The value need not have a name.",
+                    "type": "string"
                 }
             }
         },
         "local-class": {
             "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
-                "local-id": {
-                    "type": "string"
-                },
                 "name": {
+                    "x-key": "value-name",
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
                     "items": {
                         "$ref": "#/definitions/name-and-value"
                     },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                    "type": "array"
+                },
+                "local-id": {
+                    "type": "string"
                 }
             }
         },
+        "resource-spec": {
+            "$ref": "#/definitions/global-class"
+        },
         "service-end-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
+                        "state": {
+                            "$ref": "#/definitions/lifecycle-state-pac"
+                        },
                         "layer-protocol": {
+                            "x-key": "local-id",
                             "items": {
                                 "$ref": "#/definitions/layer-protocol"
                             },
-                            "type": "array",
-                            "x-key": "local-id"
+                            "type": "array"
                         },
                         "direction": {
                             "enum": [
@@ -1416,13 +1100,40 @@
                                 "undefined-or-unknown"
                             ],
                             "type": "string"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/lifecycle-state-pac"
                         }
                     }
                 }
-            ]
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "context": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/global-class"
+                },
+                {
+                    "properties": {
+                        "service-end-point": {
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/service-end-point"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ],
+            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements)."
+        },
+        "time-range": {
+            "properties": {
+                "start-time": {
+                    "type": "string"
+                },
+                "end-time": {
+                    "type": "string"
+                }
+            }
         },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
@@ -1437,65 +1148,6 @@
                     "type": "string"
                 }
             }
-        },
-        "admin-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
-            "properties": {
-                "administrative-state": {
-                    "enum": [
-                        "locked",
-                        "unlocked"
-                    ],
-                    "type": "string"
-                },
-                "lifecycle-state": {
-                    "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
-                    ],
-                    "type": "string"
-                },
-                "operational-state": {
-                    "enum": [
-                        "disabled",
-                        "enabled"
-                    ],
-                    "type": "string"
-                }
-            }
-        },
-        "service-spec": {
-            "$ref": "#/definitions/global-class"
-        },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
-            "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
-                },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
-                }
-            }
-        },
-        "resource-spec": {
-            "$ref": "#/definitions/global-class"
         },
         "get-service-end-point-detailsRPC_input_schema": {
             "properties": {

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -12,8922 +12,10541 @@
     ],
     "paths": {
         "/config/context/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update context by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_by_id"
+                "operationId": "delete_context_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete context by ID",
+                "description": "Delete operation of resource: context",
+                "produces": [
+                    "application/json"
+                ]
             },
             "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Create operation of resource: context",
                 "parameters": [
                     {
-                        "required": true,
-                        "description": "contextbody object",
                         "schema": {
                             "$ref": "#/definitions/context_schema"
                         },
+                        "in": "body",
+                        "description": "contextbody object",
                         "name": "context",
-                        "in": "body"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Create context by ID",
+                "description": "Create operation of resource: context",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_context_by_id"
-            },
-            "delete": {
+                "operationId": "update_context_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "produces": [
-                    "application/json"
-                ],
-                "description": "Delete operation of resource: context",
-                "summary": "Delete context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
+                "parameters": [
+                    {
                         "schema": {
                             "$ref": "#/definitions/context_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
+                        },
+                        "in": "body",
+                        "description": "contextbody object",
+                        "name": "context",
+                        "required": true
                     }
-                },
-                "description": "Retrieve operation of resource: context",
-                "parameters": [],
+                ],
+                "summary": "Update context by ID",
+                "description": "Update operation of resource: context",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve context",
+                ]
+            },
+            "get": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context"
+                "operationId": "retrieve_context",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve context",
+                "description": "Retrieve operation of resource: context",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-end-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
+                "operationId": "retrieve_context_service-end-point_service-end-point",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve service-end-point",
+                "description": "Retrieve operation of resource: service-end-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/service-end-point"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve service-end-point by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: service-end-point",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/layer-protocol"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol by ID",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/lifecycle-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                "operationId": "retrieve_context_service-end-point_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/lifecycle-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_name_name"
+                "operationId": "retrieve_context_service-end-point_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     },
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve name by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: name",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_label_label"
+                "operationId": "retrieve_context_service-end-point_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     },
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve label by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: label",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                ]
             }
         },
         "/config/context/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name"
+                "operationId": "retrieve_context_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
-            },
             "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Delete operation of resource: name",
                 "parameters": [
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_name_name_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "description": "Delete operation of resource: name",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                ]
+            },
+            "post": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name_by_id"
+                "operationId": "create_context_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label"
+                "operationId": "retrieve_context_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
             "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_label_label_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Delete operation of resource: label",
                 "parameters": [
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_label_label_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "description": "Delete operation of resource: label",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+                ]
+            },
+            "post": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label_by_id"
+                "operationId": "create_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Create label by ID",
+                "description": "Create operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Update label by ID",
+                "description": "Update operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/network-topology-service"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: nw-topology-service",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve nw-topology-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_nw-topology-service"
+                "operationId": "retrieve_context_nw-topology-service_nw-topology-service",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/network-topology-service"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve nw-topology-service",
+                "description": "Retrieve operation of resource: nw-topology-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name"
+                "operationId": "retrieve_context_nw-topology-service_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/nw-topology-service/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name_by_id"
+                "operationId": "retrieve_context_nw-topology-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_label_label"
+                "operationId": "retrieve_context_nw-topology-service_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/nw-topology-service/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_label_label_by_id"
+                "operationId": "retrieve_context_nw-topology-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: topology",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve topology",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_topology"
+                "operationId": "retrieve_context_topology_topology",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve topology",
+                "description": "Retrieve operation of resource: topology",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_topology_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_topology_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_topology_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_topology_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/topology"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: topology",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve topology by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: topology",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: node",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_node"
+                "operationId": "retrieve_context_topology_node_node",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve node",
+                "description": "Retrieve operation of resource: node",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/node"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: node",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_node_by_id"
+                "operationId": "retrieve_context_topology_node_node_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/node"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve node by ID",
+                "description": "Retrieve operation of resource: node",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: owned-node-edge-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve owned-node-edge-point",
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/node-edge-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: owned-node-edge-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/node-edge-point"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve owned-node-edge-point by ID",
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/layer-protocol"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol by ID",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_state_state"
+                "operationId": "retrieve_context_topology_node_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-capacity",
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity",
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken."
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity",
+                            "description": "Capacity available to be assigned."
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view",
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of total-size",
+                        "name": "total-size",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost"
+                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-cost",
+                "description": "Retrieve operation of resource: transfer-cost",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity"
+                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-integrity",
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing"
+                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-timing",
+                "description": "Retrieve operation of resource: transfer-timing",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name"
+                "operationId": "retrieve_context_topology_node_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name_by_id"
+                "operationId": "retrieve_context_topology_node_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_label_label"
+                "operationId": "retrieve_context_topology_node_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_label_label_by_id"
+                "operationId": "retrieve_context_topology_node_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: link",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_link"
+                "operationId": "retrieve_context_topology_link_link",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve link",
+                "description": "Retrieve operation of resource: link",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: link",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_link_by_id"
+                "operationId": "retrieve_context_topology_link_link_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve link by ID",
+                "description": "Retrieve operation of resource: link",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_state_state"
+                "operationId": "retrieve_context_topology_link_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-capacity",
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity",
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken."
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity",
+                            "description": "Capacity available to be assigned."
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view",
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of total-size",
+                        "name": "total-size",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost"
+                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-cost",
+                "description": "Retrieve operation of resource: transfer-cost",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity"
+                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-integrity",
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing"
+                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve transfer-timing",
+                "description": "Retrieve operation of resource: transfer-timing",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: risk-parameter",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-parameter",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter"
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/risk-parameter-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve risk-parameter",
+                "description": "Retrieve operation of resource: risk-parameter",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic"
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "risk-characteristic-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id"
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of risk-characteristic-name",
+                        "name": "risk-characteristic-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: validation",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_validation_validation"
+                "operationId": "retrieve_context_topology_link_validation_validation",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/validation-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve validation",
+                "description": "Retrieve operation of resource: validation",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism"
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "required": true,
-                        "type": "string",
-                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id"
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: lp-transition",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve lp-transition",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition"
+                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/layer-protocol-transition-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve lp-transition",
+                "description": "Retrieve operation of resource: lp-transition",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_name_name"
+                "operationId": "retrieve_context_topology_link_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_name_name_by_id"
+                "operationId": "retrieve_context_topology_link_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_label_label"
+                "operationId": "retrieve_context_topology_link_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_label_label_by_id"
+                "operationId": "retrieve_context_topology_link_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_name_name"
+                "operationId": "retrieve_context_topology_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_name_name_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     },
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve name by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: name",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_topology_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_label_label"
+                "operationId": "retrieve_context_topology_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_label_label_by_id"
-            },
             "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_label_label_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
-                        "description": "ID of uuid",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true
                     },
                     {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
-                ],
-                "produces": [
-                    "application/json"
                 ],
                 "summary": "Retrieve label by ID",
-                "consumes": [
+                "description": "Retrieve operation of resource: label",
+                "produces": [
                     "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label_by_id"
+                ]
             }
         },
         "/config/context/path-comp-service/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: path-comp-service",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path-comp-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_path-comp-service"
+                "operationId": "retrieve_context_path-comp-service_path-comp-service",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve path-comp-service",
+                "description": "Retrieve operation of resource: path-comp-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/path-computation-service"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: path-comp-service",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path-comp-service by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_path-comp-service_by_id"
+                "operationId": "delete_context_path-comp-service_path-comp-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete path-comp-service by ID",
+                "description": "Delete operation of resource: path-comp-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_path-comp-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-computation-service"
+                        },
+                        "in": "body",
+                        "description": "path-comp-servicebody object",
+                        "name": "path-comp-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Create path-comp-service by ID",
+                "description": "Create operation of resource: path-comp-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_path-comp-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-computation-service"
+                        },
+                        "in": "body",
+                        "description": "path-comp-servicebody object",
+                        "name": "path-comp-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Update path-comp-service by ID",
+                "description": "Update operation of resource: path-comp-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_path-comp-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/path-computation-service"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve path-comp-service by ID",
+                "description": "Retrieve operation of resource: path-comp-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_service-port"
+                "operationId": "retrieve_context_path-comp-service_service-port_service-port",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve service-port",
+                "description": "Retrieve operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/path-comp-service-port"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_service-port_by_id"
+                "operationId": "delete_context_path-comp-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete service-port by ID",
+                "description": "Delete operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-comp-service-port"
+                        },
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "required": true
+                    }
+                ],
+                "summary": "Create service-port by ID",
+                "description": "Create operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-comp-service-port"
+                        },
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "required": true
+                    }
+                ],
+                "summary": "Update service-port by ID",
+                "description": "Update operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/path-comp-service-port"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve service-port by ID",
+                "description": "Retrieve operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_name_name"
+                "operationId": "retrieve_context_path-comp-service_service-port_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_name_name_by_id"
+                "operationId": "delete_context_path-comp-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/routing-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: routing-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve routing-constraint",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_routing-constraint"
+                "operationId": "delete_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete routing-constraint by ID",
+                "description": "Delete operation of resource: routing-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "in": "body",
+                        "description": "routing-constraintbody object",
+                        "name": "routing-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Create routing-constraint by ID",
+                "description": "Create operation of resource: routing-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "in": "body",
+                        "description": "routing-constraintbody object",
+                        "name": "routing-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Update routing-constraint by ID",
+                "description": "Update operation of resource: routing-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_routing-constraint",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve routing-constraint",
+                "description": "Retrieve operation of resource: routing-constraint",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/requested-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_requested-capacity_requested-capacity"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_requested-capacity_requested-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve requested-capacity",
+                "description": "Retrieve operation of resource: requested-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-path",
+                "description": "Retrieve operation of resource: include-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-path by ID",
+                "description": "Retrieve operation of resource: include-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-path",
+                "description": "Retrieve operation of resource: exclude-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-path by ID",
+                "description": "Retrieve operation of resource: exclude-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name_by_id"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name"
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name_by_id"
+                "operationId": "delete_context_path-comp-service_routing-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_routing-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_routing-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/path-objective-function"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: objective-function",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve objective-function",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_objective-function"
+                "operationId": "delete_context_path-comp-service_objective-function_objective-function_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete objective-function by ID",
+                "description": "Delete operation of resource: objective-function",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_objective-function_objective-function_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "in": "body",
+                        "description": "objective-functionbody object",
+                        "name": "objective-function",
+                        "required": true
+                    }
+                ],
+                "summary": "Create objective-function by ID",
+                "description": "Create operation of resource: objective-function",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_objective-function_objective-function_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "in": "body",
+                        "description": "objective-functionbody object",
+                        "name": "objective-function",
+                        "required": true
+                    }
+                ],
+                "summary": "Update objective-function by ID",
+                "description": "Update operation of resource: objective-function",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_objective-function_objective-function",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve objective-function",
+                "description": "Retrieve operation of resource: objective-function",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/objective-function/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_name_name"
+                "operationId": "retrieve_context_path-comp-service_objective-function_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/objective-function/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_name_name_by_id"
+                "operationId": "delete_context_path-comp-service_objective-function_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_objective-function_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_objective-function_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_objective-function_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/path-optimization-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: optimization-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve optimization-constraint",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_optimization-constraint"
+                "operationId": "delete_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete optimization-constraint by ID",
+                "description": "Delete operation of resource: optimization-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "in": "body",
+                        "description": "optimization-constraintbody object",
+                        "name": "optimization-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Create optimization-constraint by ID",
+                "description": "Create operation of resource: optimization-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "in": "body",
+                        "description": "optimization-constraintbody object",
+                        "name": "optimization-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Update optimization-constraint by ID",
+                "description": "Update operation of resource: optimization-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_optimization-constraint",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve optimization-constraint",
+                "description": "Retrieve operation of resource: optimization-constraint",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name"
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name_by_id"
+                "operationId": "delete_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_name_name"
+                "operationId": "retrieve_context_path-comp-service_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_name_name_by_id"
+                "operationId": "delete_context_path-comp-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_label_label"
+                "operationId": "retrieve_context_path-comp-service_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path-comp-service/{uuid}/label/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_label_label_by_id"
+                "operationId": "delete_context_path-comp-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete label by ID",
+                "description": "Delete operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_path-comp-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Create label by ID",
+                "description": "Create operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_path-comp-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Update label by ID",
+                "description": "Update operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_path-comp-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: path",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_path"
+                "operationId": "retrieve_context_path_path",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve path",
+                "description": "Retrieve operation of resource: path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/path"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_path_by_id"
+                "operationId": "retrieve_context_path_path_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/path"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve path by ID",
+                "description": "Retrieve operation of resource: path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/telink/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/telink/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: telink",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve telink",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_telink"
+                "operationId": "retrieve_context_path_telink_telink",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/telink/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve telink",
+                "description": "Retrieve operation of resource: telink",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: telink",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve telink by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_telink_by_id"
+                "operationId": "retrieve_context_path_telink_telink_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve telink by ID",
+                "description": "Retrieve operation of resource: telink",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/telink/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_name_name"
+                "operationId": "retrieve_context_path_telink_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/telink/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_name_name_by_id"
+                "operationId": "retrieve_context_path_telink_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/routing-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: routing-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve routing-constraint",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_routing-constraint"
+                "operationId": "retrieve_context_path_routing-constraint_routing-constraint",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve routing-constraint",
+                "description": "Retrieve operation of resource: routing-constraint",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/requested-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_requested-capacity_requested-capacity"
+                "operationId": "retrieve_context_path_routing-constraint_requested-capacity_requested-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve requested-capacity",
+                "description": "Retrieve operation of resource: requested-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path"
+                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-path",
+                "description": "Retrieve operation of resource: include-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-path by ID",
+                "description": "Retrieve operation of resource: include-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name"
+                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path"
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-path",
+                "description": "Retrieve operation of resource: exclude-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-path by ID",
+                "description": "Retrieve operation of resource: exclude-path",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name"
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_name_name"
+                "operationId": "retrieve_context_path_routing-constraint_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/routing-constraint/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_name_name_by_id"
+                "operationId": "retrieve_context_path_routing-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_name_name"
+                "operationId": "retrieve_context_path_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_name_name_by_id"
+                "operationId": "retrieve_context_path_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_label_label"
+                "operationId": "retrieve_context_path_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/path/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/path/{uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_label_label_by_id"
+                "operationId": "retrieve_context_path_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connectivity-service",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connectivity-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_connectivity-service"
+                "operationId": "retrieve_context_connectivity-service_connectivity-service",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve connectivity-service",
+                "description": "Retrieve operation of resource: connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-service"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connectivity-service",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connectivity-service by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_connectivity-service_by_id"
+                "operationId": "delete_context_connectivity-service_connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete connectivity-service by ID",
+                "description": "Delete operation of resource: connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service"
+                        },
+                        "in": "body",
+                        "description": "connectivity-servicebody object",
+                        "name": "connectivity-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Create connectivity-service by ID",
+                "description": "Create operation of resource: connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service"
+                        },
+                        "in": "body",
+                        "description": "connectivity-servicebody object",
+                        "name": "connectivity-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Update connectivity-service by ID",
+                "description": "Update operation of resource: connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve connectivity-service by ID",
+                "description": "Retrieve operation of resource: connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/service-port/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/service-port/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_service-port_service-port"
+                "operationId": "retrieve_context_connectivity-service_service-port_service-port",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/service-port/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve service-port",
+                "description": "Retrieve operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/service-port/{local-id}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-service-port"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_service-port_service-port_by_id"
+                "operationId": "delete_context_connectivity-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete service-port by ID",
+                "description": "Delete operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service-port"
+                        },
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "required": true
+                    }
+                ],
+                "summary": "Create service-port by ID",
+                "description": "Create operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service-port"
+                        },
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "required": true
+                    }
+                ],
+                "summary": "Update service-port by ID",
+                "description": "Update operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-service-port"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve service-port by ID",
+                "description": "Retrieve operation of resource: service-port",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/service-port/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/service-port/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_service-port_name_name"
+                "operationId": "retrieve_context_connectivity-service_service-port_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/service-port/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/service-port/{local-id}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_service-port_name_name_by_id"
+                "operationId": "delete_context_connectivity-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: conn-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve conn-constraint",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_conn-constraint"
+                "operationId": "delete_context_connectivity-service_conn-constraint_conn-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete conn-constraint by ID",
+                "description": "Delete operation of resource: conn-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_conn-constraint_conn-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-constraint"
+                        },
+                        "in": "body",
+                        "description": "conn-constraintbody object",
+                        "name": "conn-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Create conn-constraint by ID",
+                "description": "Create operation of resource: conn-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_conn-constraint_conn-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-constraint"
+                        },
+                        "in": "body",
+                        "description": "conn-constraintbody object",
+                        "name": "conn-constraint",
+                        "required": true
+                    }
+                ],
+                "summary": "Update conn-constraint by ID",
+                "description": "Update operation of resource: conn-constraint",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_conn-constraint",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/connectivity-constraint"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve conn-constraint",
+                "description": "Retrieve operation of resource: conn-constraint",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_requested-capacity"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_requested-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve requested-capacity",
+                "description": "Retrieve operation of resource: requested-capacity",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/include-route/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-route",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_include-route"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_include-route",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-route",
+                "description": "Retrieve operation of resource: include-route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: include-route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve include-route by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_include-route_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_include-route_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve include-route by ID",
+                "description": "Retrieve operation of resource: include-route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_name_name"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/include-route/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_name_name_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_include-route_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/exclude-route/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-route",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_exclude-route"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_exclude-route",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-route",
+                "description": "Retrieve operation of resource: exclude-route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-route by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_exclude-route_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_exclude-route_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve exclude-route by ID",
+                "description": "Retrieve operation of resource: exclude-route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_name_name"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/exclude-route/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_name_name_by_id"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_exclude-route_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name"
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name_by_id"
+                "operationId": "delete_context_connectivity-service_conn-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_conn-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_conn-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/schedule/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: schedule",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve schedule",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_schedule_schedule"
+                "operationId": "delete_context_connectivity-service_schedule_schedule_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete schedule by ID",
+                "description": "Delete operation of resource: schedule",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_schedule_schedule_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "in": "body",
+                        "description": "schedulebody object",
+                        "name": "schedule",
+                        "required": true
+                    }
+                ],
+                "summary": "Create schedule by ID",
+                "description": "Create operation of resource: schedule",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_schedule_schedule_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "in": "body",
+                        "description": "schedulebody object",
+                        "name": "schedule",
+                        "required": true
+                    }
+                ],
+                "summary": "Update schedule by ID",
+                "description": "Update operation of resource: schedule",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_schedule_schedule",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve schedule",
+                "description": "Retrieve operation of resource: schedule",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/state/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_state_state"
+                "operationId": "delete_context_connectivity-service_state_state_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete state by ID",
+                "description": "Delete operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_state_state_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "in": "body",
+                        "description": "statebody object",
+                        "name": "state",
+                        "required": true
+                    }
+                ],
+                "summary": "Create state by ID",
+                "description": "Create operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_state_state_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "in": "body",
+                        "description": "statebody object",
+                        "name": "state",
+                        "required": true
+                    }
+                ],
+                "summary": "Update state by ID",
+                "description": "Update operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_name_name"
+                "operationId": "retrieve_context_connectivity-service_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_name_name_by_id"
+                "operationId": "delete_context_connectivity-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "required": true
+                    }
+                ],
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_label_label"
+                "operationId": "retrieve_context_connectivity-service_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connectivity-service/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connectivity-service/{uuid}/label/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+            "delete": {
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connectivity-service_label_label_by_id"
+                "operationId": "delete_context_connectivity-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Delete label by ID",
+                "description": "Delete operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_connectivity-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Create label by ID",
+                "description": "Create operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_connectivity-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "required": true
+                    }
+                ],
+                "summary": "Update label by ID",
+                "description": "Update operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_connectivity-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connection",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connection",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection"
+                "operationId": "retrieve_context_connection_connection",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [],
+                "summary": "Retrieve connection",
+                "description": "Retrieve operation of resource: connection",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connection"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connection",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connection by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection_by_id"
+                "operationId": "retrieve_context_connection_connection_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/connection"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve connection by ID",
+                "description": "Retrieve operation of resource: connection",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connection-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connection-end-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_connection-end-point"
+                "operationId": "retrieve_context_connection_connection-end-point_connection-end-point",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve connection-end-point",
+                "description": "Retrieve operation of resource: connection-end-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connection-end-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: connection-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve connection-end-point by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_connection-end-point_by_id"
+                "operationId": "retrieve_context_connection_connection-end-point_connection-end-point_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/connection-end-point"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve connection-end-point by ID",
+                "description": "Retrieve operation of resource: connection-end-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_layer-protocol",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_layer-protocol_by_id"
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_layer-protocol_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/layer-protocol"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve layer-protocol by ID",
+                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_name_name_by_id"
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_state_state"
+                "operationId": "retrieve_context_connection_connection-end-point_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_name_name"
+                "operationId": "retrieve_context_connection_connection-end-point_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_name_name_by_id"
+                "operationId": "retrieve_context_connection_connection-end-point_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_label_label"
+                "operationId": "retrieve_context_connection_connection-end-point_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "connection-end-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_connection-end-point_label_label_by_id"
+                "operationId": "retrieve_context_connection_connection-end-point_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of connection-end-point_uuid",
+                        "name": "connection-end-point_uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/route/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/route/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve route",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_route_route"
+                "operationId": "retrieve_context_connection_route_route",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/route/{local-id}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve route",
+                "description": "Retrieve operation of resource: route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/route/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/route"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: route",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve route by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_route_route_by_id"
+                "operationId": "retrieve_context_connection_route_route_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/route"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve route by ID",
+                "description": "Retrieve operation of resource: route",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/route/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/route/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_route_name_name"
+                "operationId": "retrieve_context_connection_route_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/route/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/route/{local-id}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_route_name_name_by_id"
+                "operationId": "retrieve_context_connection_route_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/state/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_state_state"
+                "operationId": "retrieve_context_connection_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_name_name"
+                "operationId": "retrieve_context_connection_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_name_name_by_id"
+                "operationId": "retrieve_context_connection_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_label_label"
+                "operationId": "retrieve_context_connection_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/context/connection/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            }
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/connection/{uuid}/label/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_connection_label_label_by_id"
+                "operationId": "retrieve_context_connection_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "required": true
+                    }
+                ],
+                "summary": "Retrieve label by ID",
+                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/get-connection-details/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/get-connection-detailsRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: get-connection-details",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-connection-detailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-connection-detailsRPC_input_schema"
-                        },
-                        "name": "get-connection-details",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-connection-details by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_get-connection-details_by_id"
+                "operationId": "create_get-connection-details_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/get-connection-detailsRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/get-connection-detailsRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "get-connection-detailsbody object",
+                        "name": "get-connection-details",
+                        "required": true
+                    }
+                ],
+                "summary": "Create get-connection-details by ID",
+                "description": "Create operation of resource: get-connection-details",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/get-connectivity-service-list/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/get-connectivity-service-listRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: get-connectivity-service-list",
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-connectivity-service-list by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_get-connectivity-service-list_by_id"
+                "operationId": "create_get-connectivity-service-list_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/get-connectivity-service-listRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create get-connectivity-service-list by ID",
+                "description": "Create operation of resource: get-connectivity-service-list",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/get-connection-end-point-details/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/get-connection-end-point-detailsRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: get-connection-end-point-details",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-connection-end-point-detailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-connection-end-point-detailsRPC_input_schema"
-                        },
-                        "name": "get-connection-end-point-details",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-connection-end-point-details by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_get-connection-end-point-details_by_id"
+                "operationId": "create_get-connection-end-point-details_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/get-connection-end-point-detailsRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/get-connection-end-point-detailsRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "get-connection-end-point-detailsbody object",
+                        "name": "get-connection-end-point-details",
+                        "required": true
+                    }
+                ],
+                "summary": "Create get-connection-end-point-details by ID",
+                "description": "Create operation of resource: get-connection-end-point-details",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/get-connectivity-service-details/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/get-connectivity-service-detailsRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: get-connectivity-service-details",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-connectivity-service-detailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-connectivity-service-detailsRPC_input_schema"
-                        },
-                        "name": "get-connectivity-service-details",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-connectivity-service-details by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_get-connectivity-service-details_by_id"
+                "operationId": "create_get-connectivity-service-details_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/get-connectivity-service-detailsRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/get-connectivity-service-detailsRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "get-connectivity-service-detailsbody object",
+                        "name": "get-connectivity-service-details",
+                        "required": true
+                    }
+                ],
+                "summary": "Create get-connectivity-service-details by ID",
+                "description": "Create operation of resource: get-connectivity-service-details",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/create-connectivity-service/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/create-connectivity-serviceRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: create-connectivity-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "create-connectivity-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/create-connectivity-serviceRPC_input_schema"
-                        },
-                        "name": "create-connectivity-service",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create create-connectivity-service by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_create-connectivity-service_by_id"
+                "operationId": "create_create-connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/create-connectivity-serviceRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/create-connectivity-serviceRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "create-connectivity-servicebody object",
+                        "name": "create-connectivity-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Create create-connectivity-service by ID",
+                "description": "Create operation of resource: create-connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/update-connectivity-service/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/update-connectivity-serviceRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: update-connectivity-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "update-connectivity-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/update-connectivity-serviceRPC_input_schema"
-                        },
-                        "name": "update-connectivity-service",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create update-connectivity-service by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_update-connectivity-service_by_id"
+                "operationId": "create_update-connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/update-connectivity-serviceRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/update-connectivity-serviceRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "update-connectivity-servicebody object",
+                        "name": "update-connectivity-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Create update-connectivity-service by ID",
+                "description": "Create operation of resource: update-connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/operations/delete-connectivity-service/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/delete-connectivity-serviceRPC_output_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: delete-connectivity-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "delete-connectivity-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/delete-connectivity-serviceRPC_input_schema"
-                        },
-                        "name": "delete-connectivity-service",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create delete-connectivity-service by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_delete-connectivity-service_by_id"
+                "operationId": "create_delete-connectivity-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/delete-connectivity-serviceRPC_output_schema"
+                        },
+                        "description": "Successful operation"
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/delete-connectivity-serviceRPC_input_schema"
+                        },
+                        "in": "body",
+                        "description": "delete-connectivity-servicebody object",
+                        "name": "delete-connectivity-service",
+                        "required": true
+                    }
+                ],
+                "summary": "Create delete-connectivity-service by ID",
+                "description": "Create operation of resource: delete-connectivity-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         }
     },
     "definitions": {
-        "connectivity-context": {
-            "properties": {
-                "connection": {
-                    "items": {
-                        "$ref": "#/definitions/connection"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                },
-                "connectivity-service": {
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                }
-            }
-        },
         "route": {
-            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes.",
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
@@ -8935,15 +10554,247 @@
                 {
                     "properties": {
                         "lower-connection": {
+                            "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
-                            },
-                            "type": "array"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
+                                "type": "string"
+                            }
                         }
                     }
                 }
-            ]
+            ],
+            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
+        },
+        "connection": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "state": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "route": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/route"
+                            }
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "connection-end-point": {
+                            "x-key": "uuid",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection-end-point"
+                            }
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "node": {
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connectivity-service-port": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint.",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ]
+                        },
+                        "service-end-point": {
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "connection-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "state": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "connection-port-role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ]
+                        },
+                        "client-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "server-node-edge-point": {
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                            "type": "string"
+                        },
+                        "layer-protocol": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            }
+                        },
+                        "peer-connection-end-point": {
+                            "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid",
+                            "type": "string"
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "sink",
+                                "source",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "connection-port-direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint.",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "connectivity-context": {
+            "properties": {
+                "connection": {
+                    "x-key": "uuid",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection"
+                    }
+                },
+                "connectivity-service": {
+                    "x-key": "uuid",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connectivity-service"
+                    }
+                }
+            }
+        },
+        "connectivity-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "schedule": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "conn-constraint": {
+                            "$ref": "#/definitions/connectivity-constraint"
+                        },
+                        "service-port": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service-port"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
         },
         "connectivity-constraint": {
             "allOf": [
@@ -8952,362 +10803,122 @@
                 },
                 {
                     "properties": {
-                        "service-type": {
-                            "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivty",
-                                "multipoint-connectivity"
-                            ],
+                        "coroute-inclusion": {
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid",
                             "type": "string"
                         },
-                        "exclude-route": {
+                        "diversity-exclusion": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "include-route": {
+                            "x-key": "local-id",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "include-path": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "cost-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "x-key": "cost-name cost-value cost-algorithm"
-                        },
-                        "preferred-transport-layer": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string",
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            },
-                            "type": "array"
-                        },
-                        "exclude-path": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            },
-                            "type": "array"
+                            }
                         },
                         "service-level": {
                             "type": "string",
                             "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
                         },
-                        "avoid-topology": {
+                        "exclude-route": {
+                            "x-key": "local-id",
+                            "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                                "$ref": "#/definitions/te-link"
+                            }
                         },
-                        "diversity-exclusion": {
+                        "preferred-transport-layer": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                            },
-                            "type": "array"
+                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers",
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
+                        },
+                        "service-type": {
+                            "type": "string",
+                            "enum": [
+                                "point-to-point-connectivity",
+                                "point-to-multipoint-connectivty",
+                                "multipoint-connectivity"
+                            ]
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
                         },
                         "latency-characteristic": {
+                            "x-key": "traffic-property-name traffic-property-queing-latency",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/latency-characteristic"
                             },
-                            "type": "array",
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "x-key": "traffic-property-name traffic-property-queing-latency"
-                        },
-                        "coroute-inclusion": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic."
                         },
                         "include-topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "include-route": {
-                            "items": {
-                                "$ref": "#/definitions/te-link"
-                            },
                             "type": "array",
-                            "x-key": "local-id"
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "exclude-path": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "cost-characteristic": {
+                            "x-key": "cost-name cost-value cost-algorithm",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity."
+                        },
+                        "include-path": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid",
+                                "type": "string"
+                            }
                         }
                     }
                 }
             ]
         },
-        "connection": {
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string"
-                        },
-                        "route": {
-                            "items": {
-                                "$ref": "#/definitions/route"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "connection-end-point": {
-                            "items": {
-                                "$ref": "#/definitions/connection-end-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
-        "connectivity-service": {
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string"
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string"
-                        },
-                        "schedule": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "service-port": {
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service-port"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "connection": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        }
-                    }
-                }
-            ]
-        },
-        "connectivity-service-port": {
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                        },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string"
-                        },
-                        "role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "connection-end-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "termination-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string"
-                        },
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "client-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "connection-port-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "connection-port-role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "context": {
-            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/global-class"
-                },
-                {
-                    "properties": {
-                        "service-end-point": {
-                            "items": {
-                                "$ref": "#/definitions/service-end-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
-        "operational-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
+        "admin-state-pac": {
             "properties": {
                 "lifecycle-state": {
+                    "type": "string"
+                },
+                "administrative-state": {
                     "type": "string"
                 },
                 "operational-state": {
                     "type": "string"
                 }
-            }
-        },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
-                },
-                "start-time": {
-                    "type": "string"
-                }
-            }
+            },
+            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects."
         },
         "layer-protocol": {
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
@@ -9318,420 +10929,175 @@
                             "type": "string",
                             "description": "Indicates whether the layer is terminated and if so how."
                         },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
                         "termination-direction": {
+                            "type": "string",
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows",
                             "enum": [
                                 "bidirectional",
                                 "sink",
                                 "source",
                                 "undefined-or-unknown"
-                            ],
+                            ]
+                        },
+                        "layer-protocol-name": {
                             "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
                         }
                     }
                 }
-            ]
+            ],
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
         },
-        "name-and-value": {
-            "description": "A scoped name-value pair",
+        "global-class": {
             "properties": {
-                "value": {
+                "uuid": {
                     "type": "string",
-                    "description": "The value"
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
                 },
-                "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
+                "label": {
+                    "x-key": "value-name",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state."
+                },
+                "name": {
+                    "x-key": "value-name",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity."
                 }
-            }
+            },
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. "
         },
         "local-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
                 "local-id": {
                     "type": "string"
                 },
                 "name": {
+                    "x-key": "value-name",
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/name-and-value"
                     },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity."
                 }
-            }
+            },
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. "
         },
         "service-end-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
+                        "state": {
+                            "$ref": "#/definitions/lifecycle-state-pac"
+                        },
                         "layer-protocol": {
+                            "x-key": "local-id",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
+                            }
                         },
                         "direction": {
+                            "type": "string",
                             "enum": [
                                 "bidirectional",
                                 "sink",
                                 "source",
                                 "undefined-or-unknown"
-                            ],
-                            "type": "string"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/lifecycle-state-pac"
+                            ]
                         }
                     }
                 }
-            ]
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
         },
-        "lifecycle-state-pac": {
-            "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
+        "name-and-value": {
             "properties": {
-                "lifecycle-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "admin-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
-            "properties": {
-                "administrative-state": {
-                    "type": "string"
+                "value-name": {
+                    "type": "string",
+                    "description": "The name of the value. The value need not have a name."
                 },
+                "value": {
+                    "type": "string",
+                    "description": "The value"
+                }
+            },
+            "description": "A scoped name-value pair"
+        },
+        "operational-state-pac": {
+            "properties": {
                 "lifecycle-state": {
                     "type": "string"
                 },
                 "operational-state": {
                     "type": "string"
                 }
-            }
+            },
+            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects."
         },
         "service-spec": {
             "$ref": "#/definitions/global-class"
         },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
-            "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
+        "context": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/global-class"
                 },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                {
+                    "properties": {
+                        "service-end-point": {
+                            "x-key": "uuid",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service-end-point"
+                            }
+                        }
+                    }
                 }
-            }
+            ],
+            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements)."
+        },
+        "lifecycle-state-pac": {
+            "properties": {
+                "lifecycle-state": {
+                    "type": "string"
+                }
+            },
+            "description": "Provides state attributes for an entity that has lifeccycle aspects only."
         },
         "resource-spec": {
             "$ref": "#/definitions/global-class"
         },
-        "node": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "aggregated-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "owned-node-edge-point": {
-                            "items": {
-                                "$ref": "#/definitions/node-edge-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "encap-topology": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        }
-                    }
-                }
-            ]
-        },
-        "transfer-capacity-pac": {
-            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
+        "time-range": {
             "properties": {
-                "available-capacity": {
-                    "description": "Capacity available to be assigned.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-assigned-to-user-view": {
-                    "items": {
-                        "$ref": "#/definitions/capacity"
-                    },
-                    "type": "array",
-                    "description": "Capacity already assigned",
-                    "x-key": "total-size"
-                },
-                "total-potential-capacity": {
-                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-interaction-algorithm": {
-                    "type": "string",
-                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)"
-                }
-            }
-        },
-        "risk-parameter-pac": {
-            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
-            "properties": {
-                "risk-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/risk-characteristic"
-                    },
-                    "type": "array",
-                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
-                    "x-key": "risk-characteristic-name"
-                }
-            }
-        },
-        "capacity": {
-            "description": "Information on capacity of a particular TopologicalEntity.",
-            "properties": {
-                "committed-burst-size": {
+                "start-time": {
                     "type": "string"
                 },
-                "peak-burst-size": {
+                "end-time": {
                     "type": "string"
-                },
-                "peak-information-rate": {
-                    "type": "string"
-                },
-                "coupling-flag": {
-                    "type": "boolean"
-                },
-                "color-aware": {
-                    "type": "boolean"
-                },
-                "committed-information-rate": {
-                    "type": "string"
-                },
-                "packet-bw-profile-type": {
-                    "type": "string"
-                },
-                "total-size": {
-                    "type": "string",
-                    "description": "Total capacity of the TopologicalEntity in MB/s"
                 }
             }
-        },
-        "risk-characteristic": {
-            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
-            "properties": {
-                "risk-identifier-list": {
-                    "items": {
-                        "type": "string",
-                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity."
-                    },
-                    "type": "array"
-                },
-                "risk-characteristic-name": {
-                    "type": "string",
-                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated."
-                }
-            }
-        },
-        "network-topology-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        }
-                    }
-                }
-            ]
-        },
-        "transfer-cost-pac": {
-            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
-            "properties": {
-                "cost-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/cost-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                    "x-key": "cost-name cost-value cost-algorithm"
-                }
-            }
-        },
-        "node-edge-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "termination-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string"
-                        },
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "client-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "mapped-service-end-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "link-port-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the LinkEnd."
-                        },
-                        "link-port-role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "te-link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        }
-                    }
-                }
-            ]
         },
         "transfer-integrity-pac": {
-            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
             "properties": {
-                "error-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded."
-                },
                 "unavailable-time-characteristic": {
                     "type": "string",
                     "description": "Describes the duration for which there may be no valid signal propagated."
-                },
-                "loss-characteristic": {
-                    "type": "string",
-                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips)."
                 },
                 "delivery-order-characteristic": {
                     "type": "string",
@@ -9741,107 +11107,92 @@
                     "type": "string",
                     "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity."
                 },
+                "loss-characteristic": {
+                    "type": "string",
+                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips)."
+                },
+                "error-characteristic": {
+                    "type": "string",
+                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded."
+                },
                 "repeat-delivery-characteristic": {
                     "type": "string",
                     "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay."
                 }
-            }
+            },
+            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact."
         },
-        "cost-characteristic": {
-            "description": "The information for a particular cost characteristic.",
-            "properties": {
-                "cost-name": {
-                    "type": "string",
-                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName."
-                },
-                "cost-value": {
-                    "type": "string",
-                    "description": "The specific cost."
-                },
-                "cost-algorithm": {
-                    "type": "string",
-                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm."
-                }
-            }
-        },
-        "validation-pac": {
-            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
-            "properties": {
-                "validation-mechanism": {
-                    "items": {
-                        "$ref": "#/definitions/validation-mechanism"
-                    },
-                    "type": "array",
-                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
-                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
-                }
-            }
-        },
-        "transfer-timing-pac": {
-            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
-            "properties": {
-                "latency-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/latency-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                    "x-key": "traffic-property-name traffic-property-queing-latency"
-                }
-            }
-        },
-        "link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
+        "topology": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
-                        "node": {
+                        "link": {
+                            "x-key": "uuid",
+                            "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                                "$ref": "#/definitions/link"
+                            }
                         },
                         "layer-protocol-name": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "och",
                                     "odu",
                                     "eth",
                                     "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
+                                ]
+                            }
                         },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
+                        "node": {
+                            "x-key": "uuid",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/node"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). "
+        },
+        "validation-pac": {
+            "properties": {
+                "validation-mechanism": {
+                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/validation-mechanism"
+                    },
+                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity."
+                }
+            },
+            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity."
+        },
+        "transfer-timing-pac": {
+            "properties": {
+                "latency-characteristic": {
+                    "x-key": "traffic-property-name traffic-property-queing-latency",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/latency-characteristic"
+                    },
+                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic."
+                }
+            },
+            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity."
+        },
+        "link": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
                         },
@@ -9851,35 +11202,125 @@
                         "transfer-cost": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         },
+                        "risk-parameter": {
+                            "$ref": "#/definitions/risk-parameter-pac"
+                        },
+                        "node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "layer-protocol-name": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
+                        },
                         "lp-transition": {
                             "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases.",
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "validation": {
+                            "$ref": "#/definitions/validation-pac"
+                        },
                         "transfer-timing": {
                             "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "node": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            }
                         }
                     }
                 }
-            ]
+            ],
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). "
         },
-        "layer-protocol-transition-pac": {
-            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
-            "properties": {
-                "node-edge-point": {
-                    "items": {
-                        "type": "string",
-                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
-                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                    },
-                    "type": "array"
+        "node-edge-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
                 },
-                "transitioned-layer-protocol-name": {
-                    "items": {
-                        "type": "string",
-                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role."
-                    },
-                    "type": "array"
+                {
+                    "properties": {
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "client-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "mapped-service-end-point": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "layer-protocol": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            }
+                        },
+                        "link-port-role": {
+                            "type": "string",
+                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "sink",
+                                "source",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "link-port-direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the LinkEnd.",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ]
+                        }
+                    }
                 }
-            }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
         },
         "topology-context": {
             "properties": {
@@ -9887,38 +11328,72 @@
                     "$ref": "#/definitions/network-topology-service"
                 },
                 "topology": {
+                    "x-key": "uuid",
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/topology"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
+                    }
                 }
             }
         },
-        "validation-mechanism": {
-            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
-            "properties": {
-                "validation-mechanism": {
-                    "type": "string",
-                    "description": "Name of mechanism used to validate adjacency"
+        "te-link": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
                 },
-                "validation-robustness": {
-                    "type": "string",
-                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
-                },
-                "layer-protocol-adjacency-validated": {
-                    "type": "string",
-                    "description": "State of validatiion"
+                {
+                    "properties": {
+                        "node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "node": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
-            }
+            ],
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). "
+        },
+        "capacity": {
+            "properties": {
+                "committed-information-rate": {
+                    "type": "string"
+                },
+                "peak-information-rate": {
+                    "type": "string"
+                },
+                "committed-burst-size": {
+                    "type": "string"
+                },
+                "total-size": {
+                    "type": "string",
+                    "description": "Total capacity of the TopologicalEntity in MB/s"
+                },
+                "color-aware": {
+                    "type": "boolean"
+                },
+                "coupling-flag": {
+                    "type": "boolean"
+                },
+                "peak-burst-size": {
+                    "type": "string"
+                },
+                "packet-bw-profile-type": {
+                    "type": "string"
+                }
+            },
+            "description": "Information on capacity of a particular TopologicalEntity."
         },
         "latency-characteristic": {
-            "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
             "properties": {
-                "traffic-property-queing-latency": {
-                    "type": "string",
-                    "description": "The specific queuing latency for the traffic property."
-                },
                 "traffic-property-name": {
                     "type": "string",
                     "description": "The identifier of the specific traffic property to which the queuing latency applies."
@@ -9927,94 +11402,318 @@
                     "type": "string",
                     "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
                 },
-                "wander-characteristic": {
-                    "type": "string",
-                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
-                },
                 "fixed-latency-characteristic": {
                     "type": "string",
                     "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity"
+                },
+                "traffic-property-queing-latency": {
+                    "type": "string",
+                    "description": "The specific queuing latency for the traffic property."
+                },
+                "wander-characteristic": {
+                    "type": "string",
+                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
                 }
-            }
+            },
+            "description": "Provides information on latency characteristic for a particular stated trafficProperty."
         },
-        "topology": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
+        "risk-characteristic": {
+            "properties": {
+                "risk-characteristic-name": {
+                    "type": "string",
+                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated."
+                },
+                "risk-identifier-list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity."
+                    }
+                }
+            },
+            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic."
+        },
+        "validation-mechanism": {
+            "properties": {
+                "validation-robustness": {
+                    "type": "string",
+                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
+                },
+                "validation-mechanism": {
+                    "type": "string",
+                    "description": "Name of mechanism used to validate adjacency"
+                },
+                "layer-protocol-adjacency-validated": {
+                    "type": "string",
+                    "description": "State of validatiion"
+                }
+            },
+            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism"
+        },
+        "layer-protocol-transition-pac": {
+            "properties": {
+                "transitioned-layer-protocol-name": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role."
+                    }
+                },
+                "node-edge-point": {
+                    "type": "array",
+                    "items": {
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                        "type": "string",
+                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link."
+                    }
+                }
+            },
+            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links."
+        },
+        "risk-parameter-pac": {
+            "properties": {
+                "risk-characteristic": {
+                    "x-key": "risk-characteristic-name",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/risk-characteristic"
+                    },
+                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration."
+                }
+            },
+            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics."
+        },
+        "network-topology-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "topology": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "transfer-cost-pac": {
+            "properties": {
+                "cost-characteristic": {
+                    "x-key": "cost-name cost-value cost-algorithm",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cost-characteristic"
+                    },
+                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity."
+                }
+            },
+            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. "
+        },
+        "cost-characteristic": {
+            "properties": {
+                "cost-algorithm": {
+                    "type": "string",
+                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm."
+                },
+                "cost-value": {
+                    "type": "string",
+                    "description": "The specific cost."
+                },
+                "cost-name": {
+                    "type": "string",
+                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName."
+                }
+            },
+            "description": "The information for a particular cost characteristic."
+        },
+        "transfer-capacity-pac": {
+            "properties": {
+                "capacity-assigned-to-user-view": {
+                    "x-key": "total-size",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/capacity"
+                    },
+                    "description": "Capacity already assigned"
+                },
+                "capacity-interaction-algorithm": {
+                    "type": "string",
+                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)"
+                },
+                "available-capacity": {
+                    "$ref": "#/definitions/capacity",
+                    "description": "Capacity available to be assigned."
+                },
+                "total-potential-capacity": {
+                    "$ref": "#/definitions/capacity",
+                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken."
+                }
+            },
+            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile."
+        },
+        "node": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
-                        "node": {
-                            "items": {
-                                "$ref": "#/definitions/node"
-                            },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "aggregated-node-edge-point": {
                             "type": "array",
-                            "x-key": "uuid"
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "owned-node-edge-point": {
+                            "x-key": "uuid",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/node-edge-point"
+                            }
+                        },
+                        "transfer-timing": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "encap-topology": {
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                            "type": "string"
                         },
                         "layer-protocol-name": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "och",
                                     "odu",
                                     "eth",
                                     "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
+                                ]
+                            }
                         },
-                        "link": {
-                            "items": {
-                                "$ref": "#/definitions/link"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
                         }
                     }
                 }
-            ]
+            ],
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). "
         },
-        "path-comp-service-port": {
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component",
+        "path-optimization-constraint": {
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
                 },
                 {
                     "properties": {
-                        "service-layer": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
+                        "traffic-interruption": {
                             "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-computation-context": {
+            "properties": {
+                "path-comp-service": {
+                    "x-key": "uuid",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path-computation-service"
+                    }
+                },
+                "path": {
+                    "x-key": "uuid",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path"
+                    }
+                }
+            }
+        },
+        "routing-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "path-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
                         },
-                        "service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
                         },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the EndPoint."
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            }
                         },
-                        "role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
+                        "exclude-path": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/te-link"
+                            }
+                        },
+                        "include-topology": {
+                            "type": "array",
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            }
+                        },
+                        "service-level": {
                             "type": "string",
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "cost-characteristic": {
+                            "x-key": "cost-name cost-value cost-algorithm",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity."
+                        },
+                        "include-path": {
+                            "x-key": "local-id",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/te-link"
+                            }
+                        },
+                        "latency-characteristic": {
+                            "x-key": "traffic-property-name traffic-property-queing-latency",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic."
                         }
                     }
                 }
@@ -10027,9 +11726,6 @@
                 },
                 {
                     "properties": {
-                        "concurrent-paths": {
-                            "type": "string"
-                        },
                         "link-utilization": {
                             "type": "string"
                         },
@@ -10037,6 +11733,9 @@
                             "type": "string"
                         },
                         "cost-optimization": {
+                            "type": "string"
+                        },
+                        "concurrent-paths": {
                             "type": "string"
                         },
                         "resource-sharing": {
@@ -10053,160 +11752,99 @@
                 },
                 {
                     "properties": {
-                        "routing-constraint": {
-                            "$ref": "#/definitions/routing-constraint"
+                        "objective-function": {
+                            "$ref": "#/definitions/path-objective-function"
                         },
                         "path": {
+                            "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            },
-                            "type": "array"
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid",
+                                "type": "string"
+                            }
                         },
                         "optimization-constraint": {
                             "$ref": "#/definitions/path-optimization-constraint"
                         },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
                         "service-port": {
+                            "x-key": "local-id",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/path-comp-service-port"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "objective-function": {
-                            "$ref": "#/definitions/path-objective-function"
-                        }
-                    }
-                }
-            ]
-        },
-        "path-optimization-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "traffic-interruption": {
-                            "type": "string"
-                        }
-                    }
-                }
-            ]
-        },
-        "routing-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "include-path": {
-                            "items": {
-                                "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "cost-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "x-key": "cost-name cost-value cost-algorithm"
-                        },
-                        "exclude-path": {
-                            "items": {
-                                "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "avoid-topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "latency-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "x-key": "traffic-property-name traffic-property-queing-latency"
-                        },
-                        "path-layer": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "include-topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                            }
                         }
                     }
                 }
             ]
         },
         "path": {
-            "description": "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
-                        "routing-constraint": {
-                            "$ref": "#/definitions/routing-constraint"
-                        },
                         "telink": {
+                            "x-key": "local-id",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
+                            }
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
                         }
                     }
                 }
-            ]
+            ],
+            "description": "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes"
         },
-        "path-computation-context": {
-            "properties": {
-                "path-comp-service": {
-                    "items": {
-                        "$ref": "#/definitions/path-computation-service"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
+        "path-comp-service-port": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
                 },
-                "path": {
-                    "items": {
-                        "$ref": "#/definitions/path"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
+                {
+                    "properties": {
+                        "service-layer": {
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint.",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ]
+                        },
+                        "service-end-point": {
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ]
+                        }
+                    }
                 }
-            }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
         },
         "context_schema": {
             "allOf": [
@@ -10215,63 +11853,63 @@
                 },
                 {
                     "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "value-name"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "value-name"
-                        },
                         "path-comp-service": {
+                            "x-key": "uuid",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/path-computation-service"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                            }
                         },
                         "connection": {
+                            "x-key": "uuid",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/connection"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                            }
                         },
-                        "connectivity-service": {
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service"
-                            },
+                        "label": {
+                            "x-key": "value-name",
                             "type": "array",
-                            "x-key": "uuid"
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state."
+                        },
+                        "name": {
+                            "x-key": "value-name",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity."
                         },
                         "nw-topology-service": {
                             "$ref": "#/definitions/network-topology-service"
                         },
+                        "uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
                         "path": {
+                            "x-key": "uuid",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/path"
-                            },
+                            }
+                        },
+                        "connectivity-service": {
+                            "x-key": "uuid",
                             "type": "array",
-                            "x-key": "uuid"
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service"
+                            }
                         },
                         "topology": {
+                            "x-key": "uuid",
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/topology"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                            }
                         }
                     }
                 }
@@ -10297,10 +11935,10 @@
         "get-connectivity-service-listRPC_output_schema": {
             "properties": {
                 "conn-service": {
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/connectivity-service"
-                    },
-                    "type": "array"
+                    }
                 }
             }
         },
@@ -10340,17 +11978,17 @@
         },
         "create-connectivity-serviceRPC_input_schema": {
             "properties": {
-                "service-port": {
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service-port"
-                    },
-                    "type": "array"
+                "conn-schedule": {
+                    "type": "string"
                 },
                 "conn-constraint": {
                     "$ref": "#/definitions/connectivity-constraint"
                 },
-                "conn-schedule": {
-                    "type": "string"
+                "service-port": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connectivity-service-port"
+                    }
                 }
             }
         },
@@ -10366,11 +12004,11 @@
                 "service-id-or-name": {
                     "type": "string"
                 },
-                "conn-constraint": {
-                    "$ref": "#/definitions/connectivity-constraint"
-                },
                 "conn-schedule": {
                     "type": "string"
+                },
+                "conn-constraint": {
+                    "$ref": "#/definitions/connectivity-constraint"
                 }
             }
         },

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -12,314 +12,76 @@
     ],
     "paths": {},
     "definitions": {
-        "connection-point-and-adapter-pac": {
+        "traffic-shaping-pac": {
             "properties": {
-                "mac-length": {
-                    "type": "string",
-                    "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
-                },
-                "csf-report": {
+                "codirectional": {
                     "type": "boolean",
-                    "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
+                    "description": "This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP."
                 },
-                "partner-system-id": {
+                "prio-config-list": {
+                    "type": "array",
+                    "description": "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
+                    "items": {
+                        "$ref": "#/definitions/priority-configuration"
+                    }
+                },
+                "sched-config": {
                     "type": "string",
-                    "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
+                    "description": "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.\nScheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).\nNote that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute."
                 },
-                "actor-oper-key": {
+                "queue-config-list": {
+                    "type": "array",
+                    "description": "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.",
+                    "items": {
+                        "$ref": "#/definitions/queue-configuration"
+                    }
+                }
+            },
+            "description": "This object class models the ETH traffic shaping function as defined in G.8021.\nBasic attribute: codirectional, prioConfigList, queueConfigList, schedConfig"
+        },
+        "traffic-conditioning-configuration": {
+            "properties": {
+                "cir": {
                     "type": "string",
-                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
+                    "description": "This attribute indicates the Committed Information Rate in bits/s."
                 },
-                "csf-config": {
+                "cbs": {
+                    "type": "string",
+                    "description": "This attribute indicates the Committed Burst Size in bytes."
+                },
+                "ebs": {
+                    "type": "string",
+                    "description": "This attribute indicates the Excess Burst Size in bytes."
+                },
+                "colour-mode": {
+                    "type": "string",
+                    "description": "This attribute indicates the colour mode.",
                     "enum": [
-                        "disabled",
-                        "enabled",
-                        "enabled-with-rdi-fdi",
-                        "enabled-with-rdi-fdi-dci",
-                        "enabled-with-dci"
-                    ],
+                        "colour-blind",
+                        "colour-aware"
+                    ]
+                },
+                "eir": {
                     "type": "string",
-                    "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
+                    "description": "This attribute indicates the Excess Information Rate in bits/s."
                 },
-                "traffic-conditioning": {
-                    "$ref": "#/definitions/traffic-conditioning-pac"
-                },
-                "partner-system-priority": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
-                },
-                "data-rate": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
-                },
-                "vlan-config": {
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
-                },
-                "traffic-shaping": {
-                    "$ref": "#/definitions/traffic-shaping-pac"
-                },
-                "pll-thr": {
-                    "type": "string",
-                    "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
-                },
-                "actor-system-id": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
-                },
-                "collector-max-delay": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
-                },
-                "filter-config": {
-                    "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                    "$ref": "#/definitions/control-frame-filter"
-                },
-                "filter-config-snk": {
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
-                    },
-                    "type": "array"
-                },
-                "is-ssf-reported": {
+                "coupling-flag": {
                     "type": "boolean",
-                    "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
+                    "description": "This attribute indicates the coupling flag."
                 },
-                "auxiliary-function-position-sequence": {
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
-                    },
-                    "type": "array"
-                },
-                "actor-system-priority": {
+                "queue-id": {
                     "type": "string",
-                    "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
-                },
-                "csf-rdi-fdi-enable": {
-                    "type": "boolean",
-                    "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
-                },
-                "partner-oper-key": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
-                }
-            }
-        },
-        "priority-mapping": {
-            "description": "This data type provides the priority mapping done in the 'P Regenerate' process defined in G.8021.",
-            "properties": {
-                "priority1": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 1."
-                },
-                "priority0": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 0."
-                },
-                "priority3": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 3."
-                },
-                "priority2": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 2."
-                },
-                "priority5": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 5."
-                },
-                "priority4": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 4."
-                },
-                "priority7": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 7."
-                },
-                "priority6": {
-                    "type": "string",
-                    "description": "This attribute defines the new priority value for the old priority value 6."
-                }
-            }
-        },
-        "connection-end-point-lp-spec": {
-            "properties": {
-                "termination-spec": {
-                    "$ref": "#/definitions/eth-termination-pac"
-                },
-                "adapter-spec": {
-                    "$ref": "#/definitions/connection-point-and-adapter-pac"
+                    "description": "This attribute indicates the queue id."
                 }
             }
         },
         "priority-configuration": {
             "properties": {
+                "queue-id": {
+                    "type": "string"
+                },
                 "priority": {
                     "type": "string"
-                },
-                "queue-id": {
-                    "type": "string"
-                }
-            }
-        },
-        "traffic-conditioning-pac": {
-            "description": "This object class models the ETH traffic conditioning function as defined in G.8021.\nBasic attributes: codirectional, condConfigList, prioConfigList",
-            "properties": {
-                "cond-config-list": {
-                    "items": {
-                        "$ref": "#/definitions/traffic-conditioning-configuration"
-                    },
-                    "type": "array",
-                    "description": "This attribute indicates for the conditioner process the conditioning parameters:\n- Queue ID: Indicates the Queue ID\n- Committed Information Rate (CIR): number of bits per second\n- Committed Burst Size (CBS): number of bytes\n- Excess Information Rate (EIR): number of bits per second\n- Excess Burst Size (EBS): number of bytes\n- Coupling flag (CF): 0 or 1\n- Color mode (CM): color-blind and color-aware."
-                },
-                "prio-config-list": {
-                    "items": {
-                        "$ref": "#/definitions/priority-configuration"
-                    },
-                    "type": "array",
-                    "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue."
-                },
-                "codirectional": {
-                    "type": "boolean",
-                    "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
-                }
-            }
-        },
-        "bandwidth-report": {
-            "description": "Data type for the bandwidth report.",
-            "properties": {
-                "nominal-bandwidth": {
-                    "type": "string",
-                    "description": "This attribute returns the configured bandwidth"
-                },
-                "port-id": {
-                    "type": "string",
-                    "description": "This attribute returns the far end port identifier."
-                },
-                "source-mac-address": {
-                    "type": "string",
-                    "description": "The sourceMacAddress is the address from the far end."
-                },
-                "current-bandwidth": {
-                    "type": "string",
-                    "description": "This attribute returns the current bandwidth."
-                }
-            }
-        },
-        "address-tuple": {
-            "description": "This data type contains an address tuple consisting of a MAC address and a corresponding port list.",
-            "properties": {
-                "port-list": {
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute contains the ports associated to the MAC address in the address tuple."
-                    },
-                    "type": "array"
-                },
-                "address": {
-                    "type": "string",
-                    "description": "This attribute contains the MAC address of the address tuple."
-                }
-            }
-        },
-        "traffic-shaping-pac": {
-            "description": "This object class models the ETH traffic shaping function as defined in G.8021.\nBasic attribute: codirectional, prioConfigList, queueConfigList, schedConfig",
-            "properties": {
-                "sched-config": {
-                    "type": "string",
-                    "description": "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.\nScheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).\nNote that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute."
-                },
-                "prio-config-list": {
-                    "items": {
-                        "$ref": "#/definitions/priority-configuration"
-                    },
-                    "type": "array",
-                    "description": "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue."
-                },
-                "codirectional": {
-                    "type": "boolean",
-                    "description": "This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP."
-                },
-                "queue-config-list": {
-                    "items": {
-                        "$ref": "#/definitions/queue-configuration"
-                    },
-                    "type": "array",
-                    "description": "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped."
-                }
-            }
-        },
-        "node-edge-point-lp-spec": {
-            "properties": {
-                "termination-spec": {
-                    "$ref": "#/definitions/ety-termination-pac"
-                }
-            }
-        },
-        "queue-configuration": {
-            "properties": {
-                "queue-id": {
-                    "type": "string",
-                    "description": "This attribute indicates the queue id."
-                },
-                "queue-threshold": {
-                    "type": "string",
-                    "description": "This attribute defines the threshold of the queue in bytes."
-                },
-                "queue-depth": {
-                    "type": "string",
-                    "description": "This attribute defines the depth of the queue in bytes."
-                }
-            }
-        },
-        "eth-termination-pac": {
-            "description": "This object class models the Ethernet Flow Termination function located at a layer boundary.",
-            "properties": {
-                "frametype-config": {
-                    "enum": [
-                        "admit-only-vlan-tagged-frames",
-                        "admit-only-untagged-and-priority-tagged-frames",
-                        "admit-all-frames"
-                    ],
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.\nrange of type : see Enumeration"
-                },
-                "port-vid": {
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021."
-                },
-                "priority-regenerate": {
-                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
-                    "$ref": "#/definitions/priority-mapping"
-                },
-                "priority-code-point-config": {
-                    "enum": [
-                        "8p0d",
-                        "7p1d",
-                        "6p2d",
-                        "5p3d",
-                        "dei"
-                    ],
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.\nrange of type : see Enumeration"
-                },
-                "ether-type": {
-                    "enum": [
-                        "c-tag",
-                        "s-tag",
-                        "i-tag"
-                    ],
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021."
-                },
-                "filter-config": {
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.\nIt indicates the configured filter action for each of the 33 group MAC addresses for control frames.\nThe 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.\nrange of type : MacAddress: \n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to \n01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to \n01-80-C2-00-00-2F;\nActionEnum:\nPASS, BLOCK"
-                    },
-                    "type": "array"
                 }
             }
         },
@@ -333,30 +95,9 @@
                     "type": "boolean",
                     "description": "This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information."
                 },
-                "phy-type-list": {
-                    "items": {
-                        "enum": [
-                            "other",
-                            "unknown",
-                            "none",
-                            "2base-tl",
-                            "10mbit-s",
-                            "10pass-ts",
-                            "100base-t4",
-                            "100base-x",
-                            "100base-t2",
-                            "1000base-x",
-                            "1000base-t",
-                            "10gbase-x",
-                            "10gbase-r",
-                            "10gbase-w"
-                        ],
-                        "type": "string",
-                        "description": "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3."
-                    },
-                    "type": "array"
-                },
                 "phy-type": {
+                    "type": "string",
+                    "description": "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.",
                     "enum": [
                         "other",
                         "unknown",
@@ -372,76 +113,205 @@
                         "10gbase-x",
                         "10gbase-r",
                         "10gbase-w"
-                    ],
+                    ]
+                },
+                "phy-type-list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.",
+                        "enum": [
+                            "other",
+                            "unknown",
+                            "none",
+                            "2base-tl",
+                            "10mbit-s",
+                            "10pass-ts",
+                            "100base-t4",
+                            "100base-x",
+                            "100base-t2",
+                            "1000base-x",
+                            "1000base-t",
+                            "10gbase-x",
+                            "10gbase-r",
+                            "10gbase-w"
+                        ]
+                    }
+                }
+            }
+        },
+        "bandwidth-report": {
+            "properties": {
+                "source-mac-address": {
                     "type": "string",
-                    "description": "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2."
+                    "description": "The sourceMacAddress is the address from the far end."
+                },
+                "port-id": {
+                    "type": "string",
+                    "description": "This attribute returns the far end port identifier."
+                },
+                "nominal-bandwidth": {
+                    "type": "string",
+                    "description": "This attribute returns the configured bandwidth"
+                },
+                "current-bandwidth": {
+                    "type": "string",
+                    "description": "This attribute returns the current bandwidth."
+                }
+            },
+            "description": "Data type for the bandwidth report."
+        },
+        "priority-mapping": {
+            "properties": {
+                "priority7": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 7."
+                },
+                "priority5": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 5."
+                },
+                "priority1": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 1."
+                },
+                "priority4": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 4."
+                },
+                "priority6": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 6."
+                },
+                "priority0": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 0."
+                },
+                "priority3": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 3."
+                },
+                "priority2": {
+                    "type": "string",
+                    "description": "This attribute defines the new priority value for the old priority value 2."
+                }
+            },
+            "description": "This data type provides the priority mapping done in the 'P Regenerate' process defined in G.8021."
+        },
+        "address-tuple": {
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "This attribute contains the MAC address of the address tuple."
+                },
+                "port-list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute contains the ports associated to the MAC address in the address tuple."
+                    }
+                }
+            },
+            "description": "This data type contains an address tuple consisting of a MAC address and a corresponding port list."
+        },
+        "connection-point-and-adapter-pac": {
+            "properties": {
+                "actor-oper-key": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
+                },
+                "collector-max-delay": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
+                },
+                "pll-thr": {
+                    "type": "string",
+                    "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
+                },
+                "traffic-conditioning": {
+                    "$ref": "#/definitions/traffic-conditioning-pac"
+                },
+                "csf-rdi-fdi-enable": {
+                    "type": "boolean",
+                    "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
+                },
+                "auxiliary-function-position-sequence": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
+                    }
+                },
+                "actor-system-priority": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
+                },
+                "partner-system-id": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
+                },
+                "partner-system-priority": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
+                },
+                "is-ssf-reported": {
+                    "type": "boolean",
+                    "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
+                },
+                "csf-report": {
+                    "type": "boolean",
+                    "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
+                },
+                "csf-config": {
+                    "type": "string",
+                    "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false",
+                    "enum": [
+                        "disabled",
+                        "enabled",
+                        "enabled-with-rdi-fdi",
+                        "enabled-with-rdi-fdi-dci",
+                        "enabled-with-dci"
+                    ]
+                },
+                "data-rate": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
+                },
+                "filter-config-snk": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
+                    }
+                },
+                "vlan-config": {
+                    "type": "string",
+                    "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
+                },
+                "traffic-shaping": {
+                    "$ref": "#/definitions/traffic-shaping-pac"
+                },
+                "filter-config": {
+                    "$ref": "#/definitions/control-frame-filter",
+                    "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
+                },
+                "partner-oper-key": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
+                },
+                "mac-length": {
+                    "type": "string",
+                    "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
+                },
+                "actor-system-id": {
+                    "type": "string",
+                    "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
                 }
             }
         },
         "control-frame-filter": {
-            "description": "This data type identifies the filter action for each of the 33 group MAC addresses (control frames).\nValue 'false' means block: The frame is discarded by the filter process.\nValue 'true' means pass: The frame is passed unchanged through the filter process.",
             "properties": {
-                "c2-00-00-0e": {
-                    "type": "boolean",
-                    "description": "This attribute identifies the Individual LAN Scope group address, Nearest Bridge group address (LLDP protocol)."
-                },
-                "c2-00-00-0d": {
-                    "type": "boolean",
-                    "description": "This attribute identifies the Provider Bridge MVRP address."
-                },
-                "c2-00-00-2a": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-0f": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-0a": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-25": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-0c": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-0b": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-10": {
-                    "type": "boolean",
-                    "description": "This attribute identifies the 'All LANs Bridge Management Group Address'."
-                },
-                "c2-00-00-02": {
-                    "type": "boolean",
-                    "description": "This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast address (LACP/LAMP or Link OAM protocols)."
-                },
-                "c2-00-00-2f": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-2e": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-2d": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-2c": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
                 "c2-00-00-05": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
-                "c2-00-00-22": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
@@ -449,13 +319,9 @@
                     "type": "boolean",
                     "description": "This attribute identifies the Customer Bridge MVRP address."
                 },
-                "c2-00-00-06": {
+                "c2-00-00-2c": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
-                },
-                "c2-00-00-01": {
-                    "type": "boolean",
-                    "description": "This attribute identifies the IEEE MAC-specific Control Protocols group address (PAUSE protocol)."
                 },
                 "c2-00-00-00": {
                     "type": "boolean",
@@ -465,7 +331,7 @@
                     "type": "boolean",
                     "description": "This attribute identifies the Nearest non-TPMR Bridge group address (Port Authentication protocol)."
                 },
-                "c2-00-00-24": {
+                "c2-00-00-2b": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
@@ -473,19 +339,19 @@
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
-                "c2-00-00-28": {
-                    "type": "boolean",
-                    "description": "Reserved for future standardization."
-                },
                 "c2-00-00-09": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
-                "c2-00-00-08": {
+                "c2-00-00-07": {
                     "type": "boolean",
-                    "description": "This attribute identifies the Provider Bridge Group address."
+                    "description": "This attribute identifies the Metro Ethernet Forum E-LMI protocol group address."
                 },
-                "c2-00-00-2b": {
+                "c2-00-00-0d": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the Provider Bridge MVRP address."
+                },
+                "c2-00-00-0a": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
@@ -493,63 +359,197 @@
                     "type": "boolean",
                     "description": "Reserved for future standardization."
                 },
-                "c2-00-00-04": {
+                "c2-00-00-0c": {
                     "type": "boolean",
-                    "description": "This attribute identifies the IEEE MAC-specific Control Protocols group address."
+                    "description": "Reserved for future standardization."
                 },
-                "c2-00-00-07": {
+                "c2-00-00-2e": {
                     "type": "boolean",
-                    "description": "This attribute identifies the Metro Ethernet Forum E-LMI protocol group address."
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-0f": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-02": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast address (LACP/LAMP or Link OAM protocols)."
                 },
                 "c2-00-00-20": {
                     "type": "boolean",
                     "description": "This attribute identifies the Customer and Provider Bridge MMRP address."
                 },
-                "c2-00-00-27": {
+                "c2-00-00-25": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
+                },
+                "c2-00-00-0e": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the Individual LAN Scope group address, Nearest Bridge group address (LLDP protocol)."
+                },
+                "c2-00-00-10": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the 'All LANs Bridge Management Group Address'."
+                },
+                "c2-00-00-08": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the Provider Bridge Group address."
                 },
                 "c2-00-00-26": {
                     "type": "boolean",
                     "description": "Reserved for future standardization."
+                },
+                "c2-00-00-0b": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-24": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-28": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-2f": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-2a": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-06": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-27": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-01": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the IEEE MAC-specific Control Protocols group address (PAUSE protocol)."
+                },
+                "c2-00-00-2d": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-22": {
+                    "type": "boolean",
+                    "description": "Reserved for future standardization."
+                },
+                "c2-00-00-04": {
+                    "type": "boolean",
+                    "description": "This attribute identifies the IEEE MAC-specific Control Protocols group address."
+                }
+            },
+            "description": "This data type identifies the filter action for each of the 33 group MAC addresses (control frames).\nValue 'false' means block: The frame is discarded by the filter process.\nValue 'true' means pass: The frame is passed unchanged through the filter process."
+        },
+        "node-edge-point-lp-spec": {
+            "properties": {
+                "termination-spec": {
+                    "$ref": "#/definitions/ety-termination-pac"
                 }
             }
         },
-        "traffic-conditioning-configuration": {
+        "eth-termination-pac": {
             "properties": {
-                "cbs": {
+                "priority-code-point-config": {
                     "type": "string",
-                    "description": "This attribute indicates the Committed Burst Size in bytes."
+                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.\nrange of type : see Enumeration",
+                    "enum": [
+                        "8p0d",
+                        "7p1d",
+                        "6p2d",
+                        "5p3d",
+                        "dei"
+                    ]
                 },
-                "eir": {
+                "ether-type": {
                     "type": "string",
-                    "description": "This attribute indicates the Excess Information Rate in bits/s."
+                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.",
+                    "enum": [
+                        "c-tag",
+                        "s-tag",
+                        "i-tag"
+                    ]
+                },
+                "port-vid": {
+                    "type": "string",
+                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021."
+                },
+                "priority-regenerate": {
+                    "$ref": "#/definitions/priority-mapping",
+                    "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021."
+                },
+                "filter-config": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.\nIt indicates the configured filter action for each of the 33 group MAC addresses for control frames.\nThe 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.\nrange of type : MacAddress: \n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to \n01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to \n01-80-C2-00-00-2F;\nActionEnum:\nPASS, BLOCK"
+                    }
+                },
+                "frametype-config": {
+                    "type": "string",
+                    "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.\nrange of type : see Enumeration",
+                    "enum": [
+                        "admit-only-vlan-tagged-frames",
+                        "admit-only-untagged-and-priority-tagged-frames",
+                        "admit-all-frames"
+                    ]
+                }
+            },
+            "description": "This object class models the Ethernet Flow Termination function located at a layer boundary."
+        },
+        "queue-configuration": {
+            "properties": {
+                "queue-depth": {
+                    "type": "string",
+                    "description": "This attribute defines the depth of the queue in bytes."
                 },
                 "queue-id": {
                     "type": "string",
                     "description": "This attribute indicates the queue id."
                 },
-                "colour-mode": {
-                    "enum": [
-                        "colour-blind",
-                        "colour-aware"
-                    ],
+                "queue-threshold": {
                     "type": "string",
-                    "description": "This attribute indicates the colour mode."
-                },
-                "coupling-flag": {
-                    "type": "boolean",
-                    "description": "This attribute indicates the coupling flag."
-                },
-                "cir": {
-                    "type": "string",
-                    "description": "This attribute indicates the Committed Information Rate in bits/s."
-                },
-                "ebs": {
-                    "type": "string",
-                    "description": "This attribute indicates the Excess Burst Size in bytes."
+                    "description": "This attribute defines the threshold of the queue in bytes."
                 }
             }
+        },
+        "connection-end-point-lp-spec": {
+            "properties": {
+                "adapter-spec": {
+                    "$ref": "#/definitions/connection-point-and-adapter-pac"
+                },
+                "termination-spec": {
+                    "$ref": "#/definitions/eth-termination-pac"
+                }
+            }
+        },
+        "traffic-conditioning-pac": {
+            "properties": {
+                "codirectional": {
+                    "type": "boolean",
+                    "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
+                },
+                "prio-config-list": {
+                    "type": "array",
+                    "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
+                    "items": {
+                        "$ref": "#/definitions/priority-configuration"
+                    }
+                },
+                "cond-config-list": {
+                    "type": "array",
+                    "description": "This attribute indicates for the conditioner process the conditioning parameters:\n- Queue ID: Indicates the Queue ID\n- Committed Information Rate (CIR): number of bits per second\n- Committed Burst Size (CBS): number of bytes\n- Excess Information Rate (EIR): number of bits per second\n- Excess Burst Size (EBS): number of bytes\n- Coupling flag (CF): 0 or 1\n- Color mode (CM): color-blind and color-aware.",
+                    "items": {
+                        "$ref": "#/definitions/traffic-conditioning-configuration"
+                    }
+                }
+            },
+            "description": "This object class models the ETH traffic conditioning function as defined in G.8021.\nBasic attributes: codirectional, condConfigList, prioConfigList"
         }
     }
 }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -1,9 +1,9 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-notification API generated from tapi-notification.yang",
-        "title": "tapi-notification API"
+        "title": "tapi-notification API",
+        "version": "1.0.0"
     },
     "host": "localhost:8080",
     "basePath": "/restconf",
@@ -12,86 +12,14 @@
     ],
     "paths": {
         "/config/context/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "produces": [
-                    "application/json"
-                ],
-                "description": "Delete operation of resource: context",
-                "summary": "Delete context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_by_id"
-            },
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: context",
+                "operationId": "retrieve_context",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve context",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -103,20 +31,99 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: context",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve context",
+                ]
+            },
+            "delete": {
+                "description": "Delete operation of resource: context",
+                "operationId": "delete_context_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context"
+                "summary": "Delete context by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "contextbody object",
+                        "required": true,
+                        "name": "context",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: context",
+                "operationId": "update_context_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update context by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "contextbody object",
+                        "required": true,
+                        "name": "context",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: context",
+                "operationId": "create_context_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create context by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/": {
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: service-end-point",
+                "operationId": "retrieve_context_service-end-point_service-end-point",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve service-end-point",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -132,122 +139,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve service-end-point",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: service-end-point",
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve service-end-point by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -259,28 +172,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -296,28 +209,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "required": true,
+                        "name": "local-id",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -329,35 +249,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
-                        "type": "string",
                         "name": "local-id",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -373,35 +293,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
-                        "type": "string",
                         "name": "local-id",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -413,42 +340,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_service-end-point_state_state",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve state",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -460,28 +373,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -497,151 +410,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -653,35 +450,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_service-end-point_label_label",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -697,151 +487,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -853,35 +527,20 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                ]
             }
         },
         "/config/context/name/": {
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -897,122 +556,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_name_name"
+                ]
             }
         },
         "/config/context/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_name_name_by_id"
-            },
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1024,28 +589,122 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name_by_id"
+                "summary": "Delete name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/label/": {
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_label_label",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1061,122 +720,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_label_label"
+                ]
             }
         },
         "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_label_label_by_id"
-            },
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1188,28 +753,122 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+                "description": "Delete operation of resource: label",
+                "operationId": "delete_context_label_label_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label_by_id"
+                "summary": "Delete label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "required": true,
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: label",
+                "operationId": "update_context_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "required": true,
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: label",
+                "operationId": "create_context_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/": {
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: notif-subscription",
+                "operationId": "retrieve_context_notif-subscription_notif-subscription",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notif-subscription",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1225,20 +884,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notif-subscription",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve notif-subscription",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_notif-subscription"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: notif-subscription",
+                "operationId": "retrieve_context_notif-subscription_notif-subscription_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notif-subscription by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1250,28 +917,130 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notif-subscription",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve notif-subscription by ID",
+                "description": "Delete operation of resource: notif-subscription",
+                "operationId": "delete_context_notif-subscription_notif-subscription_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notif-subscription_by_id"
+                "summary": "Delete notif-subscription by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "notif-subscriptionbody object",
+                        "required": true,
+                        "name": "notif-subscription",
+                        "schema": {
+                            "$ref": "#/definitions/notification-subscription-service"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: notif-subscription",
+                "operationId": "update_context_notif-subscription_notif-subscription_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update notif-subscription by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "notif-subscriptionbody object",
+                        "required": true,
+                        "name": "notif-subscription",
+                        "schema": {
+                            "$ref": "#/definitions/notification-subscription-service"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: notif-subscription",
+                "operationId": "create_context_notif-subscription_notif-subscription_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create notif-subscription by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/notification/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: notification",
+                "operationId": "retrieve_context_notif-subscription_notification_notification",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1287,28 +1056,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notification",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve notification",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_notification_notification"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of notification_uuid",
+                        "required": true,
+                        "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: notification",
+                "operationId": "retrieve_context_notif-subscription_notification_notification_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1320,35 +1096,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notification",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/target-object-name/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve notification by ID",
+                "description": "Retrieve operation of resource: target-object-name",
+                "operationId": "retrieve_context_notif-subscription_notification_target-object-name_target-object-name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_notification_by_id"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/target-object-name/": {
-            "get": {
+                "summary": "Retrieve target-object-name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1364,35 +1140,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: target-object-name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/target-object-name/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve target-object-name",
+                "description": "Retrieve operation of resource: target-object-name",
+                "operationId": "retrieve_context_notif-subscription_notification_target-object-name_target-object-name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_target-object-name_target-object-name"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/target-object-name/{value-name}/": {
-            "get": {
+                "summary": "Retrieve target-object-name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1404,42 +1187,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: target-object-name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/changed-attributes/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve target-object-name by ID",
+                "description": "Retrieve operation of resource: changed-attributes",
+                "operationId": "retrieve_context_notif-subscription_notification_changed-attributes_changed-attributes",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_target-object-name_target-object-name_by_id"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/changed-attributes/": {
-            "get": {
+                "summary": "Retrieve changed-attributes",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1455,35 +1231,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: changed-attributes",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/changed-attributes/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve changed-attributes",
+                "description": "Retrieve operation of resource: changed-attributes",
+                "operationId": "retrieve_context_notif-subscription_notification_changed-attributes_changed-attributes_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_changed-attributes_changed-attributes"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/changed-attributes/{value-name}/": {
-            "get": {
+                "summary": "Retrieve changed-attributes by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1495,42 +1278,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: changed-attributes",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/additional-info/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve changed-attributes by ID",
+                "description": "Retrieve operation of resource: additional-info",
+                "operationId": "retrieve_context_notif-subscription_notification_additional-info_additional-info",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_changed-attributes_changed-attributes_by_id"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/additional-info/": {
-            "get": {
+                "summary": "Retrieve additional-info",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1546,35 +1322,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: additional-info",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/additional-info/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve additional-info",
+                "description": "Retrieve operation of resource: additional-info",
+                "operationId": "retrieve_context_notif-subscription_notification_additional-info_additional-info_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_additional-info_additional-info"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/additional-info/{value-name}/": {
-            "get": {
+                "summary": "Retrieve additional-info by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1586,42 +1369,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: additional-info",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/name/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve additional-info by ID",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_notification_name_name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_additional-info_additional-info_by_id"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/name/": {
-            "get": {
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1637,35 +1413,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/name/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_notification_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_name_name"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/name/{value-name}/": {
-            "get": {
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1677,42 +1460,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/label/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notif-subscription_notification_label_label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_name_name_by_id"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/label/": {
-            "get": {
+                "summary": "Retrieve label",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1728,35 +1504,42 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/label/{value-name}/": {
+            "get": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of notification_uuid",
                         "required": true,
-                        "type": "string",
                         "name": "notification_uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notif-subscription_notification_label_label_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification_label_label"
-            }
-        },
-        "/config/context/notif-subscription/{uuid}/notification/{notification_uuid}/label/{value-name}/": {
-            "get": {
+                "summary": "Retrieve label by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1768,42 +1551,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of notification_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "notification_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_notification_label_label_by_id"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/notification-channel/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: notification-channel",
+                "operationId": "retrieve_context_notif-subscription_notification-channel_notification-channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification-channel",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1815,28 +1584,130 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notification-channel",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve notification-channel",
+                "description": "Delete operation of resource: notification-channel",
+                "operationId": "delete_context_notif-subscription_notification-channel_notification-channel_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification-channel_notification-channel"
+                "summary": "Delete notification-channel by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "notification-channelbody object",
+                        "required": true,
+                        "name": "notification-channel",
+                        "schema": {
+                            "$ref": "#/definitions/notification-channel"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: notification-channel",
+                "operationId": "update_context_notif-subscription_notification-channel_notification-channel_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update notification-channel by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "notification-channelbody object",
+                        "required": true,
+                        "name": "notification-channel",
+                        "schema": {
+                            "$ref": "#/definitions/notification-channel"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: notification-channel",
+                "operationId": "create_context_notif-subscription_notification-channel_notification-channel_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create notification-channel by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/notification-channel/name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_notification-channel_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1852,28 +1723,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_notification-channel_name_name"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/notification-channel/name/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_notification-channel_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1885,35 +1763,151 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_notif-subscription_notification-channel_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_notification-channel_name_name_by_id"
+                "summary": "Delete name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_notif-subscription_notification-channel_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_notif-subscription_notification-channel_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/subscription-filter/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: subscription-filter",
+                "operationId": "retrieve_context_notif-subscription_subscription-filter_subscription-filter",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve subscription-filter",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1925,28 +1919,130 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: subscription-filter",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve subscription-filter",
+                "description": "Delete operation of resource: subscription-filter",
+                "operationId": "delete_context_notif-subscription_subscription-filter_subscription-filter_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_subscription-filter_subscription-filter"
+                "summary": "Delete subscription-filter by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "subscription-filterbody object",
+                        "required": true,
+                        "name": "subscription-filter",
+                        "schema": {
+                            "$ref": "#/definitions/subscription-filter"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: subscription-filter",
+                "operationId": "update_context_notif-subscription_subscription-filter_subscription-filter_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update subscription-filter by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "subscription-filterbody object",
+                        "required": true,
+                        "name": "subscription-filter",
+                        "schema": {
+                            "$ref": "#/definitions/subscription-filter"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: subscription-filter",
+                "operationId": "create_context_notif-subscription_subscription-filter_subscription-filter_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create subscription-filter by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/subscription-filter/name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_subscription-filter_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1962,28 +2058,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_subscription-filter_name_name"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/subscription-filter/name/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_subscription-filter_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -1995,35 +2098,151 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_notif-subscription_subscription-filter_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_subscription-filter_name_name_by_id"
+                "summary": "Delete name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_notif-subscription_subscription-filter_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_notif-subscription_subscription-filter_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2039,28 +2258,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_name_name"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/name/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notif-subscription_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2072,35 +2298,151 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_notif-subscription_name_name_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_name_name_by_id"
+                "summary": "Delete name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_notif-subscription_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "namebody object",
+                        "required": true,
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_notif-subscription_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create name by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/label/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notif-subscription_label_label",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2116,28 +2458,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notif-subscription_label_label"
+                ]
             }
         },
         "/config/context/notif-subscription/{uuid}/label/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notif-subscription_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2149,35 +2498,143 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "delete": {
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
                         "name": "uuid",
+                        "type": "string",
                         "in": "path"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
                         "name": "value-name",
+                        "type": "string",
                         "in": "path"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+                "description": "Delete operation of resource: label",
+                "operationId": "delete_context_notif-subscription_label_label_by_id",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_notif-subscription_label_label_by_id"
+                "summary": "Delete label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "required": true,
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Update operation of resource: label",
+                "operationId": "update_context_notif-subscription_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "required": true,
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: label",
+                "operationId": "create_context_notif-subscription_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create label by ID",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/notification/": {
             "get": {
+                "parameters": [],
+                "description": "Retrieve operation of resource: notification",
+                "operationId": "retrieve_context_notification_notification",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2193,20 +2650,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notification",
-                "parameters": [],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve notification",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_notification"
+                ]
             }
         },
         "/config/context/notification/{uuid}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: notification",
+                "operationId": "retrieve_context_notification_notification_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2218,28 +2683,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: notification",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve notification by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_notification_by_id"
+                ]
             }
         },
         "/config/context/notification/{uuid}/target-object-name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: target-object-name",
+                "operationId": "retrieve_context_notification_target-object-name_target-object-name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve target-object-name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2255,28 +2720,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: target-object-name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve target-object-name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_target-object-name_target-object-name"
+                ]
             }
         },
         "/config/context/notification/{uuid}/target-object-name/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: target-object-name",
+                "operationId": "retrieve_context_notification_target-object-name_target-object-name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve target-object-name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2288,35 +2760,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: target-object-name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve target-object-name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_target-object-name_target-object-name_by_id"
+                ]
             }
         },
         "/config/context/notification/{uuid}/changed-attributes/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: changed-attributes",
+                "operationId": "retrieve_context_notification_changed-attributes_changed-attributes",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve changed-attributes",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2332,28 +2797,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: changed-attributes",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve changed-attributes",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_changed-attributes_changed-attributes"
+                ]
             }
         },
         "/config/context/notification/{uuid}/changed-attributes/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: changed-attributes",
+                "operationId": "retrieve_context_notification_changed-attributes_changed-attributes_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve changed-attributes by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2365,35 +2837,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: changed-attributes",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve changed-attributes by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_changed-attributes_changed-attributes_by_id"
+                ]
             }
         },
         "/config/context/notification/{uuid}/additional-info/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: additional-info",
+                "operationId": "retrieve_context_notification_additional-info_additional-info",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve additional-info",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2409,28 +2874,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: additional-info",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve additional-info",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_additional-info_additional-info"
+                ]
             }
         },
         "/config/context/notification/{uuid}/additional-info/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: additional-info",
+                "operationId": "retrieve_context_notification_additional-info_additional-info_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve additional-info by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2442,35 +2914,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: additional-info",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve additional-info by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_additional-info_additional-info_by_id"
+                ]
             }
         },
         "/config/context/notification/{uuid}/name/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notification_name_name",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2486,28 +2951,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_name_name"
+                ]
             }
         },
         "/config/context/notification/{uuid}/name/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_notification_name_name_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2519,35 +2991,28 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_name_name_by_id"
+                ]
             }
         },
         "/config/context/notification/{uuid}/label/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notification_label_label",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2563,28 +3028,35 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_label_label"
+                ]
             }
         },
         "/config/context/notification/{uuid}/label/{value-name}/": {
             "get": {
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "name": "uuid",
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "name": "value-name",
+                        "type": "string",
+                        "in": "path"
+                    }
+                ],
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_notification_label_label_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2596,38 +3068,22 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_notification_label_label_by_id"
+                ]
             }
         },
         "/streams/notification/": {
             "get": {
+                "description": "Retrieve operation of resource: notification",
+                "operationId": "retrieve_notification_by_id",
                 "schemes": [
                     "ws"
                 ],
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve notification by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2641,17 +3097,17 @@
                 },
                 "produces": [
                     "application/json"
-                ],
-                "description": "Retrieve operation of resource: notification",
-                "summary": "Retrieve notification by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_notification_by_id"
+                ]
             }
         },
         "/operations/get-supported-notification-types/": {
             "post": {
+                "description": "Create operation of resource: get-supported-notification-types",
+                "operationId": "create_get-supported-notification-types_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-supported-notification-types by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2663,19 +3119,30 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-supported-notification-types",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-supported-notification-types by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-supported-notification-types_by_id"
+                ]
             }
         },
         "/operations/create-notification-subscription-service/": {
             "post": {
+                "parameters": [
+                    {
+                        "description": "create-notification-subscription-servicebody object",
+                        "required": true,
+                        "name": "create-notification-subscription-service",
+                        "schema": {
+                            "$ref": "#/definitions/create-notification-subscription-serviceRPC_input_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: create-notification-subscription-service",
+                "operationId": "create_create-notification-subscription-service_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create create-notification-subscription-service by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2687,30 +3154,30 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: create-notification-subscription-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "create-notification-subscription-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/create-notification-subscription-serviceRPC_input_schema"
-                        },
-                        "name": "create-notification-subscription-service",
-                        "in": "body"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create create-notification-subscription-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_create-notification-subscription-service_by_id"
+                ]
             }
         },
         "/operations/update-notification-subscription-service/": {
             "post": {
+                "parameters": [
+                    {
+                        "description": "update-notification-subscription-servicebody object",
+                        "required": true,
+                        "name": "update-notification-subscription-service",
+                        "schema": {
+                            "$ref": "#/definitions/update-notification-subscription-serviceRPC_input_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: update-notification-subscription-service",
+                "operationId": "create_update-notification-subscription-service_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create update-notification-subscription-service by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2722,30 +3189,30 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: update-notification-subscription-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "update-notification-subscription-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/update-notification-subscription-serviceRPC_input_schema"
-                        },
-                        "name": "update-notification-subscription-service",
-                        "in": "body"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create update-notification-subscription-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_update-notification-subscription-service_by_id"
+                ]
             }
         },
         "/operations/delete-notification-subscription-service/": {
             "post": {
+                "parameters": [
+                    {
+                        "description": "delete-notification-subscription-servicebody object",
+                        "required": true,
+                        "name": "delete-notification-subscription-service",
+                        "schema": {
+                            "$ref": "#/definitions/delete-notification-subscription-serviceRPC_input_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: delete-notification-subscription-service",
+                "operationId": "create_delete-notification-subscription-service_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create delete-notification-subscription-service by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2757,30 +3224,30 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: delete-notification-subscription-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "delete-notification-subscription-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/delete-notification-subscription-serviceRPC_input_schema"
-                        },
-                        "name": "delete-notification-subscription-service",
-                        "in": "body"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create delete-notification-subscription-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_delete-notification-subscription-service_by_id"
+                ]
             }
         },
         "/operations/get-notification-subscription-service-details/": {
             "post": {
+                "parameters": [
+                    {
+                        "description": "get-notification-subscription-service-detailsbody object",
+                        "required": true,
+                        "name": "get-notification-subscription-service-details",
+                        "schema": {
+                            "$ref": "#/definitions/get-notification-subscription-service-detailsRPC_input_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: get-notification-subscription-service-details",
+                "operationId": "create_get-notification-subscription-service-details_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-notification-subscription-service-details by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2792,30 +3259,19 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-notification-subscription-service-details",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-notification-subscription-service-detailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-notification-subscription-service-detailsRPC_input_schema"
-                        },
-                        "name": "get-notification-subscription-service-details",
-                        "in": "body"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-notification-subscription-service-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-notification-subscription-service-details_by_id"
+                ]
             }
         },
         "/operations/get-notification-subscription-service-list/": {
             "post": {
+                "description": "Create operation of resource: get-notification-subscription-service-list",
+                "operationId": "create_get-notification-subscription-service-list_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-notification-subscription-service-list by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2827,19 +3283,30 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-notification-subscription-service-list",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-notification-subscription-service-list by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-notification-subscription-service-list_by_id"
+                ]
             }
         },
         "/operations/get-notification-list/": {
             "post": {
+                "parameters": [
+                    {
+                        "description": "get-notification-listbody object",
+                        "required": true,
+                        "name": "get-notification-list",
+                        "schema": {
+                            "$ref": "#/definitions/get-notification-listRPC_input_schema"
+                        },
+                        "in": "body"
+                    }
+                ],
+                "description": "Create operation of resource: get-notification-list",
+                "operationId": "create_get-notification-list_by_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-notification-list by ID",
                 "responses": {
                     "200": {
                         "description": "Successful operation",
@@ -2851,30 +3318,31 @@
                         "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-notification-list",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-notification-listbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-notification-listRPC_input_schema"
-                        },
-                        "name": "get-notification-list",
-                        "in": "body"
-                    }
-                ],
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-notification-list by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-notification-list_by_id"
+                ]
             }
         }
     },
     "definitions": {
+        "notification-context": {
+            "properties": {
+                "notification": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/notification"
+                    },
+                    "x-key": "uuid"
+                },
+                "notif-subscription": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/notification-subscription-service"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
         "notification-subscription-service": {
             "allOf": [
                 {
@@ -2882,19 +3350,10 @@
                 },
                 {
                     "properties": {
-                        "supported-notification-types": {
-                            "items": {
-                                "enum": [
-                                    "object-creation",
-                                    "object-deletion",
-                                    "attribute-value-change"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
                         "supported-object-types": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "topology",
                                     "node",
@@ -2907,34 +3366,60 @@
                                     "node-edge-point",
                                     "service-end-point",
                                     "connection-end-point"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
+                                ]
+                            }
+                        },
+                        "subscription-state": {
+                            "type": "string",
+                            "enum": [
+                                "suspended",
+                                "active"
+                            ]
                         },
                         "notification": {
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/notification"
                             },
-                            "type": "array",
                             "x-key": "uuid"
                         },
                         "subscription-filter": {
                             "$ref": "#/definitions/subscription-filter"
                         },
-                        "subscription-state": {
-                            "enum": [
-                                "suspended",
-                                "active"
-                            ],
-                            "type": "string"
-                        },
                         "notification-channel": {
                             "$ref": "#/definitions/notification-channel"
+                        },
+                        "supported-notification-types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "object-creation",
+                                    "object-deletion",
+                                    "attribute-value-change"
+                                ]
+                            }
                         }
                     }
                 }
             ]
+        },
+        "name-and-value-change": {
+            "description": "A scoped name-value triple, including old value and new value",
+            "properties": {
+                "new-value": {
+                    "type": "string",
+                    "description": "The value"
+                },
+                "old-value": {
+                    "type": "string",
+                    "description": "The value"
+                },
+                "value-name": {
+                    "type": "string",
+                    "description": "The name of the value. The value need not have a name."
+                }
+            }
         },
         "notification": {
             "allOf": [
@@ -2943,29 +3428,8 @@
                 },
                 {
                     "properties": {
-                        "target-object-name": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "x-key": "value-name"
-                        },
-                        "additional-info": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "x-key": "value-name"
-                        },
-                        "notification-type": {
-                            "enum": [
-                                "object-creation",
-                                "object-deletion",
-                                "attribute-value-change"
-                            ],
-                            "type": "string"
-                        },
                         "target-object-type": {
+                            "type": "string",
                             "enum": [
                                 "topology",
                                 "node",
@@ -2978,45 +3442,66 @@
                                 "node-edge-point",
                                 "service-end-point",
                                 "connection-end-point"
-                            ],
-                            "type": "string"
+                            ]
                         },
-                        "changed-attributes": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value-change"
-                            },
-                            "type": "array",
-                            "x-key": "value-name"
-                        },
-                        "layer-protocol-name": {
+                        "notification-type": {
+                            "type": "string",
                             "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string"
+                                "object-creation",
+                                "object-deletion",
+                                "attribute-value-change"
+                            ]
                         },
-                        "additional-text": {
-                            "type": "string"
+                        "additional-info": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
                         },
                         "event-time-stamp": {
                             "type": "string"
                         },
-                        "target-object-identifier": {
+                        "changed-attributes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value-change"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "additional-text": {
                             "type": "string"
                         },
                         "sequence-number": {
                             "type": "string",
                             "description": "A monotonous increasing sequence number associated with the notification.\nThe exact semantics of how this sequence number is assigned (per channel or subscription or source or system) is left undefined."
                         },
+                        "target-object-identifier": {
+                            "type": "string"
+                        },
                         "source-indicator": {
+                            "type": "string",
                             "enum": [
                                 "resource-operation",
                                 "management-operation",
                                 "unknown"
-                            ],
-                            "type": "string"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "target-object-name": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
                         }
                     }
                 }
@@ -3030,40 +3515,32 @@
                 {
                     "properties": {
                         "requested-notification-types": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "object-creation",
                                     "object-deletion",
                                     "attribute-value-change"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
+                                ]
+                            }
                         },
                         "requested-layer-protocols": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "och",
                                     "odu",
                                     "eth",
                                     "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "requested-object-identifier": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "include-content": {
-                            "type": "boolean",
-                            "description": "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)"
+                                ]
+                            }
                         },
                         "requested-object-types": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "topology",
                                     "node",
@@ -3076,49 +3553,22 @@
                                     "node-edge-point",
                                     "service-end-point",
                                     "connection-end-point"
-                                ],
+                                ]
+                            }
+                        },
+                        "requested-object-identifier": {
+                            "type": "array",
+                            "items": {
                                 "type": "string"
-                            },
-                            "type": "array"
+                            }
+                        },
+                        "include-content": {
+                            "type": "boolean",
+                            "description": "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)"
                         }
                     }
                 }
             ]
-        },
-        "notification-context": {
-            "properties": {
-                "notification": {
-                    "items": {
-                        "$ref": "#/definitions/notification"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                },
-                "notif-subscription": {
-                    "items": {
-                        "$ref": "#/definitions/notification-subscription-service"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "name-and-value-change": {
-            "description": "A scoped name-value triple, including old value and new value",
-            "properties": {
-                "old-value": {
-                    "type": "string",
-                    "description": "The value"
-                },
-                "new-value": {
-                    "type": "string",
-                    "description": "The value"
-                },
-                "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
-                }
-            }
         },
         "notification-channel": {
             "allOf": [
@@ -3127,13 +3577,53 @@
                 },
                 {
                     "properties": {
-                        "stream-address": {
-                            "type": "string",
-                            "description": "The address/location/URI of the channel/stream to which the subscribed notifications are published.\nThis specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string."
-                        },
                         "next-sequence-no": {
                             "type": "string",
                             "description": "The sequence number of the next notification that will be published on the channel"
+                        },
+                        "stream-address": {
+                            "type": "string",
+                            "description": "The address/location/URI of the channel/stream to which the subscribed notifications are published.\nThis specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string."
+                        }
+                    }
+                }
+            ]
+        },
+        "time-range": {
+            "properties": {
+                "start-time": {
+                    "type": "string"
+                },
+                "end-time": {
+                    "type": "string"
+                }
+            }
+        },
+        "layer-protocol": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "termination-direction": {
+                            "type": "string",
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
                         }
                     }
                 }
@@ -3148,66 +3638,60 @@
                 {
                     "properties": {
                         "service-end-point": {
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/service-end-point"
                             },
-                            "type": "array",
                             "x-key": "uuid"
                         }
                     }
                 }
             ]
         },
-        "operational-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
+        "global-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
-                "lifecycle-state": {
-                    "type": "string"
+                "uuid": {
+                    "type": "string",
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
                 },
-                "operational-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
+                "label": {
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    }
                 },
-                "start-time": {
-                    "type": "string"
-                }
-            }
-        },
-        "layer-protocol": {
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "termination-state": {
-                            "type": "string",
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        }
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
                     }
                 }
-            ]
+            }
+        },
+        "resource-spec": {
+            "$ref": "#/definitions/global-class"
+        },
+        "service-spec": {
+            "$ref": "#/definitions/global-class"
+        },
+        "admin-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
+            "properties": {
+                "operational-state": {
+                    "type": "string"
+                },
+                "administrative-state": {
+                    "type": "string"
+                },
+                "lifecycle-state": {
+                    "type": "string"
+                }
+            }
         },
         "name-and-value": {
             "description": "A scoped name-value pair",
@@ -3222,19 +3706,14 @@
                 }
             }
         },
-        "local-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+        "operational-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
             "properties": {
-                "local-id": {
+                "operational-state": {
                     "type": "string"
                 },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                "lifecycle-state": {
+                    "type": "string"
                 }
             }
         },
@@ -3247,21 +3726,37 @@
                 {
                     "properties": {
                         "layer-protocol": {
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/layer-protocol"
                             },
-                            "type": "array",
                             "x-key": "local-id"
-                        },
-                        "direction": {
-                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/lifecycle-state-pac"
+                        },
+                        "direction": {
+                            "type": "string"
                         }
                     }
                 }
             ]
+        },
+        "local-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+            "properties": {
+                "local-id": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    }
+                }
+            }
         },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
@@ -3271,51 +3766,6 @@
                 }
             }
         },
-        "admin-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
-            "properties": {
-                "administrative-state": {
-                    "type": "string"
-                },
-                "lifecycle-state": {
-                    "type": "string"
-                },
-                "operational-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "service-spec": {
-            "$ref": "#/definitions/global-class"
-        },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
-            "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
-                },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
-                }
-            }
-        },
-        "resource-spec": {
-            "$ref": "#/definitions/global-class"
-        },
         "context_schema": {
             "allOf": [
                 {
@@ -3323,39 +3773,39 @@
                 },
                 {
                     "properties": {
-                        "notification": {
-                            "items": {
-                                "$ref": "#/definitions/notification"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "value-name"
-                        },
                         "uuid": {
                             "type": "string",
                             "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
                         },
                         "notif-subscription": {
+                            "type": "array",
                             "items": {
                                 "$ref": "#/definitions/notification-subscription-service"
                             },
+                            "x-key": "uuid"
+                        },
+                        "label": {
+                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
                             "type": "array",
+                            "x-key": "value-name",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            }
+                        },
+                        "notification": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/notification"
+                            },
                             "x-key": "uuid"
                         },
                         "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "x-key": "value-name",
                             "items": {
                                 "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "value-name"
+                            }
                         }
                     }
                 }
@@ -3363,19 +3813,10 @@
         },
         "get-supported-notification-typesRPC_output_schema": {
             "properties": {
-                "supported-notification-types": {
-                    "items": {
-                        "enum": [
-                            "object-creation",
-                            "object-deletion",
-                            "attribute-value-change"
-                        ],
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "supported-object-types": {
+                    "type": "array",
                     "items": {
+                        "type": "string",
                         "enum": [
                             "topology",
                             "node",
@@ -3388,10 +3829,19 @@
                             "node-edge-point",
                             "service-end-point",
                             "connection-end-point"
-                        ],
-                        "type": "string"
-                    },
-                    "type": "array"
+                        ]
+                    }
+                },
+                "supported-notification-types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "object-creation",
+                            "object-deletion",
+                            "attribute-value-change"
+                        ]
+                    }
                 }
             }
         },
@@ -3401,11 +3851,11 @@
                     "$ref": "#/definitions/subscription-filter"
                 },
                 "subscription-state": {
+                    "type": "string",
                     "enum": [
                         "suspended",
                         "active"
-                    ],
-                    "type": "string"
+                    ]
                 }
             }
         },
@@ -3425,11 +3875,11 @@
                     "type": "string"
                 },
                 "subscription-state": {
+                    "type": "string",
                     "enum": [
                         "suspended",
                         "active"
-                    ],
-                    "type": "string"
+                    ]
                 }
             }
         },
@@ -3471,19 +3921,19 @@
         "get-notification-subscription-service-listRPC_output_schema": {
             "properties": {
                 "subscription-service": {
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/notification-subscription-service"
-                    },
-                    "type": "array"
+                    }
                 }
             }
         },
         "get-notification-listRPC_input_schema": {
             "properties": {
-                "subscription-id-or-name": {
+                "time-period": {
                     "type": "string"
                 },
-                "time-period": {
+                "subscription-id-or-name": {
                     "type": "string"
                 }
             }
@@ -3491,10 +3941,10 @@
         "get-notification-listRPC_output_schema": {
             "properties": {
                 "notification": {
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/notification"
-                    },
-                    "type": "array"
+                    }
                 }
             }
         }

--- a/SWAGGER/tapi-och.swagger
+++ b/SWAGGER/tapi-och.swagger
@@ -1,8 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-och API generated from tapi-och.yang",
+        "version": "1.0.0",
         "title": "tapi-och API"
     },
     "host": "localhost:8080",
@@ -12,60 +12,58 @@
     ],
     "paths": {},
     "definitions": {
-        "connection-end-point-lp-spec": {
-            "properties": {
-                "termination-spec": {
-                    "$ref": "#/definitions/termination-pac"
-                },
-                "adapter-spec": {
-                    "$ref": "#/definitions/adapter-and-connection-point-pac"
-                }
-            }
-        },
         "adapter-and-connection-point-pac": {
             "properties": {
                 "monitored-direction": {
+                    "description": "This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK.",
                     "enum": [
                         "sink",
                         "source"
                     ],
-                    "type": "string",
-                    "description": "This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK."
-                }
-            }
-        },
-        "termination-pac": {
-            "properties": {
-                "selected-application-identifier": {
-                    "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
-                    "$ref": "#/definitions/application-identifier"
-                },
-                "nominal-central-frequency-or-wavelength": {
-                    "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
-                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    "type": "string"
                 }
             }
         },
         "pool-property-pac": {
             "properties": {
+                "max-client-instances": {
+                    "type": "string"
+                },
                 "client-capacity": {
                     "type": "string"
                 },
                 "max-client-size": {
                     "type": "string"
+                }
+            }
+        },
+        "nominal-central-frequency-or-wavelength": {
+            "properties": {
+                "nominal-central-frequency-or-wavelength": {
+                    "type": "string"
                 },
-                "max-client-instances": {
+                "link-type": {
                     "type": "string"
                 }
             }
         },
         "application-identifier": {
             "properties": {
-                "application-identifier-value": {
-                    "type": "string"
-                },
                 "application-identifier-type": {
                     "type": "string"
+                },
+                "application-identifier-value": {
+                    "type": "string"
+                }
+            }
+        },
+        "connection-end-point-lp-spec": {
+            "properties": {
+                "adapter-spec": {
+                    "$ref": "#/definitions/adapter-and-connection-point-pac"
+                },
+                "termination-spec": {
+                    "$ref": "#/definitions/termination-pac"
                 }
             }
         },
@@ -76,13 +74,15 @@
                 }
             }
         },
-        "nominal-central-frequency-or-wavelength": {
+        "termination-pac": {
             "properties": {
-                "link-type": {
-                    "type": "string"
-                },
                 "nominal-central-frequency-or-wavelength": {
-                    "type": "string"
+                    "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
+                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                },
+                "selected-application-identifier": {
+                    "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
+                    "$ref": "#/definitions/application-identifier"
                 }
             }
         }

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -1,8 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-odu API generated from tapi-odu.yang",
+        "version": "1.0.0",
         "title": "tapi-odu API"
     },
     "host": "localhost:8080",
@@ -12,42 +12,93 @@
     ],
     "paths": {},
     "definitions": {
+        "oduk-h-nominal-bit-rate-and-tolerance": {
+            "description": "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
+            "properties": {
+                "tolerance": {
+                    "description": "tolerance in ppm",
+                    "type": "string"
+                },
+                "frequency": {
+                    "description": "frequency in kilohertz",
+                    "type": "string"
+                }
+            }
+        },
         "connection-end-point-lp-spec": {
             "properties": {
-                "termination-spec": {
-                    "$ref": "#/definitions/termination-pac"
-                },
                 "adapter-spec": {
                     "$ref": "#/definitions/adapter-and-connection-point-pac"
+                },
+                "termination-spec": {
+                    "$ref": "#/definitions/termination-pac"
+                }
+            }
+        },
+        "pool-property-pac": {
+            "properties": {
+                "max-client-instances": {
+                    "type": "string"
+                },
+                "max-client-size": {
+                    "type": "string"
+                },
+                "client-capacity": {
+                    "type": "string"
                 }
             }
         },
         "adapter-and-connection-point-pac": {
             "properties": {
+                "aps-enable": {
+                    "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.",
+                    "type": "boolean"
+                },
+                "adaptation-active": {
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point.",
+                    "type": "boolean"
+                },
                 "auto-payload-type": {
-                    "type": "boolean",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. ",
+                    "type": "boolean"
                 },
                 "aps-level": {
-                    "type": "string",
-                    "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
-                },
-                "inserted-payload-type": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. "
+                    "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.",
+                    "type": "string"
                 },
                 "accepted-msi": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. ",
+                    "type": "string"
+                },
+                "nominal-bit-rate-and-tolerance": {
+                    "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
+                    "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
+                },
+                "odu-type-and-rate": {
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G",
+                    "type": "string"
                 },
                 "position-seq": {
                     "items": {
-                        "type": "string",
-                        "description": "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.\nThe order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.\nWithin the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.\nThe syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.\nThe order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).\nIf a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.\n"
+                        "description": "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.\nThe order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.\nWithin the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.\nThe syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.\nThe order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).\nIf a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.\n",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "accepted-payload-type": {
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. ",
+                    "type": "string"
+                },
+                "current-number-of-tributary-slots": {
+                    "items": {
+                        "description": "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. \nThe upper bound of this attribute is dependent on the HO-ODUk server layer. \nWhen the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):\n- After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)\n- After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)\nThis attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n",
+                        "type": "string"
                     },
                     "type": "array"
                 },
                 "k": {
+                    "description": "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.\n",
+                    "type": "string",
                     "enum": [
                         "1.25-g",
                         "2.5-g",
@@ -57,147 +108,89 @@
                         "100-g",
                         "flex-cbr",
                         "flex-gfp"
-                    ],
-                    "type": "string",
-                    "description": "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.\n"
-                },
-                "odu-type-and-rate": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G"
-                },
-                "aps-enable": {
-                    "type": "boolean",
-                    "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
-                },
-                "expected-msi": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. "
+                    ]
                 },
                 "tributary-slot-list": {
                     "items": {
-                        "type": "string",
-                        "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
+                        "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).",
+                        "type": "string"
                     },
                     "type": "array"
                 },
                 "transmitted-msi": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function."
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function.",
+                    "type": "string"
                 },
-                "current-number-of-tributary-slots": {
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. \nThe upper bound of this attribute is dependent on the HO-ODUk server layer. \nWhen the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):\n- After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)\n- After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)\nThis attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n"
-                    },
-                    "type": "array"
-                },
-                "nominal-bit-rate-and-tolerance": {
-                    "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                    "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
+                "inserted-payload-type": {
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. ",
+                    "type": "string"
                 },
                 "applicable-problems": {
+                    "description": "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList.",
+                    "type": "string",
                     "enum": [
                         "plm",
                         "msim",
                         "lof-lom",
                         "loomfi"
-                    ],
-                    "type": "string",
-                    "description": "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList."
+                    ]
                 },
-                "accepted-payload-type": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. "
-                },
-                "adaptation-active": {
-                    "type": "boolean",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point."
+                "expected-msi": {
+                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. ",
+                    "type": "string"
                 }
             }
         },
         "termination-pac": {
             "properties": {
-                "tim-act-disabled": {
-                    "type": "boolean",
-                    "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled."
+                "dm-source": {
+                    "description": "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue.",
+                    "type": "boolean"
+                },
+                "ex-dapi": {
+                    "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.",
+                    "type": "string"
+                },
+                "rate": {
+                    "description": "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n",
+                    "type": "string"
                 },
                 "deg-m": {
-                    "type": "string",
-                    "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected."
+                    "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.",
+                    "type": "string"
                 },
                 "txti": {
-                    "type": "string",
-                    "description": "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission."
-                },
-                "dm-value": {
-                    "type": "boolean",
-                    "description": "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1."
+                    "description": "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.",
+                    "type": "string"
                 },
                 "deg-thr": {
                     "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
                     "$ref": "#/definitions/deg-thr"
                 },
+                "dm-value": {
+                    "description": "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1.",
+                    "type": "boolean"
+                },
+                "ex-sapi": {
+                    "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.",
+                    "type": "string"
+                },
                 "tim-det-mode": {
+                    "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI",
+                    "type": "string",
                     "enum": [
                         "dapi",
                         "sapi",
                         "both"
-                    ],
-                    "type": "string",
-                    "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI"
+                    ]
+                },
+                "tim-act-disabled": {
+                    "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled.",
+                    "type": "boolean"
                 },
                 "acti": {
-                    "type": "string",
-                    "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail."
-                },
-                "rate": {
-                    "type": "string",
-                    "description": "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n"
-                },
-                "ex-dapi": {
-                    "type": "string",
-                    "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
-                },
-                "dm-source": {
-                    "type": "boolean",
-                    "description": "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue."
-                },
-                "ex-sapi": {
-                    "type": "string",
-                    "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
-                }
-            }
-        },
-        "pool-property-pac": {
-            "properties": {
-                "client-capacity": {
+                    "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.",
                     "type": "string"
-                },
-                "max-client-size": {
-                    "type": "string"
-                },
-                "max-client-instances": {
-                    "type": "string"
-                }
-            }
-        },
-        "oduk-h-nominal-bit-rate-and-tolerance": {
-            "description": "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-            "properties": {
-                "frequency": {
-                    "type": "string",
-                    "description": "frequency in kilohertz"
-                },
-                "tolerance": {
-                    "type": "string",
-                    "description": "tolerance in ppm"
-                }
-            }
-        },
-        "node-edge-point-lp-spec": {
-            "properties": {
-                "odu-pool-property-spec": {
-                    "$ref": "#/definitions/pool-property-pac"
                 }
             }
         },
@@ -205,15 +198,22 @@
             "description": "Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. \ndegThrValue when type is PERCENTAGE:\npercentageGranularity is used to indicate the number of decimal points\nSo if percentageGranularity is 0 a value of 1 in degThrValue would indicate 1%, a value of 10 = 10%, a value of 100 = 100%\nSo if percentageGranularity is 3 (thousandths) a value of 1 in degThrValue would indicate 0.001%, a value of 1000 = 1%, a value of 1000000 = 100%\ndegThrValue when type is NUMBER_ERROR_BLOCKS:\nNumber of Errored Blocks is captured in an integer value.",
             "properties": {
                 "deg-thr-value": {
-                    "type": "string",
-                    "description": "Percentage of detected errored blocks"
-                },
-                "percentage-granularity": {
+                    "description": "Percentage of detected errored blocks",
                     "type": "string"
                 },
                 "deg-thr-type": {
-                    "type": "string",
-                    "description": "Number of errored blocks"
+                    "description": "Number of errored blocks",
+                    "type": "string"
+                },
+                "percentage-granularity": {
+                    "type": "string"
+                }
+            }
+        },
+        "node-edge-point-lp-spec": {
+            "properties": {
+                "odu-pool-property-spec": {
+                    "$ref": "#/definitions/pool-property-pac"
                 }
             }
         }

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -1,9 +1,9 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-path-computation API generated from tapi-path-computation.yang",
-        "title": "tapi-path-computation API"
+        "title": "tapi-path-computation API",
+        "version": "1.0.0"
     },
     "host": "localhost:8080",
     "basePath": "/restconf",
@@ -12,6918 +12,7372 @@
     ],
     "paths": {
         "/config/context/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_by_id"
-            },
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Create operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Create context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_context_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "contextbody object",
+                        "name": "context",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "required": true
                     }
-                },
+                ],
+                "operationId": "create_context_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: context",
+                "summary": "Retrieve context",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "operationId": "retrieve_context",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        }
+                    }
+                }
+            },
+            "delete": {
                 "description": "Delete operation of resource: context",
                 "summary": "Delete context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: context",
-                "parameters": [],
+                "operationId": "delete_context_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve context",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: context",
+                "summary": "Update context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context"
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "contextbody object",
+                        "name": "context",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/service-end-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve service-end-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
+                "parameters": [],
+                "operationId": "retrieve_context_service-end-point_service-end-point",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/layer-protocol/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/service-end-point/{uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
+                }
+            }
+        },
+        "/config/context/service-end-point/{uuid}/": {
+            "get": {
+                "description": "Retrieve operation of resource: service-end-point",
+                "summary": "Retrieve service-end-point by ID",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/service-end-point"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/service-end-point/{uuid}/layer-protocol/": {
+            "get": {
+                "description": "Retrieve operation of resource: layer-protocol",
                 "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "description": "Retrieve operation of resource: layer-protocol",
+                "summary": "Retrieve layer-protocol by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "summary": "Retrieve state",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_state_state",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/lifecycle-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_label_label"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_label_label",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                }
             }
         },
         "/config/context/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name"
-            }
-        },
-        "/config/context/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
+                "parameters": [],
+                "operationId": "retrieve_context_name_name",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
-            },
-            "post": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
                     },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_name_name_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_name_name_by_id"
-            }
-        },
-        "/config/context/label/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/label/{value-name}/"
+                                "x-path": "/context/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_label_label"
+                }
             }
         },
-        "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
+        "/config/context/name/{value-name}/": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
                         "name": "value-name",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
-                        "required": true,
-                        "description": "labelbody object",
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         },
-                        "name": "label",
-                        "in": "body"
+                        "required": true
                     }
                 ],
+                "operationId": "create_context_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
-            "delete": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_label_label_by_id"
+                }
             },
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
                         "name": "value-name",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "delete_context_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            }
+        },
+        "/config/context/label/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "operationId": "retrieve_context_label_label",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/label/{value-name}/": {
+            "post": {
+                "description": "Create operation of resource: label",
+                "summary": "Create label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: label",
                 "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: label",
+                "summary": "Delete label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: label",
+                "summary": "Update label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/nw-topology-service/": {
             "get": {
+                "description": "Retrieve operation of resource: nw-topology-service",
+                "summary": "Retrieve nw-topology-service",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "operationId": "retrieve_context_nw-topology-service_nw-topology-service",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/network-topology-service"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: nw-topology-service",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve nw-topology-service",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_nw-topology-service"
+                }
             }
         },
         "/config/context/nw-topology-service/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name"
+                "parameters": [],
+                "operationId": "retrieve_context_nw-topology-service_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/nw-topology-service/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/nw-topology-service/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name_by_id"
-            }
-        },
-        "/config/context/nw-topology-service/label/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
+                ],
+                "operationId": "retrieve_context_nw-topology-service_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_label_label"
-            }
-        },
-        "/config/context/nw-topology-service/label/{value-name}/": {
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
+                }
+            }
+        },
+        "/config/context/nw-topology-service/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
+                "summary": "Retrieve label",
+                "consumes": [
+                    "application/json"
                 ],
+                "parameters": [],
+                "operationId": "retrieve_context_nw-topology-service_label_label",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/nw-topology-service/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/nw-topology-service/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
                 "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_label_label_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_nw-topology-service_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: topology",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve topology",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_topology"
-            }
-        },
-        "/config/context/topology/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
+                "parameters": [],
+                "operationId": "retrieve_context_topology_topology",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_topology_by_id"
-            },
-            "post": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_topology_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_topology_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/node/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/"
+                                "x-path": "/context/topology/{uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: node",
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/": {
+            "get": {
+                "description": "Retrieve operation of resource: topology",
+                "summary": "Retrieve topology by ID",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_topology_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/topology"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/": {
+            "get": {
+                "description": "Retrieve operation of resource: node",
                 "summary": "Retrieve node",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_node"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_node",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: node",
+                "summary": "Retrieve node by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_node_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: node",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_node_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: owned-node-edge-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve owned-node-edge-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "summary": "Retrieve owned-node-edge-point by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: owned-node-edge-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "description": "Retrieve operation of resource: layer-protocol",
+                "summary": "Retrieve layer-protocol by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "summary": "Retrieve state",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "node_uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
-            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "node_uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
                 "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "name": "owned-node-edge-point_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "summary": "Retrieve state",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_state_state",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_state_state"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "summary": "Retrieve transfer-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "summary": "Retrieve total-potential-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: available-capacity",
+                "summary": "Retrieve available-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of total-size",
+                        "name": "total-size",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-cost",
+                "summary": "Retrieve transfer-cost",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "summary": "Retrieve cost-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "summary": "Retrieve transfer-integrity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-timing",
+                "summary": "Retrieve transfer-timing",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "summary": "Retrieve latency-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "node_uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_node_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_label_label_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/link/": {
-            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_node_label_label",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: link",
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label by ID",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of node_uuid",
+                        "name": "node_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_node_label_label_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/": {
+            "get": {
+                "description": "Retrieve operation of resource: link",
                 "summary": "Retrieve link",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_link"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_link",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: link",
+                "summary": "Retrieve link by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_link_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: link",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_link_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "summary": "Retrieve state",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_state_state",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_state_state"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "summary": "Retrieve transfer-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "summary": "Retrieve total-potential-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: available-capacity",
+                "summary": "Retrieve available-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of total-size",
+                        "name": "total-size",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-cost",
+                "summary": "Retrieve transfer-cost",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "summary": "Retrieve cost-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "summary": "Retrieve transfer-integrity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-timing",
+                "summary": "Retrieve transfer-timing",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "summary": "Retrieve latency-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
             "get": {
+                "description": "Retrieve operation of resource: risk-parameter",
+                "summary": "Retrieve risk-parameter",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-parameter-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: risk-parameter",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-parameter",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve risk-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "summary": "Retrieve risk-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of risk-characteristic-name",
+                        "name": "risk-characteristic-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "risk-characteristic-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
             "get": {
+                "description": "Retrieve operation of resource: validation",
+                "summary": "Retrieve validation",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_validation_validation",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: validation",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: validation-mechanism",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve validation-mechanism",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/": {
             "get": {
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "summary": "Retrieve validation-mechanism by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-mechanism"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "required": true,
-                        "type": "string",
-                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
             "get": {
+                "description": "Retrieve operation of resource: lp-transition",
+                "summary": "Retrieve lp-transition",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: lp-transition",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve lp-transition",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_name_name_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_label_label"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_label_label",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of link_uuid",
+                        "name": "link_uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_link_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_label_label_by_id"
+                }
             }
         },
         "/config/context/topology/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_name_name"
-            }
-        },
-        "/config/context/topology/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_name_name",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_name_name_by_id"
-            },
-            "post": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_name_name_by_id"
-            },
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/name-and-value"
+                            "items": {
+                                "x-path": "/context/topology/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/name/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_name_name_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
             }
         },
         "/config/context/topology/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_topology_label_label",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_label_label_by_id"
-            },
-            "post": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_label_label_by_id"
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label_by_id"
-            }
-        },
-        "/config/context/path-comp-service/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/"
+                                "x-path": "/context/topology/{uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: path-comp-service",
-                "parameters": [],
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_topology_label_label_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path-comp-service/": {
+            "get": {
+                "description": "Retrieve operation of resource: path-comp-service",
                 "summary": "Retrieve path-comp-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_path-comp-service"
+                "parameters": [],
+                "operationId": "retrieve_context_path-comp-service_path-comp-service",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: path-comp-service",
+                "summary": "Create path-comp-service by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "path-comp-servicebody object",
+                        "name": "path-comp-service",
+                        "schema": {
+                            "$ref": "#/definitions/path-computation-service"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_path-comp-service_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: path-comp-service",
+                "summary": "Retrieve path-comp-service by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_path-comp-service_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/path-computation-service"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: path-comp-service",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path-comp-service by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: path-comp-service",
+                "summary": "Delete path-comp-service by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_path-comp-service_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_path-comp-service_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: path-comp-service",
+                "summary": "Update path-comp-service by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "path-comp-servicebody object",
+                        "name": "path-comp-service",
+                        "schema": {
+                            "$ref": "#/definitions/path-computation-service"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_path-comp-service_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve service-port",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_service-port"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_service-port",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: service-port",
+                "summary": "Create service-port by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "schema": {
+                            "$ref": "#/definitions/path-comp-service-port"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_service-port_service-port_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: service-port",
+                "summary": "Retrieve service-port by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_service-port_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/path-comp-service-port"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: service-port",
+                "summary": "Delete service-port by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_service-port_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_service-port_service-port_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: service-port",
+                "summary": "Update service-port by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "service-portbody object",
+                        "name": "service-port",
+                        "schema": {
+                            "$ref": "#/definitions/path-comp-service-port"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_service-port_service-port_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/service-port/{local-id}/name/{value-name}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_service-port_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_service-port_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_service-port_name_name_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_service-port_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_service-port_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: routing-constraint",
+                "summary": "Create routing-constraint by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "routing-constraintbody object",
+                        "name": "routing-constraint",
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: routing-constraint",
+                "summary": "Retrieve routing-constraint",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_routing-constraint",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/routing-constraint"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: routing-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve routing-constraint",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: routing-constraint",
+                "summary": "Delete routing-constraint by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_routing-constraint"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: routing-constraint",
+                "summary": "Update routing-constraint by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "routing-constraintbody object",
+                        "name": "routing-constraint",
+                        "schema": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_routing-constraint_routing-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/requested-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: requested-capacity",
+                "summary": "Retrieve requested-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_requested-capacity_requested-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_requested-capacity_requested-capacity"
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "summary": "Retrieve cost-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_cost-characteristic_cost-characteristic_by_id"
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "summary": "Retrieve latency-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_latency-characteristic_latency-characteristic_by_id"
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve include-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve include-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path_by_id"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
                         "name": "local-id",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_include-path_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
-            "get": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name_by_id"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/te-link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
                         "name": "local-id",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_include-path_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/": {
+            "get": {
+                "description": "Retrieve operation of resource: exclude-path",
+                "summary": "Retrieve exclude-path",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/": {
+            "get": {
+                "description": "Retrieve operation of resource: exclude-path",
                 "summary": "Retrieve exclude-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_exclude-path_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_exclude-path_name_name_by_id"
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/routing-constraint/name/{value-name}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_routing-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_routing-constraint_name_name_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_routing-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_routing-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: objective-function",
+                "summary": "Create objective-function by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "objective-functionbody object",
+                        "name": "objective-function",
+                        "schema": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_objective-function_objective-function_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: objective-function",
+                "summary": "Retrieve objective-function",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_objective-function_objective-function",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/path-objective-function"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: objective-function",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve objective-function",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: objective-function",
+                "summary": "Delete objective-function by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_objective-function"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_objective-function_objective-function_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: objective-function",
+                "summary": "Update objective-function by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "objective-functionbody object",
+                        "name": "objective-function",
+                        "schema": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_objective-function_objective-function_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/objective-function/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_objective-function_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/objective-function/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/objective-function/name/{value-name}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_objective-function_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_objective-function_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_objective-function_name_name_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_objective-function_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_objective-function_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: optimization-constraint",
+                "summary": "Create optimization-constraint by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "optimization-constraintbody object",
+                        "name": "optimization-constraint",
+                        "schema": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: optimization-constraint",
+                "summary": "Retrieve optimization-constraint",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_optimization-constraint",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/path-optimization-constraint"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: optimization-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve optimization-constraint",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: optimization-constraint",
+                "summary": "Delete optimization-constraint by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_optimization-constraint"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: optimization-constraint",
+                "summary": "Update optimization-constraint by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "optimization-constraintbody object",
+                        "name": "optimization-constraint",
+                        "schema": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_optimization-constraint_optimization-constraint_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/optimization-constraint/name/{value-name}/": {
-            "get": {
+            "post": {
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_optimization-constraint_name_name_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_optimization-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
         "/config/context/path-comp-service/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_name_name"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path-comp-service_name_name",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path-comp-service/{uuid}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/name/{value-name}/": {
+            "post": {
+                "description": "Create operation of resource: name",
+                "summary": "Create name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
                 "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_name_name_by_id"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/label/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path-comp-service/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path-comp-service_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path-comp-service_label_label"
-            }
-        },
-        "/config/context/path-comp-service/{uuid}/label/{value-name}/": {
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path-comp-service_label_label_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "summary": "Update name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "namebody object",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
             }
         },
-        "/config/context/path/": {
+        "/config/context/path-comp-service/{uuid}/label/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_label_label",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/"
+                                "x-path": "/context/path-comp-service/{uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: path",
-                "parameters": [],
+                }
+            }
+        },
+        "/config/context/path-comp-service/{uuid}/label/{value-name}/": {
+            "post": {
+                "description": "Create operation of resource: label",
+                "summary": "Create label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_context_path-comp-service_label_label_by_id",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path-comp-service_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete operation of resource: label",
+                "summary": "Delete label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "delete_context_path-comp-service_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            },
+            "put": {
+                "description": "Update operation of resource: label",
+                "summary": "Update label by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "body",
+                        "description": "labelbody object",
+                        "name": "label",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "update_context_path-comp-service_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                }
+            }
+        },
+        "/config/context/path/": {
+            "get": {
+                "description": "Retrieve operation of resource: path",
                 "summary": "Retrieve path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_path"
+                "parameters": [],
+                "operationId": "retrieve_context_path_path",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: path",
+                "summary": "Retrieve path by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_path_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/path"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve path by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_path_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/telink/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/telink/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: telink",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve telink",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_telink"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_telink_telink",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/telink/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/": {
             "get": {
+                "description": "Retrieve operation of resource: telink",
+                "summary": "Retrieve telink by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_telink_telink_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/te-link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: telink",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve telink by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_telink_telink_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/telink/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_telink_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_telink_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/telink/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/telink/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_telink_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_telink_name_name_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/": {
             "get": {
+                "description": "Retrieve operation of resource: routing-constraint",
+                "summary": "Retrieve routing-constraint",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_routing-constraint",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/routing-constraint"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: routing-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve routing-constraint",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_routing-constraint"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/requested-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: requested-capacity",
+                "summary": "Retrieve requested-capacity",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_requested-capacity_requested-capacity",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_requested-capacity_requested-capacity"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "summary": "Retrieve cost-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_cost-characteristic_cost-characteristic_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "summary": "Retrieve latency-characteristic by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_latency-characteristic_latency-characteristic_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve include-path",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/te-link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: include-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve include-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path_by_id"
-            }
-        },
-        "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
                         "name": "local-id",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path_routing-constraint_include-path_include-path_by_id",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name"
-            }
-        },
-        "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
-            "get": {
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name_by_id"
-            }
-        },
-        "/config/context/path/{uuid}/routing-constraint/exclude-path/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve exclude-path",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path"
-            }
-        },
-        "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/te-link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: exclude-path",
+                }
+            }
+        },
+        "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     },
                     {
+                        "in": "path",
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
                         "name": "local-id",
-                        "in": "path"
+                        "type": "string",
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path/{uuid}/routing-constraint/include-path/{local-id}/name/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_include-path_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path/{uuid}/routing-constraint/exclude-path/": {
+            "get": {
+                "description": "Retrieve operation of resource: exclude-path",
+                "summary": "Retrieve exclude-path",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/": {
+            "get": {
+                "description": "Retrieve operation of resource: exclude-path",
                 "summary": "Retrieve exclude-path by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_exclude-path_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/te-link"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/exclude-path/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of local-id",
+                        "name": "local-id",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_exclude-path_name_name_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/routing-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_routing-constraint_name_name"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_name_name",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/routing-constraint/name/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "/config/context/path/{uuid}/routing-constraint/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_routing-constraint_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_routing-constraint_name_name_by_id"
+                }
             }
         },
         "/config/context/path/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_name_name"
-            }
-        },
-        "/config/context/path/{uuid}/name/{value-name}/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path_name_name",
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_path_name_name_by_id"
-            }
-        },
-        "/config/context/path/{uuid}/label/": {
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/path/{uuid}/label/{value-name}/"
+                                "x-path": "/context/path/{uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
+                }
+            }
+        },
+        "/config/context/path/{uuid}/name/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_label_label"
-            }
-        },
-        "/config/context/path/{uuid}/label/{value-name}/": {
-            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
+                }
+            }
+        },
+        "/config/context/path/{uuid}/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
+                "summary": "Retrieve label",
+                "consumes": [
+                    "application/json"
+                ],
                 "parameters": [
                     {
+                        "in": "path",
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
                         "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "required": true
                     }
                 ],
+                "operationId": "retrieve_context_path_label_label",
                 "produces": [
                     "application/json"
                 ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "x-path": "/context/path/{uuid}/label/{value-name}/",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "/config/context/path/{uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
                 "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_path_label_label_by_id"
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of uuid",
+                        "name": "uuid",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "description": "ID of value-name",
+                        "name": "value-name",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "operationId": "retrieve_context_path_label_label_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                }
             }
         },
         "/operations/compute-p2ppath/": {
             "post": {
+                "description": "Create operation of resource: compute-p2ppath",
+                "summary": "Create compute-p2ppath by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "compute-p2ppathbody object",
+                        "name": "compute-p2ppath",
+                        "schema": {
+                            "$ref": "#/definitions/compute-p2ppathRPC_input_schema"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_compute-p2ppath_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/compute-p2ppathRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Create operation of resource: compute-p2ppath",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "compute-p2ppathbody object",
-                        "schema": {
-                            "$ref": "#/definitions/compute-p2ppathRPC_input_schema"
-                        },
-                        "name": "compute-p2ppath",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create compute-p2ppath by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_compute-p2ppath_by_id"
+                }
             }
         },
         "/operations/optimize-p2ppath/": {
             "post": {
+                "description": "Create operation of resource: optimize-p2ppath",
+                "summary": "Create optimize-p2ppath by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "optimize-p2ppathbody object",
+                        "name": "optimize-p2ppath",
+                        "schema": {
+                            "$ref": "#/definitions/optimize-p2ppathRPC_input_schema"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_optimize-p2ppath_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/optimize-p2ppathRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Create operation of resource: optimize-p2ppath",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "optimize-p2ppathbody object",
-                        "schema": {
-                            "$ref": "#/definitions/optimize-p2ppathRPC_input_schema"
-                        },
-                        "name": "optimize-p2ppath",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create optimize-p2ppath by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_optimize-p2ppath_by_id"
+                }
             }
         },
         "/operations/delete-p2ppath/": {
             "post": {
+                "description": "Create operation of resource: delete-p2ppath",
+                "summary": "Create delete-p2ppath by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "delete-p2ppathbody object",
+                        "name": "delete-p2ppath",
+                        "schema": {
+                            "$ref": "#/definitions/delete-p2ppathRPC_input_schema"
+                        },
+                        "required": true
+                    }
+                ],
+                "operationId": "create_delete-p2ppath_by_id",
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/delete-p2ppathRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
-                },
-                "description": "Create operation of resource: delete-p2ppath",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "delete-p2ppathbody object",
-                        "schema": {
-                            "$ref": "#/definitions/delete-p2ppathRPC_input_schema"
-                        },
-                        "name": "delete-p2ppath",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create delete-p2ppath by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_delete-p2ppath_by_id"
+                }
             }
         }
     },
     "definitions": {
-        "path-comp-service-port": {
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-layer": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string"
-                        },
-                        "service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                        },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "path-objective-function": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "concurrent-paths": {
-                            "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
-                            ],
-                            "type": "string"
-                        },
-                        "link-utilization": {
-                            "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
-                            ],
-                            "type": "string"
-                        },
-                        "bandwidth-optimization": {
-                            "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
-                            ],
-                            "type": "string"
-                        },
-                        "cost-optimization": {
-                            "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
-                            ],
-                            "type": "string"
-                        },
-                        "resource-sharing": {
-                            "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
-                            ],
-                            "type": "string"
-                        }
-                    }
-                }
-            ]
-        },
-        "path-computation-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "routing-constraint": {
-                            "$ref": "#/definitions/routing-constraint"
-                        },
-                        "path": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "optimization-constraint": {
-                            "$ref": "#/definitions/path-optimization-constraint"
-                        },
-                        "service-port": {
-                            "items": {
-                                "$ref": "#/definitions/path-comp-service-port"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "objective-function": {
-                            "$ref": "#/definitions/path-objective-function"
-                        }
-                    }
-                }
-            ]
-        },
         "path-optimization-constraint": {
             "allOf": [
                 {
@@ -6945,75 +7399,46 @@
                 }
             ]
         },
-        "routing-constraint": {
+        "path-comp-service-port": {
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component",
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
                 },
                 {
                     "properties": {
-                        "include-path": {
-                            "items": {
-                                "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
+                        "role": {
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ",
+                            "type": "string"
                         },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
+                        "service-end-point": {
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                            "type": "string"
                         },
-                        "cost-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "x-key": "cost-name cost-value cost-algorithm"
+                        "direction": {
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint.",
+                            "type": "string"
                         },
-                        "exclude-path": {
-                            "items": {
-                                "$ref": "#/definitions/te-link"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "avoid-topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "latency-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "x-key": "traffic-property-name traffic-property-queing-latency"
-                        },
-                        "path-layer": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "include-topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                        "service-layer": {
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ],
+                            "type": "string"
                         }
                     }
                 }
@@ -7027,15 +7452,15 @@
                 },
                 {
                     "properties": {
-                        "routing-constraint": {
-                            "$ref": "#/definitions/routing-constraint"
-                        },
                         "telink": {
                             "items": {
                                 "$ref": "#/definitions/te-link"
                             },
                             "type": "array",
                             "x-key": "local-id"
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
                         }
                     }
                 }
@@ -7043,31 +7468,154 @@
         },
         "path-computation-context": {
             "properties": {
-                "path-comp-service": {
-                    "items": {
-                        "$ref": "#/definitions/path-computation-service"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                },
                 "path": {
                     "items": {
                         "$ref": "#/definitions/path"
                     },
                     "type": "array",
                     "x-key": "uuid"
+                },
+                "path-comp-service": {
+                    "items": {
+                        "$ref": "#/definitions/path-computation-service"
+                    },
+                    "type": "array",
+                    "x-key": "uuid"
                 }
             }
         },
-        "node": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
+        "path-objective-function": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/resource-spec"
+                    "$ref": "#/definitions/local-class"
                 },
                 {
                     "properties": {
-                        "layer-protocol-name": {
+                        "concurrent-paths": {
+                            "enum": [
+                                "minimize",
+                                "maximize",
+                                "allow",
+                                "disallow",
+                                "dont-care"
+                            ],
+                            "type": "string"
+                        },
+                        "cost-optimization": {
+                            "enum": [
+                                "minimize",
+                                "maximize",
+                                "allow",
+                                "disallow",
+                                "dont-care"
+                            ],
+                            "type": "string"
+                        },
+                        "bandwidth-optimization": {
+                            "enum": [
+                                "minimize",
+                                "maximize",
+                                "allow",
+                                "disallow",
+                                "dont-care"
+                            ],
+                            "type": "string"
+                        },
+                        "resource-sharing": {
+                            "enum": [
+                                "minimize",
+                                "maximize",
+                                "allow",
+                                "disallow",
+                                "dont-care"
+                            ],
+                            "type": "string"
+                        },
+                        "link-utilization": {
+                            "enum": [
+                                "minimize",
+                                "maximize",
+                                "allow",
+                                "disallow",
+                                "dont-care"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-computation-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "path": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "service-port": {
+                            "items": {
+                                "$ref": "#/definitions/path-comp-service-port"
+                            },
+                            "type": "array",
+                            "x-key": "local-id"
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "optimization-constraint": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        },
+                        "objective-function": {
+                            "$ref": "#/definitions/path-objective-function"
+                        }
+                    }
+                }
+            ]
+        },
+        "routing-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "avoid-topology": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "type": "array",
+                            "x-key": "traffic-property-name traffic-property-queing-latency"
+                        },
+                        "exclude-path": {
+                            "items": {
+                                "$ref": "#/definitions/te-link"
+                            },
+                            "type": "array",
+                            "x-key": "local-id"
+                        },
+                        "service-level": {
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability",
+                            "type": "string"
+                        },
+                        "path-layer": {
                             "items": {
                                 "enum": [
                                     "och",
@@ -7079,124 +7627,134 @@
                             },
                             "type": "array"
                         },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "aggregated-node-edge-point": {
+                        "include-path": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "owned-node-edge-point": {
-                            "items": {
-                                "$ref": "#/definitions/node-edge-point"
+                                "$ref": "#/definitions/te-link"
                             },
                             "type": "array",
-                            "x-key": "uuid"
+                            "x-key": "local-id"
                         },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "type": "array",
+                            "x-key": "cost-name cost-value cost-algorithm"
                         },
-                        "encap-topology": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                        "include-topology": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     }
                 }
             ]
         },
-        "transfer-capacity-pac": {
-            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
+        "node-edge-point": {
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "link-port-role": {
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ],
+                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ",
+                            "type": "string"
+                        },
+                        "layer-protocol": {
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            },
+                            "type": "array",
+                            "x-key": "local-id"
+                        },
+                        "termination-direction": {
+                            "type": "string"
+                        },
+                        "client-node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "link-port-direction": {
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "The orientation of defined flow at the LinkEnd.",
+                            "type": "string"
+                        },
+                        "mapped-service-end-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        }
+                    }
+                }
+            ]
+        },
+        "cost-characteristic": {
+            "description": "The information for a particular cost characteristic.",
             "properties": {
-                "available-capacity": {
-                    "description": "Capacity available to be assigned.",
-                    "$ref": "#/definitions/capacity"
+                "cost-name": {
+                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.",
+                    "type": "string"
                 },
-                "capacity-assigned-to-user-view": {
-                    "items": {
-                        "$ref": "#/definitions/capacity"
-                    },
-                    "type": "array",
-                    "description": "Capacity already assigned",
-                    "x-key": "total-size"
+                "cost-algorithm": {
+                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.",
+                    "type": "string"
                 },
-                "total-potential-capacity": {
-                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-interaction-algorithm": {
-                    "type": "string",
-                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)"
+                "cost-value": {
+                    "description": "The specific cost.",
+                    "type": "string"
                 }
             }
         },
-        "risk-parameter-pac": {
-            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
+        "transfer-integrity-pac": {
+            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
             "properties": {
-                "risk-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/risk-characteristic"
-                    },
-                    "type": "array",
-                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
-                    "x-key": "risk-characteristic-name"
-                }
-            }
-        },
-        "capacity": {
-            "description": "Information on capacity of a particular TopologicalEntity.",
-            "properties": {
-                "committed-burst-size": {
+                "loss-characteristic": {
+                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).",
                     "type": "string"
                 },
-                "peak-burst-size": {
+                "delivery-order-characteristic": {
+                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order.",
                     "type": "string"
                 },
-                "peak-information-rate": {
+                "repeat-delivery-characteristic": {
+                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.",
                     "type": "string"
                 },
-                "coupling-flag": {
-                    "type": "boolean"
-                },
-                "color-aware": {
-                    "type": "boolean"
-                },
-                "committed-information-rate": {
+                "error-characteristic": {
+                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.",
                     "type": "string"
                 },
-                "packet-bw-profile-type": {
+                "server-integrity-process-characteristic": {
+                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.",
                     "type": "string"
                 },
-                "total-size": {
-                    "type": "string",
-                    "description": "Total capacity of the TopologicalEntity in MB/s"
-                }
-            }
-        },
-        "risk-characteristic": {
-            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
-            "properties": {
-                "risk-identifier-list": {
-                    "items": {
-                        "type": "string",
-                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity."
-                    },
-                    "type": "array"
-                },
-                "risk-characteristic-name": {
-                    "type": "string",
-                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated."
+                "unavailable-time-characteristic": {
+                    "description": "Describes the duration for which there may be no valid signal propagated.",
+                    "type": "string"
                 }
             }
         },
@@ -7209,8 +7767,8 @@
                     "properties": {
                         "topology": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
                             },
                             "type": "array"
                         }
@@ -7222,169 +7780,100 @@
             "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
             "properties": {
                 "cost-characteristic": {
+                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
                     "items": {
                         "$ref": "#/definitions/cost-characteristic"
                     },
                     "type": "array",
-                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
                     "x-key": "cost-name cost-value cost-algorithm"
                 }
             }
         },
-        "node-edge-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "termination-direction": {
-                            "type": "string"
-                        },
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "client-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "mapped-service-end-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "link-port-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the LinkEnd."
-                        },
-                        "link-port-role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "te-link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        }
-                    }
-                }
-            ]
-        },
-        "transfer-integrity-pac": {
-            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
+        "capacity": {
+            "description": "Information on capacity of a particular TopologicalEntity.",
             "properties": {
-                "error-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded."
+                "committed-burst-size": {
+                    "type": "string"
                 },
-                "unavailable-time-characteristic": {
-                    "type": "string",
-                    "description": "Describes the duration for which there may be no valid signal propagated."
+                "coupling-flag": {
+                    "type": "boolean"
                 },
-                "loss-characteristic": {
-                    "type": "string",
-                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips)."
+                "peak-burst-size": {
+                    "type": "string"
                 },
-                "delivery-order-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order."
+                "committed-information-rate": {
+                    "type": "string"
                 },
-                "server-integrity-process-characteristic": {
-                    "type": "string",
-                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity."
+                "packet-bw-profile-type": {
+                    "type": "string"
                 },
-                "repeat-delivery-characteristic": {
-                    "type": "string",
-                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay."
+                "total-size": {
+                    "description": "Total capacity of the TopologicalEntity in MB/s",
+                    "type": "string"
+                },
+                "peak-information-rate": {
+                    "type": "string"
+                },
+                "color-aware": {
+                    "type": "boolean"
                 }
             }
         },
-        "cost-characteristic": {
-            "description": "The information for a particular cost characteristic.",
+        "transfer-capacity-pac": {
+            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
             "properties": {
-                "cost-name": {
-                    "type": "string",
-                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName."
+                "available-capacity": {
+                    "description": "Capacity available to be assigned.",
+                    "$ref": "#/definitions/capacity"
                 },
-                "cost-value": {
-                    "type": "string",
-                    "description": "The specific cost."
+                "total-potential-capacity": {
+                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                    "$ref": "#/definitions/capacity"
                 },
-                "cost-algorithm": {
-                    "type": "string",
-                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm."
-                }
-            }
-        },
-        "validation-pac": {
-            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
-            "properties": {
-                "validation-mechanism": {
+                "capacity-assigned-to-user-view": {
+                    "description": "Capacity already assigned",
                     "items": {
-                        "$ref": "#/definitions/validation-mechanism"
+                        "$ref": "#/definitions/capacity"
                     },
                     "type": "array",
-                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
-                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
+                    "x-key": "total-size"
+                },
+                "capacity-interaction-algorithm": {
+                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)",
+                    "type": "string"
                 }
             }
         },
-        "transfer-timing-pac": {
-            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
+        "risk-parameter-pac": {
+            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
             "properties": {
-                "latency-characteristic": {
+                "risk-characteristic": {
+                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
                     "items": {
-                        "$ref": "#/definitions/latency-characteristic"
+                        "$ref": "#/definitions/risk-characteristic"
                     },
                     "type": "array",
-                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                    "x-key": "traffic-property-name traffic-property-queing-latency"
+                    "x-key": "risk-characteristic-name"
+                }
+            }
+        },
+        "layer-protocol-transition-pac": {
+            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
+            "properties": {
+                "node-edge-point": {
+                    "items": {
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "transitioned-layer-protocol-name": {
+                    "items": {
+                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.",
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             }
         },
@@ -7396,27 +7885,25 @@
                 },
                 {
                     "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "lp-transition": {
+                            "$ref": "#/definitions/layer-protocol-transition-pac"
+                        },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
                         },
                         "risk-parameter": {
                             "$ref": "#/definitions/risk-parameter-pac"
                         },
-                        "direction": {
-                            "type": "string",
-                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
+                        "transfer-timing": {
+                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "node-edge-point": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
                             },
                             "type": "array"
                         },
@@ -7432,101 +7919,151 @@
                             },
                             "type": "array"
                         },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
+                        "node": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
+                        "direction": {
+                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases.",
+                            "type": "string"
+                        },
+                        "validation": {
+                            "$ref": "#/definitions/validation-pac"
                         },
                         "transfer-capacity": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
                         }
                     }
                 }
             ]
         },
-        "layer-protocol-transition-pac": {
-            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
+        "risk-characteristic": {
+            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
             "properties": {
-                "node-edge-point": {
-                    "items": {
-                        "type": "string",
-                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
-                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                    },
-                    "type": "array"
+                "risk-characteristic-name": {
+                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated.",
+                    "type": "string"
                 },
-                "transitioned-layer-protocol-name": {
+                "risk-identifier-list": {
                     "items": {
-                        "type": "string",
-                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role."
+                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.",
+                        "type": "string"
                     },
                     "type": "array"
                 }
             }
         },
-        "topology-context": {
-            "properties": {
-                "nw-topology-service": {
-                    "$ref": "#/definitions/network-topology-service"
+        "node": {
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
                 },
-                "topology": {
-                    "items": {
-                        "$ref": "#/definitions/topology"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
+                {
+                    "properties": {
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "layer-protocol-name": {
+                            "items": {
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "encap-topology": {
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                            "type": "string"
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "owned-node-edge-point": {
+                            "items": {
+                                "$ref": "#/definitions/node-edge-point"
+                            },
+                            "type": "array",
+                            "x-key": "uuid"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "transfer-timing": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "aggregated-node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
                 }
-            }
-        },
-        "validation-mechanism": {
-            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
-            "properties": {
-                "validation-mechanism": {
-                    "type": "string",
-                    "description": "Name of mechanism used to validate adjacency"
-                },
-                "validation-robustness": {
-                    "type": "string",
-                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
-                },
-                "layer-protocol-adjacency-validated": {
-                    "type": "string",
-                    "description": "State of validatiion"
-                }
-            }
+            ]
         },
         "latency-characteristic": {
             "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
             "properties": {
-                "traffic-property-queing-latency": {
-                    "type": "string",
-                    "description": "The specific queuing latency for the traffic property."
+                "jitter-characteristic": {
+                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
                 },
                 "traffic-property-name": {
-                    "type": "string",
-                    "description": "The identifier of the specific traffic property to which the queuing latency applies."
-                },
-                "jitter-characteristic": {
-                    "type": "string",
-                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
+                    "description": "The identifier of the specific traffic property to which the queuing latency applies.",
+                    "type": "string"
                 },
                 "wander-characteristic": {
-                    "type": "string",
-                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
+                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
                 },
                 "fixed-latency-characteristic": {
-                    "type": "string",
-                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity"
+                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity",
+                    "type": "string"
+                },
+                "traffic-property-queing-latency": {
+                    "description": "The specific queuing latency for the traffic property.",
+                    "type": "string"
+                }
+            }
+        },
+        "validation-pac": {
+            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
+            "properties": {
+                "validation-mechanism": {
+                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
+                    "items": {
+                        "$ref": "#/definitions/validation-mechanism"
+                    },
+                    "type": "array",
+                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
+                }
+            }
+        },
+        "transfer-timing-pac": {
+            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
+            "properties": {
+                "latency-characteristic": {
+                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                    "items": {
+                        "$ref": "#/definitions/latency-characteristic"
+                    },
+                    "type": "array",
+                    "x-key": "traffic-property-name traffic-property-queing-latency"
                 }
             }
         },
@@ -7538,6 +8075,13 @@
                 },
                 {
                     "properties": {
+                        "link": {
+                            "items": {
+                                "$ref": "#/definitions/link"
+                            },
+                            "type": "array",
+                            "x-key": "uuid"
+                        },
                         "node": {
                             "items": {
                                 "$ref": "#/definitions/node"
@@ -7556,17 +8100,67 @@
                                 "type": "string"
                             },
                             "type": "array"
-                        },
-                        "link": {
-                            "items": {
-                                "$ref": "#/definitions/link"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
                         }
                     }
                 }
             ]
+        },
+        "te-link": {
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "node": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ]
+        },
+        "topology-context": {
+            "properties": {
+                "topology": {
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    },
+                    "type": "array",
+                    "x-key": "uuid"
+                },
+                "nw-topology-service": {
+                    "$ref": "#/definitions/network-topology-service"
+                }
+            }
+        },
+        "validation-mechanism": {
+            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
+            "properties": {
+                "layer-protocol-adjacency-validated": {
+                    "description": "State of validatiion",
+                    "type": "string"
+                },
+                "validation-mechanism": {
+                    "description": "Name of mechanism used to validate adjacency",
+                    "type": "string"
+                },
+                "validation-robustness": {
+                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)",
+                    "type": "string"
+                }
+            }
         },
         "context": {
             "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
@@ -7587,23 +8181,10 @@
                 }
             ]
         },
-        "operational-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
+        "lifecycle-state-pac": {
+            "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
                 "lifecycle-state": {
-                    "type": "string"
-                },
-                "operational-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
-                },
-                "start-time": {
                     "type": "string"
                 }
             }
@@ -7616,10 +8197,6 @@
                 },
                 {
                     "properties": {
-                        "termination-state": {
-                            "type": "string",
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        },
                         "layer-protocol-name": {
                             "enum": [
                                 "och",
@@ -7627,43 +8204,42 @@
                                 "eth",
                                 "mpls-tp"
                             ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "type": "string"
                         },
                         "termination-direction": {
-                            "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows",
+                            "type": "string"
+                        },
+                        "termination-state": {
+                            "description": "Indicates whether the layer is terminated and if so how.",
+                            "type": "string"
                         }
                     }
                 }
             ]
         },
-        "name-and-value": {
-            "description": "A scoped name-value pair",
+        "resource-spec": {
+            "$ref": "#/definitions/global-class"
+        },
+        "operational-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
             "properties": {
-                "value": {
-                    "type": "string",
-                    "description": "The value"
+                "operational-state": {
+                    "type": "string"
                 },
-                "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
+                "lifecycle-state": {
+                    "type": "string"
                 }
             }
         },
-        "local-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+        "time-range": {
             "properties": {
-                "local-id": {
+                "start-time": {
                     "type": "string"
                 },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                "end-time": {
+                    "type": "string"
                 }
             }
         },
@@ -7682,68 +8258,86 @@
                             "type": "array",
                             "x-key": "local-id"
                         },
-                        "direction": {
-                            "type": "string"
-                        },
                         "state": {
                             "$ref": "#/definitions/lifecycle-state-pac"
+                        },
+                        "direction": {
+                            "type": "string"
                         }
                     }
                 }
             ]
         },
-        "lifecycle-state-pac": {
-            "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
+        "global-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
-                "lifecycle-state": {
+                "label": {
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array",
+                    "x-key": "value-name"
+                },
+                "uuid": {
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array",
+                    "x-key": "value-name"
+                }
+            }
+        },
+        "name-and-value": {
+            "description": "A scoped name-value pair",
+            "properties": {
+                "value-name": {
+                    "description": "The name of the value. The value need not have a name.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "The value",
                     "type": "string"
                 }
             }
         },
-        "admin-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
+        "local-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
-                "administrative-state": {
+                "local-id": {
                     "type": "string"
                 },
-                "lifecycle-state": {
-                    "type": "string"
-                },
-                "operational-state": {
-                    "type": "string"
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array",
+                    "x-key": "value-name"
                 }
             }
         },
         "service-spec": {
             "$ref": "#/definitions/global-class"
         },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+        "admin-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
             "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
+                "operational-state": {
+                    "type": "string"
                 },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                "administrative-state": {
+                    "type": "string"
                 },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                "lifecycle-state": {
+                    "type": "string"
                 }
             }
-        },
-        "resource-spec": {
-            "$ref": "#/definitions/global-class"
         },
         "context_schema": {
             "allOf": [
@@ -7752,36 +8346,6 @@
                 },
                 {
                     "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "value-name"
-                        },
-                        "label": {
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "value-name"
-                        },
-                        "path-comp-service": {
-                            "items": {
-                                "$ref": "#/definitions/path-computation-service"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        },
-                        "nw-topology-service": {
-                            "$ref": "#/definitions/network-topology-service"
-                        },
                         "path": {
                             "items": {
                                 "$ref": "#/definitions/path"
@@ -7789,9 +8353,39 @@
                             "type": "array",
                             "x-key": "uuid"
                         },
+                        "uuid": {
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                            "type": "string"
+                        },
+                        "nw-topology-service": {
+                            "$ref": "#/definitions/network-topology-service"
+                        },
+                        "label": {
+                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "type": "array",
+                            "x-key": "value-name"
+                        },
                         "topology": {
                             "items": {
                                 "$ref": "#/definitions/topology"
+                            },
+                            "type": "array",
+                            "x-key": "uuid"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "type": "array",
+                            "x-key": "value-name"
+                        },
+                        "path-comp-service": {
+                            "items": {
+                                "$ref": "#/definitions/path-computation-service"
                             },
                             "type": "array",
                             "x-key": "uuid"
@@ -7802,17 +8396,17 @@
         },
         "compute-p2ppathRPC_input_schema": {
             "properties": {
-                "routing-constraint": {
-                    "$ref": "#/definitions/routing-constraint"
-                },
-                "objective-function": {
-                    "$ref": "#/definitions/path-objective-function"
-                },
                 "service-port": {
                     "items": {
                         "$ref": "#/definitions/path-comp-service-port"
                     },
                     "type": "array"
+                },
+                "routing-constraint": {
+                    "$ref": "#/definitions/routing-constraint"
+                },
+                "objective-function": {
+                    "$ref": "#/definitions/path-objective-function"
                 }
             }
         },
@@ -7825,8 +8419,8 @@
         },
         "optimize-p2ppathRPC_input_schema": {
             "properties": {
-                "path-id-or-name": {
-                    "type": "string"
+                "objective-function": {
+                    "$ref": "#/definitions/path-objective-function"
                 },
                 "routing-constraint": {
                     "$ref": "#/definitions/routing-constraint"
@@ -7834,8 +8428,8 @@
                 "optimization-constraint": {
                     "$ref": "#/definitions/path-optimization-constraint"
                 },
-                "objective-function": {
-                    "$ref": "#/definitions/path-objective-function"
+                "path-id-or-name": {
+                    "type": "string"
                 }
             }
         },

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -1,9 +1,9 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-topology API generated from tapi-topology.yang",
-        "title": "tapi-topology API"
+        "title": "tapi-topology API",
+        "version": "1.0.0"
     },
     "host": "localhost:8080",
     "basePath": "/restconf",
@@ -12,4591 +12,4072 @@
     ],
     "paths": {
         "/config/context/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
+            "delete": {
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Update context by ID",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_by_id"
+                "summary": "Delete context by ID",
+                "description": "Delete operation of resource: context",
+                "operationId": "delete_context_by_id"
             },
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Create operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Create context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
+                "description": "Create operation of resource: context",
+                "operationId": "create_context_by_id",
+                "parameters": [
+                    {
+                        "description": "contextbody object",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "context"
                     }
-                },
+                ]
+            },
+            "get": {
                 "produces": [
                     "application/json"
                 ],
-                "description": "Delete operation of resource: context",
-                "summary": "Delete context by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_by_id"
-            },
-            "get": {
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/context_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: context",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve context",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context"
+                "summary": "Retrieve context",
+                "description": "Retrieve operation of resource: context",
+                "operationId": "retrieve_context",
+                "parameters": []
+            },
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Update context by ID",
+                "description": "Update operation of resource: context",
+                "operationId": "update_context_by_id",
+                "parameters": [
+                    {
+                        "description": "contextbody object",
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "context"
+                    }
+                ]
             }
         },
         "/config/context/service-end-point/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/"
+                                "x-path": "/context/service-end-point/{uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve service-end-point",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
+                "description": "Retrieve operation of resource: service-end-point",
+                "operationId": "retrieve_context_service-end-point_service-end-point",
+                "parameters": []
             }
         },
         "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/service-end-point"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve service-end-point by ID",
                 "description": "Retrieve operation of resource: service-end-point",
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol",
                 "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol by ID",
                 "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/lifecycle-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve state",
                 "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_service-end-point_state_state",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name"
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_name_name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "uuid"
+                    }
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/"
+                                "x-path": "/context/service-end-point/{uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label"
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_service-end-point_label_label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "uuid"
+                    }
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                ]
             }
         },
         "/config/context/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/name/{value-name}/"
+                                "x-path": "/context/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_name_name"
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_name_name",
+                "parameters": []
             }
         },
         "/config/context/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
-            },
             "delete": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_name_name_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    }
+                ]
+            },
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_name_name_by_id"
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_name_name_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    },
+                    {
+                        "description": "namebody object",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "name"
+                    }
+                ]
             },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
+                ]
+            },
+            "put": {
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve name by ID",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name_by_id"
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_name_name_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    },
+                    {
+                        "description": "namebody object",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "name"
+                    }
+                ]
             }
         },
         "/config/context/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/label/{value-name}/"
+                                "x-path": "/context/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_label_label"
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_label_label",
+                "parameters": []
             }
         },
         "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
             "delete": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Delete label by ID",
+                "description": "Delete operation of resource: label",
+                "operationId": "delete_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    }
+                ]
+            },
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_label_label_by_id"
+                "summary": "Create label by ID",
+                "description": "Create operation of resource: label",
+                "operationId": "create_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "label"
+                    }
+                ]
             },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
+                ]
+            },
+            "put": {
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieve label by ID",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_label_label_by_id"
+                "summary": "Update label by ID",
+                "description": "Update operation of resource: label",
+                "operationId": "update_context_label_label_by_id",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "value-name"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "in": "body",
+                        "required": true,
+                        "name": "label"
+                    }
+                ]
             }
         },
         "/config/context/nw-topology-service/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/network-topology-service"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: nw-topology-service",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve nw-topology-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_nw-topology-service"
+                "summary": "Retrieve nw-topology-service",
+                "description": "Retrieve operation of resource: nw-topology-service",
+                "operationId": "retrieve_context_nw-topology-service_nw-topology-service",
+                "parameters": []
             }
         },
         "/config/context/nw-topology-service/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/name/{value-name}/"
+                                "x-path": "/context/nw-topology-service/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name"
+                "summary": "Retrieve name",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_nw-topology-service_name_name",
+                "parameters": []
             }
         },
         "/config/context/nw-topology-service/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_nw-topology-service_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_name_name_by_id"
+                ]
             }
         },
         "/config/context/nw-topology-service/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/label/{value-name}/"
+                                "x-path": "/context/nw-topology-service/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_label_label"
+                "summary": "Retrieve label",
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_nw-topology-service_label_label",
+                "parameters": []
             }
         },
         "/config/context/nw-topology-service/label/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_nw-topology-service_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_label_label_by_id"
+                ]
             }
         },
         "/config/context/topology/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/"
+                                "x-path": "/context/topology/{uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: topology",
-                "parameters": [],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve topology",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology"
+                "description": "Retrieve operation of resource: topology",
+                "operationId": "retrieve_context_topology_topology",
+                "parameters": []
             }
         },
         "/config/context/topology/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_topology_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_topology_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_topology_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/topology"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve topology by ID",
                 "description": "Retrieve operation of resource: topology",
+                "operationId": "retrieve_context_topology_topology_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve node",
                 "description": "Retrieve operation of resource: node",
+                "operationId": "retrieve_context_topology_node_node",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_node"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve node by ID",
                 "description": "Retrieve operation of resource: node",
+                "operationId": "retrieve_context_topology_node_node_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_node_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve owned-node-edge-point",
                 "description": "Retrieve operation of resource: owned-node-edge-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve owned-node-edge-point by ID",
                 "description": "Retrieve operation of resource: owned-node-edge-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol",
                 "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve layer-protocol by ID",
                 "description": "Retrieve operation of resource: layer-protocol",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     },
                     {
                         "description": "ID of local-id",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "local-id",
-                        "in": "path"
+                        "name": "local-id"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve state",
                 "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "name": "owned-node-edge-point_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve state",
                 "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_topology_node_state_state",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-capacity",
                 "description": "Retrieve operation of resource: transfer-capacity",
+                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view",
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of total-size",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "total-size",
-                        "in": "path"
+                        "name": "total-size"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-cost",
                 "description": "Retrieve operation of resource: transfer-cost",
+                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of cost-name cost-value cost-algorithm",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
+                        "name": "cost-name cost-value cost-algorithm"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-integrity",
                 "description": "Retrieve operation of resource: transfer-integrity",
+                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-timing",
                 "description": "Retrieve operation of resource: transfer-timing",
+                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of traffic-property-name traffic-property-queing-latency",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
+                        "name": "traffic-property-name traffic-property-queing-latency"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_name_name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_name_name"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_node_label_label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_label_label"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_node_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of node_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
+                        "name": "node_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_label_label_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve link",
                 "description": "Retrieve operation of resource: link",
+                "operationId": "retrieve_context_topology_link_link",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_link"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve link by ID",
                 "description": "Retrieve operation of resource: link",
+                "operationId": "retrieve_context_topology_link_link_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_link_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve state",
                 "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_topology_link_state_state",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-capacity",
                 "description": "Retrieve operation of resource: transfer-capacity",
+                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view",
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of total-size",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "total-size",
-                        "in": "path"
+                        "name": "total-size"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-cost",
                 "description": "Retrieve operation of resource: transfer-cost",
+                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of cost-name cost-value cost-algorithm",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
+                        "name": "cost-name cost-value cost-algorithm"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-integrity",
                 "description": "Retrieve operation of resource: transfer-integrity",
+                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve transfer-timing",
                 "description": "Retrieve operation of resource: transfer-timing",
+                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of traffic-property-name traffic-property-queing-latency",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
+                        "name": "traffic-property-name traffic-property-queing-latency"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-parameter-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve risk-parameter",
                 "description": "Retrieve operation of resource: risk-parameter",
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-parameter",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of risk-characteristic-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "risk-characteristic-name",
-                        "in": "path"
+                        "name": "risk-characteristic-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve validation",
                 "description": "Retrieve operation of resource: validation",
+                "operationId": "retrieve_context_topology_link_validation_validation",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve validation-mechanism",
                 "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-mechanism"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve validation-mechanism by ID",
                 "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "in": "path"
+                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve lp-transition",
                 "description": "Retrieve operation of resource: lp-transition",
+                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve lp-transition",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_link_name_name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_name_name"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_link_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_link_label_label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_label_label"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_link_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of link_uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
+                        "name": "link_uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_label_label_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/name/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/name/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_name_name"
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_name_name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "uuid"
+                    }
+                ]
             }
         },
         "/config/context/topology/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_name_name_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_name_name_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/label/": {
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/label/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/label/{value-name}/",
+                                "type": "string"
                             },
                             "type": "array"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
+                "consumes": [
                     "application/json"
                 ],
                 "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label"
+                "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_label_label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "required": true,
+                        "in": "path",
+                        "type": "string",
+                        "name": "uuid"
+                    }
+                ]
             }
         },
         "/config/context/topology/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_label_label_by_id"
-            },
             "get": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Retrieve label by ID",
                 "description": "Retrieve operation of resource: label",
+                "operationId": "retrieve_context_topology_label_label_by_id",
                 "parameters": [
                     {
                         "description": "ID of uuid",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "name": "uuid"
                     },
                     {
                         "description": "ID of value-name",
                         "required": true,
+                        "in": "path",
                         "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "name": "value-name"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label_by_id"
+                ]
             }
         },
         "/operations/get-topology-details/": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-topology-detailsRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-topology-details by ID",
                 "description": "Create operation of resource: get-topology-details",
+                "operationId": "create_get-topology-details_by_id",
                 "parameters": [
                     {
-                        "required": true,
                         "description": "get-topology-detailsbody object",
                         "schema": {
                             "$ref": "#/definitions/get-topology-detailsRPC_input_schema"
                         },
-                        "name": "get-topology-details",
-                        "in": "body"
+                        "in": "body",
+                        "required": true,
+                        "name": "get-topology-details"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-topology-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-topology-details_by_id"
+                ]
             }
         },
         "/operations/get-node-details/": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-node-detailsRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-node-details by ID",
                 "description": "Create operation of resource: get-node-details",
+                "operationId": "create_get-node-details_by_id",
                 "parameters": [
                     {
-                        "required": true,
                         "description": "get-node-detailsbody object",
                         "schema": {
                             "$ref": "#/definitions/get-node-detailsRPC_input_schema"
                         },
-                        "name": "get-node-details",
-                        "in": "body"
+                        "in": "body",
+                        "required": true,
+                        "name": "get-node-details"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-node-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-node-details_by_id"
+                ]
             }
         },
         "/operations/get-node-edge-point-details/": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-node-edge-point-detailsRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-node-edge-point-details by ID",
                 "description": "Create operation of resource: get-node-edge-point-details",
+                "operationId": "create_get-node-edge-point-details_by_id",
                 "parameters": [
                     {
-                        "required": true,
                         "description": "get-node-edge-point-detailsbody object",
                         "schema": {
                             "$ref": "#/definitions/get-node-edge-point-detailsRPC_input_schema"
                         },
-                        "name": "get-node-edge-point-details",
-                        "in": "body"
+                        "in": "body",
+                        "required": true,
+                        "name": "get-node-edge-point-details"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-node-edge-point-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-node-edge-point-details_by_id"
+                ]
             }
         },
         "/operations/get-link-details/": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-link-detailsRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "consumes": [
+                    "application/json"
+                ],
+                "summary": "Create get-link-details by ID",
                 "description": "Create operation of resource: get-link-details",
+                "operationId": "create_get-link-details_by_id",
                 "parameters": [
                     {
-                        "required": true,
                         "description": "get-link-detailsbody object",
                         "schema": {
                             "$ref": "#/definitions/get-link-detailsRPC_input_schema"
                         },
-                        "name": "get-link-details",
-                        "in": "body"
+                        "in": "body",
+                        "required": true,
+                        "name": "get-link-details"
                     }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-link-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-link-details_by_id"
+                ]
             }
         },
         "/operations/get-topology-list/": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-topology-listRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-topology-list",
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create get-topology-list by ID",
                 "consumes": [
                     "application/json"
                 ],
+                "summary": "Create get-topology-list by ID",
+                "description": "Create operation of resource: get-topology-list",
                 "operationId": "create_get-topology-list_by_id"
             }
         }
     },
     "definitions": {
-        "node": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
+        "latency-characteristic": {
+            "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
+            "properties": {
+                "fixed-latency-characteristic": {
+                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity",
+                    "type": "string"
+                },
+                "traffic-property-name": {
+                    "description": "The identifier of the specific traffic property to which the queuing latency applies.",
+                    "type": "string"
+                },
+                "jitter-characteristic": {
+                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
+                },
+                "wander-characteristic": {
+                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
+                },
+                "traffic-property-queing-latency": {
+                    "description": "The specific queuing latency for the traffic property.",
+                    "type": "string"
+                }
+            }
+        },
+        "topology-context": {
+            "properties": {
+                "nw-topology-service": {
+                    "$ref": "#/definitions/network-topology-service"
+                },
+                "topology": {
+                    "x-key": "uuid",
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "node-edge-point": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
+                        "client-node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "link-port-direction": {
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "The orientation of defined flow at the LinkEnd.",
+                            "type": "string"
+                        },
+                        "layer-protocol": {
+                            "x-key": "local-id",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            },
+                            "type": "array"
+                        },
+                        "termination-direction": {
+                            "enum": [
+                                "bidirectional",
+                                "sink",
+                                "source",
+                                "undefined-or-unknown"
+                            ],
+                            "type": "string"
+                        },
+                        "link-port-role": {
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ],
+                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ",
+                            "type": "string"
+                        },
+                        "mapped-service-end-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "topology": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "node": {
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/node"
+                            },
+                            "type": "array"
+                        },
+                        "link": {
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/link"
+                            },
+                            "type": "array"
+                        },
+                        "layer-protocol-name": {
+                            "items": {
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). "
+        },
+        "validation-pac": {
+            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
+            "properties": {
+                "validation-mechanism": {
+                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
+                    "items": {
+                        "$ref": "#/definitions/validation-mechanism"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "node": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "owned-node-edge-point": {
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/node-edge-point"
+                            },
+                            "type": "array"
+                        },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "encap-topology": {
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                            "type": "string"
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
                         "layer-protocol-name": {
                             "items": {
                                 "enum": [
@@ -4609,110 +4090,103 @@
                             },
                             "type": "array"
                         },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
                         "aggregated-node-edge-point": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
                             },
                             "type": "array"
                         },
-                        "owned-node-edge-point": {
-                            "items": {
-                                "$ref": "#/definitions/node-edge-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        },
                         "transfer-timing": {
                             "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "encap-topology": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
                         }
                     }
                 }
-            ]
-        },
-        "transfer-capacity-pac": {
-            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
-            "properties": {
-                "available-capacity": {
-                    "description": "Capacity available to be assigned.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-assigned-to-user-view": {
-                    "items": {
-                        "$ref": "#/definitions/capacity"
-                    },
-                    "type": "array",
-                    "description": "Capacity already assigned",
-                    "x-key": "total-size"
-                },
-                "total-potential-capacity": {
-                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-interaction-algorithm": {
-                    "type": "string",
-                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)"
-                }
-            }
+            ],
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). "
         },
         "risk-parameter-pac": {
             "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
             "properties": {
                 "risk-characteristic": {
+                    "x-key": "risk-characteristic-name",
+                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
                     "items": {
                         "$ref": "#/definitions/risk-characteristic"
                     },
-                    "type": "array",
-                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
-                    "x-key": "risk-characteristic-name"
+                    "type": "array"
                 }
             }
+        },
+        "transfer-timing-pac": {
+            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
+            "properties": {
+                "latency-characteristic": {
+                    "x-key": "traffic-property-name traffic-property-queing-latency",
+                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                    "items": {
+                        "$ref": "#/definitions/latency-characteristic"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "layer-protocol-transition-pac": {
+            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
+            "properties": {
+                "node-edge-point": {
+                    "items": {
+                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "transitioned-layer-protocol-name": {
+                    "items": {
+                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.",
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "te-link": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "node": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ],
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). "
         },
         "capacity": {
             "description": "Information on capacity of a particular TopologicalEntity.",
             "properties": {
+                "coupling-flag": {
+                    "type": "boolean"
+                },
                 "committed-burst-size": {
                     "type": "string"
                 },
                 "peak-burst-size": {
-                    "type": "string"
-                },
-                "peak-information-rate": {
-                    "type": "string"
-                },
-                "coupling-flag": {
-                    "type": "boolean"
-                },
-                "color-aware": {
-                    "type": "boolean"
-                },
-                "committed-information-rate": {
-                    "type": "string"
-                },
-                "packet-bw-profile-type": {
-                    "enum": [
-                        "not-applicable",
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
-                    ],
                     "type": "string"
                 },
                 "total-size": {
@@ -4728,24 +4202,136 @@
                         "200gbps",
                         "400gbps"
                     ],
-                    "type": "string",
-                    "description": "Total capacity of the TopologicalEntity in MB/s"
+                    "description": "Total capacity of the TopologicalEntity in MB/s",
+                    "type": "string"
+                },
+                "committed-information-rate": {
+                    "type": "string"
+                },
+                "peak-information-rate": {
+                    "type": "string"
+                },
+                "packet-bw-profile-type": {
+                    "enum": [
+                        "not-applicable",
+                        "mef-10.x",
+                        "rfc-2697",
+                        "rfc-2698",
+                        "rfc-4115"
+                    ],
+                    "type": "string"
+                },
+                "color-aware": {
+                    "type": "boolean"
                 }
             }
         },
-        "risk-characteristic": {
-            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
+        "link": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "node-edge-point": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "transfer-timing": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "node": {
+                            "items": {
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "lp-transition": {
+                            "$ref": "#/definitions/layer-protocol-transition-pac"
+                        },
+                        "risk-parameter": {
+                            "$ref": "#/definitions/risk-parameter-pac"
+                        },
+                        "layer-protocol-name": {
+                            "items": {
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "validation": {
+                            "$ref": "#/definitions/validation-pac"
+                        },
+                        "direction": {
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ],
+                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases.",
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). "
+        },
+        "transfer-capacity-pac": {
+            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
             "properties": {
-                "risk-identifier-list": {
+                "available-capacity": {
+                    "description": "Capacity available to be assigned.",
+                    "$ref": "#/definitions/capacity"
+                },
+                "total-potential-capacity": {
+                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                    "$ref": "#/definitions/capacity"
+                },
+                "capacity-interaction-algorithm": {
+                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)",
+                    "type": "string"
+                },
+                "capacity-assigned-to-user-view": {
+                    "x-key": "total-size",
+                    "description": "Capacity already assigned",
                     "items": {
-                        "type": "string",
-                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity."
+                        "$ref": "#/definitions/capacity"
                     },
                     "type": "array"
-                },
-                "risk-characteristic-name": {
-                    "type": "string",
-                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated."
+                }
+            }
+        },
+        "transfer-cost-pac": {
+            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
+            "properties": {
+                "cost-characteristic": {
+                    "x-key": "cost-name cost-value cost-algorithm",
+                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                    "items": {
+                        "$ref": "#/definitions/cost-characteristic"
+                    },
+                    "type": "array"
                 }
             }
         },
@@ -4758,8 +4344,8 @@
                     "properties": {
                         "topology": {
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid",
+                                "type": "string"
                             },
                             "type": "array"
                         }
@@ -4767,24 +4353,146 @@
                 }
             ]
         },
-        "transfer-cost-pac": {
-            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
+        "cost-characteristic": {
+            "description": "The information for a particular cost characteristic.",
             "properties": {
-                "cost-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/cost-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                    "x-key": "cost-name cost-value cost-algorithm"
+                "cost-name": {
+                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.",
+                    "type": "string"
+                },
+                "cost-algorithm": {
+                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.",
+                    "type": "string"
+                },
+                "cost-value": {
+                    "description": "The specific cost.",
+                    "type": "string"
                 }
             }
         },
-        "node-edge-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
+        "validation-mechanism": {
+            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
+            "properties": {
+                "validation-robustness": {
+                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)",
+                    "type": "string"
+                },
+                "validation-mechanism": {
+                    "description": "Name of mechanism used to validate adjacency",
+                    "type": "string"
+                },
+                "layer-protocol-adjacency-validated": {
+                    "description": "State of validatiion",
+                    "type": "string"
+                }
+            }
+        },
+        "transfer-integrity-pac": {
+            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
+            "properties": {
+                "server-integrity-process-characteristic": {
+                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.",
+                    "type": "string"
+                },
+                "repeat-delivery-characteristic": {
+                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.",
+                    "type": "string"
+                },
+                "delivery-order-characteristic": {
+                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order.",
+                    "type": "string"
+                },
+                "error-characteristic": {
+                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.",
+                    "type": "string"
+                },
+                "unavailable-time-characteristic": {
+                    "description": "Describes the duration for which there may be no valid signal propagated.",
+                    "type": "string"
+                },
+                "loss-characteristic": {
+                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).",
+                    "type": "string"
+                }
+            }
+        },
+        "risk-characteristic": {
+            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
+            "properties": {
+                "risk-identifier-list": {
+                    "items": {
+                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "risk-characteristic-name": {
+                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated.",
+                    "type": "string"
+                }
+            }
+        },
+        "global-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+            "properties": {
+                "label": {
+                    "x-key": "value-name",
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array"
+                },
+                "uuid": {
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                    "type": "string"
+                },
+                "name": {
+                    "x-key": "value-name",
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "time-range": {
+            "properties": {
+                "start-time": {
+                    "type": "string"
+                },
+                "end-time": {
+                    "type": "string"
+                }
+            }
+        },
+        "resource-spec": {
+            "$ref": "#/definitions/global-class"
+        },
+        "context": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/resource-spec"
+                    "$ref": "#/definitions/global-class"
+                },
+                {
+                    "properties": {
+                        "service-end-point": {
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/service-end-point"
+                            },
+                            "type": "array"
+                        }
+                    }
+                }
+            ],
+            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements)."
+        },
+        "layer-protocol": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
                 },
                 {
                     "properties": {
@@ -4795,357 +4503,43 @@
                                 "source",
                                 "undefined-or-unknown"
                             ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows",
                             "type": "string"
                         },
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "client-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "mapped-service-end-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "link-port-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the LinkEnd."
-                        },
-                        "link-port-role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
-                        }
-                    }
-                }
-            ]
-        },
-        "te-link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        }
-                    }
-                }
-            ]
-        },
-        "transfer-integrity-pac": {
-            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
-            "properties": {
-                "error-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded."
-                },
-                "unavailable-time-characteristic": {
-                    "type": "string",
-                    "description": "Describes the duration for which there may be no valid signal propagated."
-                },
-                "loss-characteristic": {
-                    "type": "string",
-                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips)."
-                },
-                "delivery-order-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order."
-                },
-                "server-integrity-process-characteristic": {
-                    "type": "string",
-                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity."
-                },
-                "repeat-delivery-characteristic": {
-                    "type": "string",
-                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay."
-                }
-            }
-        },
-        "cost-characteristic": {
-            "description": "The information for a particular cost characteristic.",
-            "properties": {
-                "cost-name": {
-                    "type": "string",
-                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName."
-                },
-                "cost-value": {
-                    "type": "string",
-                    "description": "The specific cost."
-                },
-                "cost-algorithm": {
-                    "type": "string",
-                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm."
-                }
-            }
-        },
-        "validation-pac": {
-            "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
-            "properties": {
-                "validation-mechanism": {
-                    "items": {
-                        "$ref": "#/definitions/validation-mechanism"
-                    },
-                    "type": "array",
-                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
-                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
-                }
-            }
-        },
-        "transfer-timing-pac": {
-            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
-            "properties": {
-                "latency-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/latency-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                    "x-key": "traffic-property-name traffic-property-queing-latency"
-                }
-            }
-        },
-        "link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "direction": {
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
                         "layer-protocol-name": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ],
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "type": "string"
                         },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
+                        "termination-state": {
+                            "description": "Indicates whether the layer is terminated and if so how.",
+                            "type": "string"
                         }
                     }
                 }
-            ]
+            ],
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
         },
-        "layer-protocol-transition-pac": {
-            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
+        "local-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
             "properties": {
-                "node-edge-point": {
-                    "items": {
-                        "type": "string",
-                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
-                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                    },
-                    "type": "array"
+                "local-id": {
+                    "type": "string"
                 },
-                "transitioned-layer-protocol-name": {
+                "name": {
+                    "x-key": "value-name",
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
                     "items": {
-                        "type": "string",
-                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role."
+                        "$ref": "#/definitions/name-and-value"
                     },
                     "type": "array"
                 }
             }
-        },
-        "topology-context": {
-            "properties": {
-                "nw-topology-service": {
-                    "$ref": "#/definitions/network-topology-service"
-                },
-                "topology": {
-                    "items": {
-                        "$ref": "#/definitions/topology"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "validation-mechanism": {
-            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
-            "properties": {
-                "validation-mechanism": {
-                    "type": "string",
-                    "description": "Name of mechanism used to validate adjacency"
-                },
-                "validation-robustness": {
-                    "type": "string",
-                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
-                },
-                "layer-protocol-adjacency-validated": {
-                    "type": "string",
-                    "description": "State of validatiion"
-                }
-            }
-        },
-        "latency-characteristic": {
-            "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
-            "properties": {
-                "traffic-property-queing-latency": {
-                    "type": "string",
-                    "description": "The specific queuing latency for the traffic property."
-                },
-                "traffic-property-name": {
-                    "type": "string",
-                    "description": "The identifier of the specific traffic property to which the queuing latency applies."
-                },
-                "jitter-characteristic": {
-                    "type": "string",
-                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
-                },
-                "wander-characteristic": {
-                    "type": "string",
-                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
-                },
-                "fixed-latency-characteristic": {
-                    "type": "string",
-                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity"
-                }
-            }
-        },
-        "topology": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "$ref": "#/definitions/node"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        },
-                        "layer-protocol-name": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "link": {
-                            "items": {
-                                "$ref": "#/definitions/link"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
-        "context": {
-            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/global-class"
-                },
-                {
-                    "properties": {
-                        "service-end-point": {
-                            "items": {
-                                "$ref": "#/definitions/service-end-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
         },
         "operational-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
@@ -5158,83 +4552,45 @@
                 }
             }
         },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
-                },
-                "start-time": {
-                    "type": "string"
-                }
-            }
-        },
-        "layer-protocol": {
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "termination-state": {
-                            "type": "string",
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        }
-                    }
-                }
-            ]
-        },
         "name-and-value": {
             "description": "A scoped name-value pair",
             "properties": {
                 "value": {
-                    "type": "string",
-                    "description": "The value"
+                    "description": "The value",
+                    "type": "string"
                 },
                 "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
+                    "description": "The name of the value. The value need not have a name.",
+                    "type": "string"
                 }
             }
         },
-        "local-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+        "lifecycle-state-pac": {
+            "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
-                "local-id": {
+                "lifecycle-state": {
+                    "type": "string"
+                }
+            }
+        },
+        "service-spec": {
+            "$ref": "#/definitions/global-class"
+        },
+        "admin-state-pac": {
+            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
+            "properties": {
+                "lifecycle-state": {
                     "type": "string"
                 },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                "administrative-state": {
+                    "type": "string"
+                },
+                "operational-state": {
+                    "type": "string"
                 }
             }
         },
         "service-end-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
@@ -5242,11 +4598,11 @@
                 {
                     "properties": {
                         "layer-protocol": {
+                            "x-key": "local-id",
                             "items": {
                                 "$ref": "#/definitions/layer-protocol"
                             },
-                            "type": "array",
-                            "x-key": "local-id"
+                            "type": "array"
                         },
                         "direction": {
                             "enum": [
@@ -5262,60 +4618,8 @@
                         }
                     }
                 }
-            ]
-        },
-        "lifecycle-state-pac": {
-            "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
-            "properties": {
-                "lifecycle-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "admin-state-pac": {
-            "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
-            "properties": {
-                "administrative-state": {
-                    "type": "string"
-                },
-                "lifecycle-state": {
-                    "type": "string"
-                },
-                "operational-state": {
-                    "type": "string"
-                }
-            }
-        },
-        "service-spec": {
-            "$ref": "#/definitions/global-class"
-        },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
-            "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
-                },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
-                }
-            }
-        },
-        "resource-spec": {
-            "$ref": "#/definitions/global-class"
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
         },
         "context_schema": {
             "allOf": [
@@ -5324,35 +4628,35 @@
                 },
                 {
                     "properties": {
-                        "nw-topology-service": {
-                            "$ref": "#/definitions/network-topology-service"
-                        },
                         "label": {
+                            "x-key": "value-name",
+                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
                             "items": {
                                 "$ref": "#/definitions/name-and-value"
                             },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "value-name"
-                        },
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                            "type": "array"
                         },
                         "topology": {
+                            "x-key": "uuid",
                             "items": {
                                 "$ref": "#/definitions/topology"
                             },
-                            "type": "array",
-                            "x-key": "uuid"
+                            "type": "array"
+                        },
+                        "uuid": {
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                            "type": "string"
                         },
                         "name": {
+                            "x-key": "value-name",
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
                             "items": {
                                 "$ref": "#/definitions/name-and-value"
                             },
-                            "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "value-name"
+                            "type": "array"
+                        },
+                        "nw-topology-service": {
+                            "$ref": "#/definitions/network-topology-service"
                         }
                     }
                 }

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -1,9 +1,9 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "1.0.0",
         "description": "tapi-virtual-network API generated from tapi-virtual-network.yang",
-        "title": "tapi-virtual-network API"
+        "title": "tapi-virtual-network API",
+        "version": "1.0.0"
     },
     "host": "localhost:8080",
     "basePath": "/restconf",
@@ -12,5388 +12,6261 @@
     ],
     "paths": {
         "/config/context/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: context",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "contextbody object",
-                        "schema": {
-                            "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update context by ID",
+            "delete": {
+                "description": "Delete operation of resource: context",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_by_id"
-            },
-            "post": {
+                "operationId": "delete_context_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
+                "summary": "Delete context by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
                 "description": "Create operation of resource: context",
                 "parameters": [
                     {
-                        "required": true,
                         "description": "contextbody object",
+                        "in": "body",
+                        "name": "context",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/context_schema"
-                        },
-                        "name": "context",
-                        "in": "body"
+                        }
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "create_context_by_id"
-            },
-            "delete": {
+                "operationId": "create_context_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
+                "summary": "Create context by ID",
                 "produces": [
                     "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: context",
+                "parameters": [
+                    {
+                        "description": "contextbody object",
+                        "in": "body",
+                        "name": "context",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/context_schema"
+                        }
+                    }
                 ],
-                "description": "Delete operation of resource: context",
-                "summary": "Delete context by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_by_id"
+                "operationId": "update_context_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update context by ID",
+                "produces": [
+                    "application/json"
+                ]
             },
             "get": {
+                "description": "Retrieve operation of resource: context",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/context_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: context",
-                "parameters": [],
+                "summary": "Retrieve context",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve context",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context"
+                ]
             }
         },
         "/config/context/service-end-point/": {
             "get": {
+                "description": "Retrieve operation of resource: service-end-point",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_service-end-point",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/service-end-point/{uuid}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [],
+                "summary": "Retrieve service-end-point",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve service-end-point",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_service-end-point_service-end-point_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "service-end-pointbody object",
-                        "schema": {
-                            "$ref": "#/definitions/service-end-point"
-                        },
-                        "name": "service-end-point",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_service-end-point_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_service-end-point_by_id"
-            },
             "get": {
+                "description": "Retrieve operation of resource: service-end-point",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_service-end-point_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/service-end-point"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-end-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve service-end-point by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve service-end-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_service-end-point_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: layer-protocol",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "description": "Retrieve operation of resource: layer-protocol",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve layer-protocol by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_layer-protocol_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_layer-protocol_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_state_state",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/lifecycle-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve state",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_state_state"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/name/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_name_name",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/service-end-point/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/service-end-point/{uuid}/name/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
-                    },
-                    {
                         "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_service-end-point_name_name_by_id"
-            },
-            "post": {
+                "operationId": "retrieve_context_service-end-point_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_name_name_by_id"
-            },
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_name_name_by_id"
+                ]
             }
         },
         "/config/context/service-end-point/{uuid}/label/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_service-end-point_label_label",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/service-end-point/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/service-end-point/{uuid}/label/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label"
-            }
-        },
-        "/config/context/service-end-point/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
-                    },
-                    {
                         "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_service-end-point_label_label_by_id"
-            },
-            "post": {
+                "operationId": "retrieve_context_service-end-point_label_label_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_service-end-point_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_service-end-point_label_label_by_id"
-            },
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve label by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_service-end-point_label_label_by_id"
+                ]
             }
         },
         "/config/context/name/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_name_name",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/name/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [],
+                "summary": "Retrieve name",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_name_name"
+                ]
             }
         },
         "/config/context/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_name_name_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_name_name_by_id"
-            },
             "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Delete operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_name_name_by_id"
-            },
-            "get": {
+                "operationId": "delete_context_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
-                        "description": "Successful operation",
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_name_name_by_id",
+                "responses": {
                     "400": {
                         "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
                     }
                 },
+                "summary": "Create name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_name_name_by_id"
+                "operationId": "retrieve_context_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                },
+                "summary": "Retrieve name by ID",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/label/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_label_label",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/label/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
+                "summary": "Retrieve label",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_label_label"
+                ]
             }
         },
         "/config/context/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_label_label_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_label_label_by_id"
-            },
             "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Delete operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "delete_context_label_label_by_id"
+                "operationId": "delete_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete label by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "in": "body",
+                        "name": "label",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create label by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "in": "body",
+                        "name": "label",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update label by ID",
+                "produces": [
+                    "application/json"
+                ]
             },
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_label_label_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve label by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_label_label_by_id"
+                ]
             }
         },
         "/config/context/nw-topology-service/": {
             "get": {
+                "description": "Retrieve operation of resource: nw-topology-service",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_nw-topology-service_nw-topology-service",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/network-topology-service"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: nw-topology-service",
-                "parameters": [],
+                "summary": "Retrieve nw-topology-service",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve nw-topology-service",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_nw-topology-service"
+                ]
             }
         },
         "/config/context/nw-topology-service/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name"
+                "operationId": "retrieve_context_nw-topology-service_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/nw-topology-service/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/nw-topology-service/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_name_name_by_id"
-            }
-        },
-        "/config/context/nw-topology-service/label/": {
-            "get": {
+                "operationId": "retrieve_context_nw-topology-service_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/nw-topology-service/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_nw-topology-service_label_label"
-            }
-        },
-        "/config/context/nw-topology-service/label/{value-name}/": {
-            "get": {
-                "responses": {
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/nw-topology-service/label/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_nw-topology-service_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/nw-topology-service/label/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/nw-topology-service/label/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_nw-topology-service_label_label_by_id"
+                "operationId": "retrieve_context_nw-topology-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                },
+                "summary": "Retrieve label by ID",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/": {
             "get": {
+                "description": "Retrieve operation of resource: topology",
+                "parameters": [],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_topology",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/topology/{uuid}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: topology",
-                "parameters": [],
+                "summary": "Retrieve topology",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve topology",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology"
+                ]
             }
         },
         "/config/context/topology/{uuid}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "update_context_topology_topology_by_id"
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "topologybody object",
-                        "schema": {
-                            "$ref": "#/definitions/topology"
-                        },
-                        "name": "topology",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_topology_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_topology_by_id"
-            },
             "get": {
+                "description": "Retrieve operation of resource: topology",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_topology_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/topology"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: topology",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve topology by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve topology by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_topology_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: node",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve node",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_node"
+                "operationId": "retrieve_context_topology_node_node",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve node",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: node",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_node_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: node",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve node by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve node by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_node_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: owned-node-edge-point",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve owned-node-edge-point",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: owned-node-edge-point",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve owned-node-edge-point by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve owned-node-edge-point by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: layer-protocol",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve layer-protocol",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve layer-protocol",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
             "get": {
+                "description": "Retrieve operation of resource: layer-protocol",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: layer-protocol",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve layer-protocol by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve layer-protocol by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve state",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
-            "get": {
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "owned-node-edge-point_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id"
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                },
+                "summary": "Retrieve label by ID",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_state_state",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve state",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve total-potential-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: available-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve available-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of total-size",
+                        "in": "path",
+                        "name": "total-size",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-cost",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-cost",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve cost-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-integrity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-timing",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-timing",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve latency-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name"
+                "operationId": "retrieve_context_topology_node_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/node/{node_uuid}/name/{value-name}/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_name_name_by_id"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
-            "get": {
+                "operationId": "retrieve_context_topology_node_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "node_uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_node_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/label/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "node_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
                         "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_node_label_label_by_id"
+                "operationId": "retrieve_context_topology_node_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/label/{value-name}/": {
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of node_uuid",
+                        "in": "path",
+                        "name": "node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_node_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                },
+                "summary": "Retrieve label by ID",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: link",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve link",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_link"
+                "operationId": "retrieve_context_topology_link_link",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve link",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/": {
             "get": {
+                "description": "Retrieve operation of resource: link",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_link_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: link",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve link by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve link by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_link_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
             "get": {
+                "description": "Retrieve operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_state_state",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve state",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_state_state"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-capacity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve total-potential-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve total-potential-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
             "get": {
+                "description": "Retrieve operation of resource: available-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "description": "Capacity available to be assigned.",
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: available-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve available-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve available-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view"
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve capacity-assigned-to-user-view",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/capacity-assigned-to-user-view/{total-size}/": {
             "get": {
+                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of total-size",
+                        "in": "path",
+                        "name": "total-size",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: capacity-assigned-to-user-view",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of total-size",
-                        "required": true,
-                        "type": "string",
-                        "name": "total-size",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve capacity-assigned-to-user-view by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve capacity-assigned-to-user-view by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-capacity_capacity-assigned-to-user-view_capacity-assigned-to-user-view_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-cost",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-cost-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-cost",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-cost",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-cost",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
             "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve cost-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-integrity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-integrity-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-integrity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-integrity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
             "get": {
+                "description": "Retrieve operation of resource: transfer-timing",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: transfer-timing",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve transfer-timing",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve transfer-timing",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
             "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve latency-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
             "get": {
+                "description": "Retrieve operation of resource: risk-parameter",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-parameter-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: risk-parameter",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve risk-parameter",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve risk-parameter",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: risk-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic"
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve risk-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of risk-characteristic-name",
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/risk-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "risk-characteristic-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve risk-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve risk-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
             "get": {
+                "description": "Retrieve operation of resource: validation",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_validation_validation",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: validation",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve validation",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve validation",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: validation-mechanism",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism"
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve validation-mechanism",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism layer-protocol-adjacency-validated validation-robustness}/": {
             "get": {
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "in": "path",
+                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/validation-mechanism"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "required": true,
-                        "type": "string",
-                        "name": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve validation-mechanism by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve validation-mechanism by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
             "get": {
+                "description": "Retrieve operation of resource: lp-transition",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: lp-transition",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve lp-transition",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve lp-transition",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_name_name"
+                "operationId": "retrieve_context_topology_link_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/name/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "link_uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_topology_link_label_label"
+                "operationId": "retrieve_context_topology_link_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/topology/{uuid}/link/{link_uuid}/label/{value-name}/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of link_uuid",
+                        "in": "path",
+                        "name": "link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_link_label_label_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "link_uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve label by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_link_label_label_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/name/": {
             "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_name_name",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/topology/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/name/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_name_name"
-            }
-        },
-        "/config/context/topology/{uuid}/name/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
-                    },
-                    {
                         "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update name by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_topology_name_name_by_id"
-            },
-            "post": {
+                "operationId": "retrieve_context_topology_name_name_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "namebody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "name",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_name_name_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_name_name_by_id"
-            },
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_name_name_by_id"
+                ]
             }
         },
         "/config/context/topology/{uuid}/label/": {
             "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_topology_label_label",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/context/topology/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/config/context/topology/{uuid}/label/{value-name}/": {
+            "get": {
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label"
-            }
-        },
-        "/config/context/topology/{uuid}/label/{value-name}/": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Update operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
                         "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
+                        "type": "string"
                     },
                     {
                         "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "value-name",
-                        "in": "path"
-                    },
-                    {
                         "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Update label by ID",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "update_context_topology_label_label_by_id"
-            },
-            "post": {
+                "operationId": "retrieve_context_topology_label_label_by_id",
                 "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
                     "400": {
                         "description": "Internal Error"
-                    }
-                },
-                "description": "Create operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
                     },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    },
-                    {
-                        "required": true,
-                        "description": "labelbody object",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "name": "label",
-                        "in": "body"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Create label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_context_topology_label_label_by_id"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
-                "description": "Delete operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Delete label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "delete_context_topology_label_label_by_id"
-            },
-            "get": {
-                "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve label by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_topology_label_label_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: virtual-nw-service",
                 "parameters": [],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve virtual-nw-service",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_virtual-nw-service"
+                "operationId": "retrieve_context_virtual-nw-service_virtual-nw-service",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve virtual-nw-service",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: virtual-nw-service",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_virtual-nw-service_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete virtual-nw-service by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: virtual-nw-service",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "virtual-nw-servicebody object",
+                        "in": "body",
+                        "name": "virtual-nw-service",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-service"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_virtual-nw-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create virtual-nw-service by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: virtual-nw-service",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "virtual-nw-servicebody object",
+                        "in": "body",
+                        "name": "virtual-nw-service",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-service"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_virtual-nw-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update virtual-nw-service by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: virtual-nw-service",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_virtual-nw-service_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/virtual-network-service"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: virtual-nw-service",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve virtual-nw-service by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve virtual-nw-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_virtual-nw-service_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/service-port/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/service-port/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: service-port",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve service-port",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_service-port_service-port"
+                "operationId": "retrieve_context_virtual-nw-service_service-port_service-port",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/service-port/{local-id}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve service-port",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/service-port/{local-id}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: service-port",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_service-port_service-port_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete service-port by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: service-port",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "service-portbody object",
+                        "in": "body",
+                        "name": "service-port",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-service-port"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create service-port by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: service-port",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "service-portbody object",
+                        "in": "body",
+                        "name": "service-port",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-service-port"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update service-port by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: service-port",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_service-port_service-port_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/virtual-network-service-port"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: service-port",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve service-port by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve service-port by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_service-port_service-port_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/service-port/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/service-port/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_service-port_name_name"
+                "operationId": "retrieve_context_virtual-nw-service_service-port_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/service-port/{local-id}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/service-port/{local-id}/name/{value-name}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_service-port_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_service-port_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_service-port_name_name_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: vnw-constraint",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve vnw-constraint",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_vnw-constraint"
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_vnw-constraint",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve vnw-constraint",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: vnw-constraint",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_vnw-constraint_vnw-constraint_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete vnw-constraint by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: vnw-constraint",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "vnw-constraintbody object",
+                        "in": "body",
+                        "name": "vnw-constraint",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-constraint"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_vnw-constraint_vnw-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create vnw-constraint by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: vnw-constraint",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "vnw-constraintbody object",
+                        "in": "body",
+                        "name": "vnw-constraint",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/virtual-network-constraint"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_vnw-constraint_vnw-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update vnw-constraint by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: vnw-constraint",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_vnw-constraint_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/virtual-network-constraint"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: vnw-constraint",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve vnw-constraint by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve vnw-constraint by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_vnw-constraint_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/requested-capacity/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: requested-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_vnw-constraint_requested-capacity_requested-capacity_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete requested-capacity by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: requested-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "requested-capacitybody object",
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_vnw-constraint_requested-capacity_requested-capacity_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create requested-capacity by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: requested-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "requested-capacitybody object",
+                        "in": "body",
+                        "name": "requested-capacity",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_vnw-constraint_requested-capacity_requested-capacity_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update requested-capacity by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: requested-capacity",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_requested-capacity_requested-capacity",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/capacity"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: requested-capacity",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve requested-capacity",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve requested-capacity",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_requested-capacity_requested-capacity"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/cost-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/cost-characteristic/{cost-name cost-value cost-algorithm}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: cost-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic"
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/cost-characteristic/{cost-name cost-value cost-algorithm}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve cost-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/cost-characteristic/{cost-name cost-value cost-algorithm}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete cost-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "cost-characteristicbody object",
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create cost-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "cost-characteristicbody object",
+                        "in": "body",
+                        "name": "cost-characteristic",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update cost-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of cost-name cost-value cost-algorithm",
+                        "in": "path",
+                        "name": "cost-name cost-value cost-algorithm",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/cost-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of cost-name cost-value cost-algorithm",
-                        "required": true,
-                        "type": "string",
-                        "name": "cost-name cost-value cost-algorithm",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve cost-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve cost-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_cost-characteristic_cost-characteristic_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/latency-characteristic/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: latency-characteristic",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic"
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve latency-characteristic",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/latency-characteristic/{traffic-property-name traffic-property-queing-latency}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete latency-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "latency-characteristicbody object",
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create latency-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "latency-characteristicbody object",
+                        "in": "body",
+                        "name": "latency-characteristic",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update latency-characteristic by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of traffic-property-name traffic-property-queing-latency",
+                        "in": "path",
+                        "name": "traffic-property-name traffic-property-queing-latency",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of traffic-property-name traffic-property-queing-latency",
-                        "required": true,
-                        "type": "string",
-                        "name": "traffic-property-name traffic-property-queing-latency",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve latency-characteristic by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve latency-characteristic by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_latency-characteristic_latency-characteristic_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     },
                     {
                         "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "local-id",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_name_name"
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/vnw-constraint/{local-id}/name/{value-name}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_vnw-constraint_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_vnw-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_vnw-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of local-id",
+                        "in": "path",
+                        "name": "local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string",
-                        "name": "local-id",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_vnw-constraint_name_name_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/schedule/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: schedule",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_schedule_schedule_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete schedule by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: schedule",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "schedulebody object",
+                        "in": "body",
+                        "name": "schedule",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_schedule_schedule_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create schedule by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: schedule",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "schedulebody object",
+                        "in": "body",
+                        "name": "schedule",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_schedule_schedule_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update schedule by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: schedule",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_schedule_schedule",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/time-range"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: schedule",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve schedule",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve schedule",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_schedule_schedule"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/state/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_state_state_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete state by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "statebody object",
+                        "in": "body",
+                        "name": "state",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_state_state_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create state by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "statebody object",
+                        "in": "body",
+                        "name": "state",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_state_state_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update state by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: state",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_state_state",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: state",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve state",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve state",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_state_state"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/name/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: name",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve name",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_name_name"
+                "operationId": "retrieve_context_virtual-nw-service_name_name",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/name/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve name",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/name/{value-name}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_name_name_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "namebody object",
+                        "in": "body",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update name by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: name",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_name_name_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: name",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve name by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve name by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_name_name_by_id"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/label/": {
             "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/virtual-nw-service/{uuid}/label/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                },
                 "description": "Retrieve operation of resource: label",
                 "parameters": [
                     {
                         "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
+                        "in": "path",
                         "name": "uuid",
-                        "in": "path"
+                        "required": true,
+                        "type": "string"
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Retrieve label",
                 "consumes": [
                     "application/json"
                 ],
-                "operationId": "retrieve_context_virtual-nw-service_label_label"
+                "operationId": "retrieve_context_virtual-nw-service_label_label",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/virtual-nw-service/{uuid}/label/{value-name}/"
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieve label",
+                "produces": [
+                    "application/json"
+                ]
             }
         },
         "/config/context/virtual-nw-service/{uuid}/label/{value-name}/": {
-            "get": {
+            "delete": {
+                "description": "Delete operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "delete_context_virtual-nw-service_label_label_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Delete label by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "post": {
+                "description": "Create operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "in": "body",
+                        "name": "label",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_context_virtual-nw-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Create label by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "put": {
+                "description": "Update operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "labelbody object",
+                        "in": "body",
+                        "name": "label",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "update_context_virtual-nw-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
+                    "200": {
+                        "description": "Successful operation"
+                    }
+                },
+                "summary": "Update label by ID",
+                "produces": [
+                    "application/json"
+                ]
+            },
+            "get": {
+                "description": "Retrieve operation of resource: label",
+                "parameters": [
+                    {
+                        "description": "ID of uuid",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "ID of value-name",
+                        "in": "path",
+                        "name": "value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "retrieve_context_virtual-nw-service_label_label_by_id",
+                "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Retrieve operation of resource: label",
-                "parameters": [
-                    {
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string",
-                        "name": "uuid",
-                        "in": "path"
-                    },
-                    {
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string",
-                        "name": "value-name",
-                        "in": "path"
-                    }
-                ],
+                "summary": "Retrieve label by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Retrieve label by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "retrieve_context_virtual-nw-service_label_label_by_id"
+                ]
             }
         },
         "/operations/create-virtual-network-service/": {
             "post": {
+                "description": "Create operation of resource: create-virtual-network-service",
+                "parameters": [
+                    {
+                        "description": "create-virtual-network-servicebody object",
+                        "in": "body",
+                        "name": "create-virtual-network-service",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/create-virtual-network-serviceRPC_input_schema"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_create-virtual-network-service_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/create-virtual-network-serviceRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: create-virtual-network-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "create-virtual-network-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/create-virtual-network-serviceRPC_input_schema"
-                        },
-                        "name": "create-virtual-network-service",
-                        "in": "body"
-                    }
-                ],
+                "summary": "Create create-virtual-network-service by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create create-virtual-network-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_create-virtual-network-service_by_id"
+                ]
             }
         },
         "/operations/delete-virtual-network-service/": {
             "post": {
+                "description": "Create operation of resource: delete-virtual-network-service",
+                "parameters": [
+                    {
+                        "description": "delete-virtual-network-servicebody object",
+                        "in": "body",
+                        "name": "delete-virtual-network-service",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/delete-virtual-network-serviceRPC_input_schema"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_delete-virtual-network-service_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/delete-virtual-network-serviceRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: delete-virtual-network-service",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "delete-virtual-network-servicebody object",
-                        "schema": {
-                            "$ref": "#/definitions/delete-virtual-network-serviceRPC_input_schema"
-                        },
-                        "name": "delete-virtual-network-service",
-                        "in": "body"
-                    }
-                ],
+                "summary": "Create delete-virtual-network-service by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create delete-virtual-network-service by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_delete-virtual-network-service_by_id"
+                ]
             }
         },
         "/operations/get-virtual-network-service-details/": {
             "post": {
+                "description": "Create operation of resource: get-virtual-network-service-details",
+                "parameters": [
+                    {
+                        "description": "get-virtual-network-service-detailsbody object",
+                        "in": "body",
+                        "name": "get-virtual-network-service-details",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/get-virtual-network-service-detailsRPC_input_schema"
+                        }
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_get-virtual-network-service-details_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-virtual-network-service-detailsRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-virtual-network-service-details",
-                "parameters": [
-                    {
-                        "required": true,
-                        "description": "get-virtual-network-service-detailsbody object",
-                        "schema": {
-                            "$ref": "#/definitions/get-virtual-network-service-detailsRPC_input_schema"
-                        },
-                        "name": "get-virtual-network-service-details",
-                        "in": "body"
-                    }
-                ],
+                "summary": "Create get-virtual-network-service-details by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-virtual-network-service-details by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-virtual-network-service-details_by_id"
+                ]
             }
         },
         "/operations/get-virtual-network-service-list/": {
             "post": {
+                "description": "Create operation of resource: get-virtual-network-service-list",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "create_get-virtual-network-service-list_by_id",
                 "responses": {
+                    "400": {
+                        "description": "Internal Error"
+                    },
                     "200": {
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/get-virtual-network-service-listRPC_output_schema"
                         }
-                    },
-                    "400": {
-                        "description": "Internal Error"
                     }
                 },
-                "description": "Create operation of resource: get-virtual-network-service-list",
+                "summary": "Create get-virtual-network-service-list by ID",
                 "produces": [
                     "application/json"
-                ],
-                "summary": "Create get-virtual-network-service-list by ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "operationId": "create_get-virtual-network-service-list_by_id"
+                ]
             }
         }
     },
     "definitions": {
+        "virtual-network-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "x-key": "traffic-property-name traffic-property-queing-latency",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            }
+                        },
+                        "service-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
+                        },
+                        "sink-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
+                        },
+                        "diversity-exclusion": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id"
+                            }
+                        },
+                        "src-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "service-level": {
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability",
+                            "type": "string"
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "x-key": "cost-name cost-value cost-algorithm",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "virtual-network-context": {
+            "properties": {
+                "virtual-nw-service": {
+                    "type": "array",
+                    "x-key": "uuid",
+                    "items": {
+                        "$ref": "#/definitions/virtual-network-service"
+                    }
+                }
+            }
+        },
         "virtual-network-service": {
             "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE.",
             "allOf": [
@@ -5403,40 +6276,40 @@
                 {
                     "properties": {
                         "service-port": {
+                            "type": "array",
+                            "x-key": "local-id",
                             "items": {
                                 "$ref": "#/definitions/virtual-network-service-port"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
+                            }
+                        },
+                        "topology": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
                         },
                         "schedule": {
                             "$ref": "#/definitions/time-range"
-                        },
-                        "layer-protocol-name": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
                         },
                         "vnw-constraint": {
+                            "type": "array",
+                            "x-key": "local-id",
                             "items": {
                                 "$ref": "#/definitions/virtual-network-constraint"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
+                            }
                         },
-                        "topology": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                        "layer-protocol-name": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
                         }
                     }
                 }
@@ -5451,206 +6324,164 @@
                 {
                     "properties": {
                         "service-layer": {
+                            "type": "string",
                             "enum": [
                                 "och",
                                 "odu",
                                 "eth",
                                 "mpls-tp"
-                            ],
-                            "type": "string"
-                        },
-                        "service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
+                            ]
                         },
                         "direction": {
+                            "description": "The orientation of defined flow at the EndPoint.",
+                            "type": "string",
                             "enum": [
                                 "bidirectional",
                                 "input",
                                 "output",
                                 "unidentified-or-unknown"
-                            ],
+                            ]
+                        },
+                        "service-end-point": {
                             "type": "string",
-                            "description": "The orientation of defined flow at the EndPoint."
+                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
                         },
                         "role": {
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ",
+                            "type": "string",
                             "enum": [
                                 "symmetric",
                                 "root",
                                 "leaf",
                                 "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                            ]
                         }
                     }
                 }
             ]
         },
-        "virtual-network-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "sink-service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "cost-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "x-key": "cost-name cost-value cost-algorithm"
-                        },
-                        "service-layer": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "src-service-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "diversity-exclusion": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-virtual-network:virtual-nw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id"
-                            },
-                            "type": "array"
-                        },
-                        "latency-characteristic": {
-                            "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "type": "array",
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "x-key": "traffic-property-name traffic-property-queing-latency"
-                        }
-                    }
-                }
-            ]
-        },
-        "virtual-network-context": {
-            "properties": {
-                "virtual-nw-service": {
-                    "items": {
-                        "$ref": "#/definitions/virtual-network-service"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "node": {
-            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
+        "link": {
+            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
                         "layer-protocol-name": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "och",
                                     "odu",
                                     "eth",
                                     "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "aggregated-node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "owned-node-edge-point": {
-                            "items": {
-                                "$ref": "#/definitions/node-edge-point"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                                ]
+                            }
                         },
                         "transfer-timing": {
                             "$ref": "#/definitions/transfer-timing-pac"
                         },
-                        "encap-topology": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                        "direction": {
+                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases.",
+                            "type": "string"
+                        },
+                        "node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                            }
+                        },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "validation": {
+                            "$ref": "#/definitions/validation-pac"
+                        },
+                        "node": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                            }
+                        },
+                        "risk-parameter": {
+                            "$ref": "#/definitions/risk-parameter-pac"
+                        },
+                        "lp-transition": {
+                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     }
                 }
             ]
         },
-        "transfer-capacity-pac": {
-            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
+        "topology-context": {
             "properties": {
-                "available-capacity": {
-                    "description": "Capacity available to be assigned.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-assigned-to-user-view": {
-                    "items": {
-                        "$ref": "#/definitions/capacity"
-                    },
+                "topology": {
                     "type": "array",
-                    "description": "Capacity already assigned",
-                    "x-key": "total-size"
+                    "x-key": "uuid",
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    }
                 },
-                "total-potential-capacity": {
-                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                    "$ref": "#/definitions/capacity"
-                },
-                "capacity-interaction-algorithm": {
-                    "type": "string",
-                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)"
+                "nw-topology-service": {
+                    "$ref": "#/definitions/network-topology-service"
                 }
             }
         },
-        "risk-parameter-pac": {
-            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
+        "latency-characteristic": {
+            "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
             "properties": {
-                "risk-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/risk-characteristic"
-                    },
+                "wander-characteristic": {
+                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
+                },
+                "fixed-latency-characteristic": {
+                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity",
+                    "type": "string"
+                },
+                "traffic-property-queing-latency": {
+                    "description": "The specific queuing latency for the traffic property.",
+                    "type": "string"
+                },
+                "jitter-characteristic": {
+                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet).",
+                    "type": "string"
+                },
+                "traffic-property-name": {
+                    "description": "The identifier of the specific traffic property to which the queuing latency applies.",
+                    "type": "string"
+                }
+            }
+        },
+        "layer-protocol-transition-pac": {
+            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
+            "properties": {
+                "transitioned-layer-protocol-name": {
                     "type": "array",
-                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
-                    "x-key": "risk-characteristic-name"
+                    "items": {
+                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.",
+                        "type": "string"
+                    }
+                },
+                "node-edge-point": {
+                    "type": "array",
+                    "items": {
+                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                    }
                 }
             }
         },
@@ -5660,131 +6491,63 @@
                 "committed-burst-size": {
                     "type": "string"
                 },
-                "peak-burst-size": {
-                    "type": "string"
-                },
-                "peak-information-rate": {
+                "committed-information-rate": {
                     "type": "string"
                 },
                 "coupling-flag": {
                     "type": "boolean"
                 },
+                "peak-information-rate": {
+                    "type": "string"
+                },
+                "peak-burst-size": {
+                    "type": "string"
+                },
                 "color-aware": {
                     "type": "boolean"
                 },
-                "committed-information-rate": {
+                "total-size": {
+                    "description": "Total capacity of the TopologicalEntity in MB/s",
                     "type": "string"
                 },
                 "packet-bw-profile-type": {
                     "type": "string"
-                },
-                "total-size": {
-                    "type": "string",
-                    "description": "Total capacity of the TopologicalEntity in MB/s"
                 }
             }
         },
-        "risk-characteristic": {
-            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
-            "properties": {
-                "risk-identifier-list": {
-                    "items": {
-                        "type": "string",
-                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity."
-                    },
-                    "type": "array"
-                },
-                "risk-characteristic-name": {
-                    "type": "string",
-                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated."
-                }
-            }
-        },
-        "network-topology-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "topology": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        }
-                    }
-                }
-            ]
-        },
-        "transfer-cost-pac": {
-            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
-            "properties": {
-                "cost-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/cost-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                    "x-key": "cost-name cost-value cost-algorithm"
-                }
-            }
-        },
-        "node-edge-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
+        "topology": {
+            "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
                     "properties": {
-                        "termination-direction": {
-                            "type": "string"
-                        },
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
+                        "link": {
                             "type": "array",
-                            "x-key": "local-id"
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/link"
+                            }
                         },
-                        "client-node-edge-point": {
+                        "layer-protocol-name": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                                "enum": [
+                                    "och",
+                                    "odu",
+                                    "eth",
+                                    "mpls-tp"
+                                ]
+                            }
                         },
-                        "mapped-service-end-point": {
+                        "node": {
+                            "type": "array",
+                            "x-key": "uuid",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "link-port-direction": {
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "type": "string",
-                            "description": "The orientation of defined flow at the LinkEnd."
-                        },
-                        "link-port-role": {
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "unknown"
-                            ],
-                            "type": "string",
-                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
+                                "$ref": "#/definitions/node"
+                            }
                         }
                     }
                 }
@@ -5798,239 +6561,38 @@
                 },
                 {
                     "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
                         "node-edge-point": {
+                            "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
+                            }
+                        },
+                        "node": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                            }
                         }
                     }
                 }
             ]
-        },
-        "transfer-integrity-pac": {
-            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
-            "properties": {
-                "error-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded."
-                },
-                "unavailable-time-characteristic": {
-                    "type": "string",
-                    "description": "Describes the duration for which there may be no valid signal propagated."
-                },
-                "loss-characteristic": {
-                    "type": "string",
-                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips)."
-                },
-                "delivery-order-characteristic": {
-                    "type": "string",
-                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order."
-                },
-                "server-integrity-process-characteristic": {
-                    "type": "string",
-                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity."
-                },
-                "repeat-delivery-characteristic": {
-                    "type": "string",
-                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay."
-                }
-            }
-        },
-        "cost-characteristic": {
-            "description": "The information for a particular cost characteristic.",
-            "properties": {
-                "cost-name": {
-                    "type": "string",
-                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName."
-                },
-                "cost-value": {
-                    "type": "string",
-                    "description": "The specific cost."
-                },
-                "cost-algorithm": {
-                    "type": "string",
-                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm."
-                }
-            }
         },
         "validation-pac": {
             "description": "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.",
             "properties": {
                 "validation-mechanism": {
+                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
+                    "type": "array",
+                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness",
                     "items": {
                         "$ref": "#/definitions/validation-mechanism"
-                    },
-                    "type": "array",
-                    "description": "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.",
-                    "x-key": "validation-mechanism layer-protocol-adjacency-validated validation-robustness"
-                }
-            }
-        },
-        "transfer-timing-pac": {
-            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
-            "properties": {
-                "latency-characteristic": {
-                    "items": {
-                        "$ref": "#/definitions/latency-characteristic"
-                    },
-                    "type": "array",
-                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                    "x-key": "traffic-property-name traffic-property-queing-latency"
-                }
-            }
-        },
-        "link": {
-            "description": "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "node": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "node-edge-point": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            },
-                            "type": "array"
-                        },
-                        "layer-protocol-name": {
-                            "items": {
-                                "enum": [
-                                    "och",
-                                    "odu",
-                                    "eth",
-                                    "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/transfer-capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
                     }
                 }
-            ]
-        },
-        "layer-protocol-transition-pac": {
-            "description": "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. \nThis abstraction is relevant when considering multi-layer routing. \nThe layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.\nThis Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.\nLinks that included details in this Pac are often referred to as Transitional Links.",
-            "properties": {
-                "node-edge-point": {
-                    "items": {
-                        "type": "string",
-                        "description": "Lists the LTPs that define the layer protocol transition of the transitional link.",
-                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                    },
-                    "type": "array"
-                },
-                "transitioned-layer-protocol-name": {
-                    "items": {
-                        "type": "string",
-                        "description": "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role."
-                    },
-                    "type": "array"
-                }
             }
         },
-        "topology-context": {
-            "properties": {
-                "nw-topology-service": {
-                    "$ref": "#/definitions/network-topology-service"
-                },
-                "topology": {
-                    "items": {
-                        "$ref": "#/definitions/topology"
-                    },
-                    "type": "array",
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "validation-mechanism": {
-            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
-            "properties": {
-                "validation-mechanism": {
-                    "type": "string",
-                    "description": "Name of mechanism used to validate adjacency"
-                },
-                "validation-robustness": {
-                    "type": "string",
-                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
-                },
-                "layer-protocol-adjacency-validated": {
-                    "type": "string",
-                    "description": "State of validatiion"
-                }
-            }
-        },
-        "latency-characteristic": {
-            "description": "Provides information on latency characteristic for a particular stated trafficProperty.",
-            "properties": {
-                "traffic-property-queing-latency": {
-                    "type": "string",
-                    "description": "The specific queuing latency for the traffic property."
-                },
-                "traffic-property-name": {
-                    "type": "string",
-                    "description": "The identifier of the specific traffic property to which the queuing latency applies."
-                },
-                "jitter-characteristic": {
-                    "type": "string",
-                    "description": "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
-                },
-                "wander-characteristic": {
-                    "type": "string",
-                    "description": "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.\nApplies to TDM systems (and not packet)."
-                },
-                "fixed-latency-characteristic": {
-                    "type": "string",
-                    "description": "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity"
-                }
-            }
-        },
-        "topology": {
+        "node": {
             "description": "The ForwardingDomain (FD) object class models the \u201cForwardingDomain\u201d topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. \nAt the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ",
             "allOf": [
                 {
@@ -6038,54 +6600,274 @@
                 },
                 {
                     "properties": {
-                        "node": {
-                            "items": {
-                                "$ref": "#/definitions/node"
-                            },
+                        "transfer-cost": {
+                            "$ref": "#/definitions/transfer-cost-pac"
+                        },
+                        "transfer-integrity": {
+                            "$ref": "#/definitions/transfer-integrity-pac"
+                        },
+                        "owned-node-edge-point": {
                             "type": "array",
-                            "x-key": "uuid"
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/node-edge-point"
+                            }
+                        },
+                        "transfer-capacity": {
+                            "$ref": "#/definitions/transfer-capacity-pac"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "aggregated-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                            }
+                        },
+                        "transfer-timing": {
+                            "$ref": "#/definitions/transfer-timing-pac"
+                        },
+                        "encap-topology": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
                         },
                         "layer-protocol-name": {
+                            "type": "array",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "och",
                                     "odu",
                                     "eth",
                                     "mpls-tp"
-                                ],
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "link": {
-                            "items": {
-                                "$ref": "#/definitions/link"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                                ]
+                            }
                         }
                     }
                 }
             ]
         },
-        "context": {
-            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
+        "risk-characteristic": {
+            "description": "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.",
+            "properties": {
+                "risk-identifier-list": {
+                    "type": "array",
+                    "items": {
+                        "description": "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.",
+                        "type": "string"
+                    }
+                },
+                "risk-characteristic-name": {
+                    "description": "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. \nFor example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).\nDepending upon the importance of the traffic being routed different risk characteristics will be evaluated.",
+                    "type": "string"
+                }
+            }
+        },
+        "validation-mechanism": {
+            "description": "Identifies the validation mechanism and describes the characteristics of that mechanism",
+            "properties": {
+                "validation-mechanism": {
+                    "description": "Name of mechanism used to validate adjacency",
+                    "type": "string"
+                },
+                "layer-protocol-adjacency-validated": {
+                    "description": "State of validatiion",
+                    "type": "string"
+                },
+                "validation-robustness": {
+                    "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)",
+                    "type": "string"
+                }
+            }
+        },
+        "transfer-cost-pac": {
+            "description": "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. \nThey may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity\nThere may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. \nUsing an entity will incur a cost. ",
+            "properties": {
+                "cost-characteristic": {
+                    "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                    "type": "array",
+                    "x-key": "cost-name cost-value cost-algorithm",
+                    "items": {
+                        "$ref": "#/definitions/cost-characteristic"
+                    }
+                }
+            }
+        },
+        "risk-parameter-pac": {
+            "description": "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. \nThe risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.\nA TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.\nThe realization can be partitioned into segments which have some relevant common failure modes.\nThere is a risk of failure/degradation of each segment of the underlying realization.\nEach segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).\nDisruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.\nAny TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.\nThe identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.\nA segment has one or more risk characteristic.\nShared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.\nWhere two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.",
+            "properties": {
+                "risk-characteristic": {
+                    "description": "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.",
+                    "type": "array",
+                    "x-key": "risk-characteristic-name",
+                    "items": {
+                        "$ref": "#/definitions/risk-characteristic"
+                    }
+                }
+            }
+        },
+        "cost-characteristic": {
+            "description": "The information for a particular cost characteristic.",
+            "properties": {
+                "cost-value": {
+                    "description": "The specific cost.",
+                    "type": "string"
+                },
+                "cost-algorithm": {
+                    "description": "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.",
+                    "type": "string"
+                },
+                "cost-name": {
+                    "description": "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.",
+                    "type": "string"
+                }
+            }
+        },
+        "network-topology-service": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/global-class"
+                    "$ref": "#/definitions/service-spec"
                 },
                 {
                     "properties": {
-                        "service-end-point": {
-                            "items": {
-                                "$ref": "#/definitions/service-end-point"
-                            },
+                        "topology": {
                             "type": "array",
-                            "x-key": "uuid"
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
                         }
                     }
                 }
             ]
+        },
+        "node-edge-point": {
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "client-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                            }
+                        },
+                        "termination-direction": {
+                            "type": "string"
+                        },
+                        "link-port-role": {
+                            "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ",
+                            "type": "string",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "unknown"
+                            ]
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "layer-protocol": {
+                            "type": "array",
+                            "x-key": "local-id",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            }
+                        },
+                        "mapped-service-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-common:service-end-point/tapi-common:uuid"
+                            }
+                        },
+                        "link-port-direction": {
+                            "description": "The orientation of defined flow at the LinkEnd.",
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "transfer-timing-pac": {
+            "description": "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.",
+            "properties": {
+                "latency-characteristic": {
+                    "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                    "type": "array",
+                    "x-key": "traffic-property-name traffic-property-queing-latency",
+                    "items": {
+                        "$ref": "#/definitions/latency-characteristic"
+                    }
+                }
+            }
+        },
+        "transfer-integrity-pac": {
+            "description": "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.\nIt includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.\nNote that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.",
+            "properties": {
+                "error-characteristic": {
+                    "description": "Describes the degree to which the signal propagated can be errored. \nApplies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.",
+                    "type": "string"
+                },
+                "loss-characteristic": {
+                    "description": "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.\nApplies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).",
+                    "type": "string"
+                },
+                "server-integrity-process-characteristic": {
+                    "description": "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.",
+                    "type": "string"
+                },
+                "repeat-delivery-characteristic": {
+                    "description": "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). \nIt can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.",
+                    "type": "string"
+                },
+                "unavailable-time-characteristic": {
+                    "description": "Describes the duration for which there may be no valid signal propagated.",
+                    "type": "string"
+                },
+                "delivery-order-characteristic": {
+                    "description": "Describes the degree to which packets will be delivered out of sequence.\nDoes not apply to TDM as the TDM protocols maintain strict order.",
+                    "type": "string"
+                }
+            }
+        },
+        "transfer-capacity-pac": {
+            "description": "The TopologicalEntity derives capacity from the underlying realization. \nA TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.\nA TopologicalEntity may be directly used in the view or may be assigned to another view for use.\nThe clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.\nRepresents the capacity available to user (client) along with client interaction and usage. \nA TopologicalEntity may reflect one or more client protocols and one or more members for each profile.",
+            "properties": {
+                "capacity-assigned-to-user-view": {
+                    "description": "Capacity already assigned",
+                    "type": "array",
+                    "x-key": "total-size",
+                    "items": {
+                        "$ref": "#/definitions/capacity"
+                    }
+                },
+                "available-capacity": {
+                    "description": "Capacity available to be assigned.",
+                    "$ref": "#/definitions/capacity"
+                },
+                "capacity-interaction-algorithm": {
+                    "description": "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)",
+                    "type": "string"
+                },
+                "total-potential-capacity": {
+                    "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                    "$ref": "#/definitions/capacity"
+                }
+            }
         },
         "operational-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
@@ -6098,100 +6880,6 @@
                 }
             }
         },
-        "time-range": {
-            "properties": {
-                "end-time": {
-                    "type": "string"
-                },
-                "start-time": {
-                    "type": "string"
-                }
-            }
-        },
-        "layer-protocol": {
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "termination-state": {
-                            "type": "string",
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        },
-                        "layer-protocol-name": {
-                            "enum": [
-                                "och",
-                                "odu",
-                                "eth",
-                                "mpls-tp"
-                            ],
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        }
-                    }
-                }
-            ]
-        },
-        "name-and-value": {
-            "description": "A scoped name-value pair",
-            "properties": {
-                "value": {
-                    "type": "string",
-                    "description": "The value"
-                },
-                "value-name": {
-                    "type": "string",
-                    "description": "The name of the value. The value need not have a name."
-                }
-            }
-        },
-        "local-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
-            "properties": {
-                "local-id": {
-                    "type": "string"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
-                }
-            }
-        },
-        "service-end-point": {
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "layer-protocol": {
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "type": "array",
-                            "x-key": "local-id"
-                        },
-                        "direction": {
-                            "type": "string"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/lifecycle-state-pac"
-                        }
-                    }
-                }
-            ]
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -6203,13 +6891,13 @@
         "admin-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
             "properties": {
-                "administrative-state": {
-                    "type": "string"
-                },
                 "lifecycle-state": {
                     "type": "string"
                 },
                 "operational-state": {
+                    "type": "string"
+                },
+                "administrative-state": {
                     "type": "string"
                 }
             }
@@ -6217,33 +6905,146 @@
         "service-spec": {
             "$ref": "#/definitions/global-class"
         },
-        "global-class": {
-            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+        "time-range": {
             "properties": {
-                "label": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                    "x-key": "value-name"
+                "start-time": {
+                    "type": "string"
                 },
-                "uuid": {
-                    "type": "string",
-                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                },
-                "name": {
-                    "items": {
-                        "$ref": "#/definitions/name-and-value"
-                    },
-                    "type": "array",
-                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                    "x-key": "value-name"
+                "end-time": {
+                    "type": "string"
                 }
             }
         },
+        "local-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+            "properties": {
+                "local-id": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    }
+                }
+            }
+        },
+        "name-and-value": {
+            "description": "A scoped name-value pair",
+            "properties": {
+                "value-name": {
+                    "description": "The name of the value. The value need not have a name.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "The value",
+                    "type": "string"
+                }
+            }
+        },
+        "context": {
+            "description": "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/global-class"
+                },
+                {
+                    "properties": {
+                        "service-end-point": {
+                            "type": "array",
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/service-end-point"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "resource-spec": {
             "$ref": "#/definitions/global-class"
+        },
+        "global-class": {
+            "description": "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ",
+            "properties": {
+                "name": {
+                    "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    }
+                },
+                "label": {
+                    "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                    "type": "array",
+                    "x-key": "value-name",
+                    "items": {
+                        "$ref": "#/definitions/name-and-value"
+                    }
+                },
+                "uuid": {
+                    "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                    "type": "string"
+                }
+            }
+        },
+        "service-end-point": {
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "direction": {
+                            "type": "string"
+                        },
+                        "layer-protocol": {
+                            "type": "array",
+                            "x-key": "local-id",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            }
+                        },
+                        "state": {
+                            "$ref": "#/definitions/lifecycle-state-pac"
+                        }
+                    }
+                }
+            ]
+        },
+        "layer-protocol": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "layer-protocol-name": {
+                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity.",
+                            "type": "string",
+                            "enum": [
+                                "och",
+                                "odu",
+                                "eth",
+                                "mpls-tp"
+                            ]
+                        },
+                        "termination-state": {
+                            "description": "Indicates whether the layer is terminated and if so how.",
+                            "type": "string"
+                        },
+                        "termination-direction": {
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
         },
         "context_schema": {
             "allOf": [
@@ -6252,42 +7053,42 @@
                 },
                 {
                     "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
                         "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "x-key": "value-name",
                             "items": {
                                 "$ref": "#/definitions/name-and-value"
-                            },
+                            }
+                        },
+                        "topology": {
                             "type": "array",
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "x-key": "value-name"
+                            "x-key": "uuid",
+                            "items": {
+                                "$ref": "#/definitions/topology"
+                            }
                         },
                         "virtual-nw-service": {
+                            "type": "array",
+                            "x-key": "uuid",
                             "items": {
                                 "$ref": "#/definitions/virtual-network-service"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
+                            }
                         },
                         "label": {
+                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
+                            "type": "array",
+                            "x-key": "value-name",
                             "items": {
                                 "$ref": "#/definitions/name-and-value"
-                            },
-                            "type": "array",
-                            "description": "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.",
-                            "x-key": "value-name"
+                            }
+                        },
+                        "uuid": {
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                            "type": "string"
                         },
                         "nw-topology-service": {
                             "$ref": "#/definitions/network-topology-service"
-                        },
-                        "topology": {
-                            "items": {
-                                "$ref": "#/definitions/topology"
-                            },
-                            "type": "array",
-                            "x-key": "uuid"
                         }
                     }
                 }
@@ -6295,17 +7096,17 @@
         },
         "create-virtual-network-serviceRPC_input_schema": {
             "properties": {
-                "service-port": {
-                    "items": {
-                        "$ref": "#/definitions/virtual-network-service-port"
-                    },
-                    "type": "array"
+                "vnw-constraint": {
+                    "$ref": "#/definitions/virtual-network-constraint"
                 },
                 "conn-schedule": {
                     "type": "string"
                 },
-                "vnw-constraint": {
-                    "$ref": "#/definitions/virtual-network-constraint"
+                "service-port": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/virtual-network-service-port"
+                    }
                 }
             }
         },
@@ -6347,10 +7148,10 @@
         "get-virtual-network-service-listRPC_output_schema": {
             "properties": {
                 "vnw-service": {
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/virtual-network-service"
-                    },
-                    "type": "array"
+                    }
                 }
             }
         }

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -133,7 +133,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
           <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).</body>
         </ownedComment>
         <generalization xmi:type="uml:Generalization" xmi:id="_NqC_oO_iEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_O3TVoshqEeaVlemTikmRHw" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" aggregation="composite" association="_O3NPAMhqEeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_O3TVoshqEeaVlemTikmRHw" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" isReadOnly="true" aggregation="composite" association="_O3NPAMhqEeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YVSTAMhqEeaVlemTikmRHw" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YVYZochqEeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -376,11 +376,11 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_l8TgscF3EeaALJQAf08uAg" name="_corouteInclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_l8BM0MF3EeaALJQAf08uAg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l8TgscF3EeaALJQAf08uAg" name="_corouteInclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" isReadOnly="true" association="_l8BM0MF3EeaALJQAf08uAg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zv3oIMGAEeaALJQAf08uAg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zxHlUcGAEeaALJQAf08uAg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wt-RckXOEeaB8vMnkFQLXQ" name="_diversityExclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_wt9DUEXOEeaB8vMnkFQLXQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wt-RckXOEeaB8vMnkFQLXQ" name="_diversityExclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" isReadOnly="true" association="_wt9DUEXOEeaB8vMnkFQLXQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Oi89IEXPEeaB8vMnkFQLXQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OjBOkEXPEeaB8vMnkFQLXQ" value="*"/>
         </ownedAttribute>
@@ -505,7 +505,7 @@ Note that depending on the service supported by an FC, an the FC can have multip
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_IM-EQchtEeaVlemTikmRHw" value="/tapi-common:context"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_l5X4NMhsEeaVlemTikmRHw" name="_connectivityService" type="_kuDzQEHaEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_l5X4MMhsEeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l5X4NMhsEeaVlemTikmRHw" name="_connectivityService" type="_kuDzQEHaEeWqPKyD1j6LMg" aggregation="composite" association="_l5X4MMhsEeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uWtQ4MhsEeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uWtQ4shsEeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -225,7 +225,7 @@ This specifics of this is typically dependent on the implementation protocol &am
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_tsdHEch5EeaVlemTikmRHw" value="/tapi-common:context"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_weSVhMh5EeaVlemTikmRHw" name="_notifSubscription" type="_oVDs4CzvEeaYO8M_h7XJ5A" isReadOnly="true" aggregation="composite" association="_weSVgMh5EeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_weSVhMh5EeaVlemTikmRHw" name="_notifSubscription" type="_oVDs4CzvEeaYO8M_h7XJ5A" aggregation="composite" association="_weSVgMh5EeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8gimcMh5EeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8gimcsh5EeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -282,7 +282,7 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_86O50chuEeaVlemTikmRHw" value="/tapi-common:context"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_JEyyNMhvEeaVlemTikmRHw" name="_pathCompService" type="_IUF7cC2XEeair-8ZDvf8jw" isReadOnly="true" aggregation="composite" association="_JEyyMMhvEeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_JEyyNMhvEeaVlemTikmRHw" name="_pathCompService" type="_IUF7cC2XEeair-8ZDvf8jw" aggregation="composite" association="_JEyyMMhvEeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_SV2G0MhvEeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SV8NcMhvEeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -625,7 +625,7 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VwRVYMhmEeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VwXcAchmEeaVlemTikmRHw" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3TemVMhmEeaVlemTikmRHw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" aggregation="composite" association="_3TemUMhmEeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3TemVMhmEeaVlemTikmRHw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_3TemUMhmEeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_73aEgMhmEeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_73aEgshmEeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/UML/TapiVirtualNetwork.uml
+++ b/UML/TapiVirtualNetwork.uml
@@ -230,7 +230,7 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <defaultValue xmi:type="uml:LiteralString" xmi:id="_PvdH0ch5EeaVlemTikmRHw" value="/tapi-common:context"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_S3gd5Mh5EeaVlemTikmRHw" name="_virtualNwService" type="_--7mUPTUEeWQB8HQFBfkJQ" isReadOnly="true" aggregation="composite" association="_S3gd4Mh5EeaVlemTikmRHw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_S3gd5Mh5EeaVlemTikmRHw" name="_virtualNwService" type="_--7mUPTUEeWQB8HQFBfkJQ" aggregation="composite" association="_S3gd4Mh5EeaVlemTikmRHw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YI7UMMh5EeaVlemTikmRHw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YI7UMsh5EeaVlemTikmRHw" value="*"/>
         </ownedAttribute>

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -120,6 +120,7 @@ module tapi-common {
         grouping context {
             list service-end-point {
                 key 'uuid';
+                config false;
                 min-elements 2;
                 uses service-end-point;
                 description "none";

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -158,12 +158,14 @@ module tapi-connectivity {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
                 }
+                config false;
                 description "none";
             }
             leaf-list diversity-exclusion {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
                 }
+                config false;
                 description "none";
             }
             leaf-list include-topology {
@@ -296,7 +298,6 @@ module tapi-connectivity {
         grouping connectivity-context {
             list connectivity-service {
                 key 'uuid';
-                config false;
                 uses connectivity-service;
                 description "none";
             }

--- a/YANG/tapi-notification.yang
+++ b/YANG/tapi-notification.yang
@@ -161,7 +161,6 @@ module tapi-notification {
         grouping notification-context {
             list notif-subscription {
                 key 'uuid';
-                config false;
                 uses notification-subscription-service;
                 description "none";
             }

--- a/YANG/tapi-path-computation.yang
+++ b/YANG/tapi-path-computation.yang
@@ -202,7 +202,6 @@ module tapi-path-computation {
         grouping path-computation-context {
             list path-comp-service {
                 key 'uuid';
-                config false;
                 uses path-computation-service;
                 description "none";
             }

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -400,6 +400,7 @@ module tapi-topology {
             }
             list topology {
                 key 'uuid';
+                config false;
                 uses topology;
                 description "none";
             }

--- a/YANG/tapi-virtual-network.yang
+++ b/YANG/tapi-virtual-network.yang
@@ -143,7 +143,6 @@ module tapi-virtual-network {
         grouping virtual-network-context {
             list virtual-nw-service {
                 key 'uuid';
-                config false;
                 uses virtual-network-service;
                 description "none";
             }

--- a/YANG/tree/tapi-common.tree
+++ b/YANG/tree/tapi-common.tree
@@ -1,74 +1,73 @@
 module: tapi-common
-    +--rw context!
-       +--rw service-end-point* [uuid]
-       |  +--ro layer-protocol* [local-id]
-       |  |  +--ro layer-protocol-name?     layer-protocol-name
-       |  |  +--ro termination-direction?   termination-direction
-       |  |  +--ro termination-state?       termination-state
-       |  |  +--ro local-id                 string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro state
-       |  |  +--ro lifecycle-state?   lifecycle-state
-       |  +--ro direction?        termination-direction
-       |  +--rw uuid              universal-id
-       |  +--rw name* [value-name]
-       |  |  +--rw value-name    string
-       |  |  +--rw value?        string
-       |  +--rw label* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
-       +--rw uuid?                universal-id
-       +--rw name* [value-name]
-       |  +--rw value-name    string
-       |  +--rw value?        string
-       +--rw label* [value-name]
-          +--rw value-name    string
-          +--rw value?        string
-
-  rpcs:
-    +---x get-service-end-point-details
-    |  +---w input
-    |  |  +---w service-epid-or-name?   string
-    |  +--ro output
-    |     +--ro service-end-point
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro lifecycle-state?   lifecycle-state
-    |        +--ro direction?        termination-direction
-    |        +--ro uuid?             universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-service-end-point-list
-       +--ro output
-          +--ro service-end-point*
-             +--ro layer-protocol* [local-id]
-             |  +--ro layer-protocol-name?     layer-protocol-name
-             |  +--ro termination-direction?   termination-direction
-             |  +--ro termination-state?       termination-state
-             |  +--ro local-id                 string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro state
-             |  +--ro lifecycle-state?   lifecycle-state
-             +--ro direction?        termination-direction
-             +--ro uuid?             universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+   +--rw context!
+      +--ro service-end-point* [uuid]
+      |  +--ro layer-protocol* [local-id]
+      |  |  +--ro layer-protocol-name?     layer-protocol-name
+      |  |  +--ro termination-direction?   termination-direction
+      |  |  +--ro termination-state?       termination-state
+      |  |  +--ro local-id                 string
+      |  |  +--ro name* [value-name]
+      |  |     +--ro value-name    string
+      |  |     +--ro value?        string
+      |  +--ro state
+      |  |  +--ro lifecycle-state?   lifecycle-state
+      |  +--ro direction?        termination-direction
+      |  +--ro uuid              universal-id
+      |  +--ro name* [value-name]
+      |  |  +--ro value-name    string
+      |  |  +--ro value?        string
+      |  +--ro label* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--rw uuid?                universal-id
+      +--rw name* [value-name]
+      |  +--rw value-name    string
+      |  +--rw value?        string
+      +--rw label* [value-name]
+         +--rw value-name    string
+         +--rw value?        string
+rpcs:
+   +---x get-service-end-point-details
+   |  +---w input
+   |  |  +---w service-epid-or-name?   string
+   |  +--ro output
+   |     +--ro service-end-point
+   |        +--ro layer-protocol* [local-id]
+   |        |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  +--ro termination-direction?   termination-direction
+   |        |  +--ro termination-state?       termination-state
+   |        |  +--ro local-id                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro state
+   |        |  +--ro lifecycle-state?   lifecycle-state
+   |        +--ro direction?        termination-direction
+   |        +--ro uuid?             universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-service-end-point-list
+      +--ro output
+         +--ro service-end-point*
+            +--ro layer-protocol* [local-id]
+            |  +--ro layer-protocol-name?     layer-protocol-name
+            |  +--ro termination-direction?   termination-direction
+            |  +--ro termination-state?       termination-state
+            |  +--ro local-id                 string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro state
+            |  +--ro lifecycle-state?   lifecycle-state
+            +--ro direction?        termination-direction
+            +--ro uuid?             universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string

--- a/YANG/tree/tapi-connectivity.tree
+++ b/YANG/tree/tapi-connectivity.tree
@@ -1,696 +1,695 @@
 module: tapi-connectivity
-  augment /tapi-common:context:
-    +--ro connectivity-service* [uuid]
-    |  +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |  +--ro service-port* [local-id]
-    |  |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |  |  +--ro role?                  tapi-common:port-role
-    |  |  +--ro direction?             tapi-common:port-direction
-    |  |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |  |  +--ro local-id               string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro conn-constraint
-    |  |  +--ro service-type?                service-type
-    |  |  +--ro service-level?               string
-    |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  +--ro requested-capacity
-    |  |  |  +--ro total-size?                   fixed-capacity-value
-    |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  +--ro committed-information-rate?   uint64
-    |  |  |  +--ro committed-burst-size?         uint64
-    |  |  |  +--ro peak-information-rate?        uint64
-    |  |  |  +--ro peak-burst-size?              uint64
-    |  |  |  +--ro color-aware?                  boolean
-    |  |  |  +--ro coupling-flag?                boolean
-    |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  +--ro cost-name         string
-    |  |  |  +--ro cost-value        string
-    |  |  |  +--ro cost-algorithm    string
-    |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  +--ro fixed-latency-characteristic?      string
-    |  |  |  +--ro jitter-characteristic?             string
-    |  |  |  +--ro wander-characteristic?             string
-    |  |  |  +--ro traffic-property-name              string
-    |  |  |  +--ro traffic-property-queing-latency    string
-    |  |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro include-route* [local-id]
-    |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  +--ro local-id           string
-    |  |  |  +--ro name* [value-name]
-    |  |  |     +--ro value-name    string
-    |  |  |     +--ro value?        string
-    |  |  +--ro exclude-route* [local-id]
-    |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  +--ro local-id           string
-    |  |  |  +--ro name* [value-name]
-    |  |  |     +--ro value-name    string
-    |  |  |     +--ro value?        string
-    |  |  +--ro local-id?                    string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro schedule
-    |  |  +--ro end-time?     date-and-time
-    |  |  +--ro start-time?   date-and-time
-    |  +--ro state
-    |  |  +--ro administrative-state?   administrative-state
-    |  |  +--ro operational-state?      operational-state
-    |  |  +--ro lifecycle-state?        lifecycle-state
-    |  +--ro direction?             tapi-common:forwarding-direction
-    |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |  +--ro uuid                   universal-id
-    |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro label* [value-name]
-    |     +--ro value-name    string
-    |     +--ro value?        string
-    +--ro connection* [uuid]
-       +--ro connection-end-point* [uuid]
-       |  +--ro layer-protocol* [local-id]
-       |  |  +--ro layer-protocol-name?     layer-protocol-name
-       |  |  +--ro termination-direction?   termination-direction
-       |  |  +--ro termination-state?       termination-state
-       |  |  +--ro local-id                 string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
-       |  +--ro state
-       |  |  +--ro operational-state?   operational-state
-       |  |  +--ro lifecycle-state?     lifecycle-state
-       |  +--ro termination-direction?       tapi-common:termination-direction
-       |  +--ro connection-port-direction?   tapi-common:port-direction
-       |  +--ro connection-port-role?        tapi-common:port-role
-       |  +--ro uuid                         universal-id
-       |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro route* [local-id]
-       |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
-       |  +--ro local-id            string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
-       +--ro state
-       |  +--ro operational-state?   operational-state
-       |  +--ro lifecycle-state?     lifecycle-state
-       +--ro layer-protocol-name?    tapi-common:layer-protocol-name
-       +--ro direction?              tapi-common:forwarding-direction
-       +--ro uuid                    universal-id
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
-
-  rpcs:
-    +---x get-connection-details
-    |  +---w input
-    |  |  +---w service-id-or-name?      string
-    |  |  +---w connection-id-or-name?   string
-    |  +--ro output
-    |     +--ro connection
-    |        +--ro connection-end-point* [uuid]
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
-    |        |  +--ro state
-    |        |  |  +--ro operational-state?   operational-state
-    |        |  |  +--ro lifecycle-state?     lifecycle-state
-    |        |  +--ro termination-direction?       tapi-common:termination-direction
-    |        |  +--ro connection-port-direction?   tapi-common:port-direction
-    |        |  +--ro connection-port-role?        tapi-common:port-role
-    |        |  +--ro uuid                         universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro route* [local-id]
-    |        |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        |  +--ro local-id            string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        +--ro state
-    |        |  +--ro operational-state?   operational-state
-    |        |  +--ro lifecycle-state?     lifecycle-state
-    |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
-    |        +--ro direction?              tapi-common:forwarding-direction
-    |        +--ro uuid?                   universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-connectivity-service-list
-    |  +--ro output
-    |     +--ro conn-service*
-    |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                  tapi-common:port-role
-    |        |  +--ro direction?             tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        |  +--ro local-id               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?                service-type
-    |        |  +--ro service-level?               string
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?             tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-connection-end-point-details
-    |  +---w input
-    |  |  +---w service-id-or-name?      string
-    |  |  +---w connection-id-or-name?   string
-    |  |  +---w conn-epid-or-name?       string
-    |  +--ro output
-    |     +--ro conn-ep
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
-    |        +--ro state
-    |        |  +--ro operational-state?   operational-state
-    |        |  +--ro lifecycle-state?     lifecycle-state
-    |        +--ro termination-direction?       tapi-common:termination-direction
-    |        +--ro connection-port-direction?   tapi-common:port-direction
-    |        +--ro connection-port-role?        tapi-common:port-role
-    |        +--ro uuid?                        universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-connectivity-service-details
-    |  +---w input
-    |  |  +---w service-id-or-name?   string
-    |  +--ro output
-    |     +--ro conn-service
-    |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                  tapi-common:port-role
-    |        |  +--ro direction?             tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        |  +--ro local-id               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?                service-type
-    |        |  +--ro service-level?               string
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?             tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x create-connectivity-service
-    |  +---w input
-    |  |  +---w service-port*
-    |  |  |  +---w service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |  |  |  +---w role?                  tapi-common:port-role
-    |  |  |  +---w direction?             tapi-common:port-direction
-    |  |  |  +---w layer-protocol-name?   tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?              string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w conn-constraint
-    |  |  |  +---w service-type?                service-type
-    |  |  |  +---w service-level?               string
-    |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  |  +---w requested-capacity
-    |  |  |  |  +---w total-size?                   fixed-capacity-value
-    |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  |  +---w committed-information-rate?   uint64
-    |  |  |  |  +---w committed-burst-size?         uint64
-    |  |  |  |  +---w peak-information-rate?        uint64
-    |  |  |  |  +---w peak-burst-size?              uint64
-    |  |  |  |  +---w color-aware?                  boolean
-    |  |  |  |  +---w coupling-flag?                boolean
-    |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  |  +---w cost-name         string
-    |  |  |  |  +---w cost-value        string
-    |  |  |  |  +---w cost-algorithm    string
-    |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  |  +---w fixed-latency-characteristic?      string
-    |  |  |  |  +---w jitter-characteristic?             string
-    |  |  |  |  +---w wander-characteristic?             string
-    |  |  |  |  +---w traffic-property-name              string
-    |  |  |  |  +---w traffic-property-queing-latency    string
-    |  |  |  +---w coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  |  +---w include-route* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w exclude-route* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w local-id?                    string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w conn-schedule?     string
-    |  +--ro output
-    |     +--ro conn-service
-    |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                  tapi-common:port-role
-    |        |  +--ro direction?             tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        |  +--ro local-id               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?                service-type
-    |        |  +--ro service-level?               string
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?             tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x update-connectivity-service
-    |  +---w input
-    |  |  +---w service-id-or-name?   string
-    |  |  +---w conn-constraint
-    |  |  |  +---w service-type?                service-type
-    |  |  |  +---w service-level?               string
-    |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  |  +---w requested-capacity
-    |  |  |  |  +---w total-size?                   fixed-capacity-value
-    |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  |  +---w committed-information-rate?   uint64
-    |  |  |  |  +---w committed-burst-size?         uint64
-    |  |  |  |  +---w peak-information-rate?        uint64
-    |  |  |  |  +---w peak-burst-size?              uint64
-    |  |  |  |  +---w color-aware?                  boolean
-    |  |  |  |  +---w coupling-flag?                boolean
-    |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  |  +---w cost-name         string
-    |  |  |  |  +---w cost-value        string
-    |  |  |  |  +---w cost-algorithm    string
-    |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  |  +---w fixed-latency-characteristic?      string
-    |  |  |  |  +---w jitter-characteristic?             string
-    |  |  |  |  +---w wander-characteristic?             string
-    |  |  |  |  +---w traffic-property-name              string
-    |  |  |  |  +---w traffic-property-queing-latency    string
-    |  |  |  +---w coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  |  +---w include-route* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w exclude-route* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w local-id?                    string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w conn-schedule?        string
-    |  +--ro output
-    |     +--ro conn-service
-    |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                  tapi-common:port-role
-    |        |  +--ro direction?             tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        |  +--ro local-id               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?                service-type
-    |        |  +--ro service-level?               string
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-route* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?             tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x delete-connectivity-service
-       +---w input
-       |  +---w service-id-or-name?   string
-       +--ro output
-          +--ro conn-service
-             +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
-             +--ro service-port* [local-id]
-             |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
-             |  +--ro role?                  tapi-common:port-role
-             |  +--ro direction?             tapi-common:port-direction
-             |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-             |  +--ro local-id               string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro conn-constraint
-             |  +--ro service-type?                service-type
-             |  +--ro service-level?               string
-             |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-             |  +--ro requested-capacity
-             |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  +--ro committed-information-rate?   uint64
-             |  |  +--ro committed-burst-size?         uint64
-             |  |  +--ro peak-information-rate?        uint64
-             |  |  +--ro peak-burst-size?              uint64
-             |  |  +--ro color-aware?                  boolean
-             |  |  +--ro coupling-flag?                boolean
-             |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-             |  |  +--ro cost-name         string
-             |  |  +--ro cost-value        string
-             |  |  +--ro cost-algorithm    string
-             |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-             |  |  +--ro fixed-latency-characteristic?      string
-             |  |  +--ro jitter-characteristic?             string
-             |  |  +--ro wander-characteristic?             string
-             |  |  +--ro traffic-property-name              string
-             |  |  +--ro traffic-property-queing-latency    string
-             |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-             |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-             |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-             |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-             |  +--ro include-route* [local-id]
-             |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro local-id           string
-             |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro exclude-route* [local-id]
-             |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro local-id           string
-             |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro local-id?                    string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro schedule
-             |  +--ro end-time?     date-and-time
-             |  +--ro start-time?   date-and-time
-             +--ro state
-             |  +--ro administrative-state?   administrative-state
-             |  +--ro operational-state?      operational-state
-             |  +--ro lifecycle-state?        lifecycle-state
-             +--ro direction?             tapi-common:forwarding-direction
-             +--ro layer-protocol-name?   tapi-common:layer-protocol-name
-             +--ro uuid?                  universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+augment /tapi-common:context:
+   +--rw connectivity-service* [uuid]
+   |  +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |  +--rw service-port* [local-id]
+   |  |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |  |  +--ro role?                  tapi-common:port-role
+   |  |  +--ro direction?             tapi-common:port-direction
+   |  |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |  |  +--rw local-id               string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw conn-constraint
+   |  |  +--ro service-type?                service-type
+   |  |  +--ro service-level?               string
+   |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+   |  |  +--ro requested-capacity
+   |  |  |  +--ro total-size?                   fixed-capacity-value
+   |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  +--ro committed-information-rate?   uint64
+   |  |  |  +--ro committed-burst-size?         uint64
+   |  |  |  +--ro peak-information-rate?        uint64
+   |  |  |  +--ro peak-burst-size?              uint64
+   |  |  |  +--ro color-aware?                  boolean
+   |  |  |  +--ro coupling-flag?                boolean
+   |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  +--ro cost-name         string
+   |  |  |  +--ro cost-value        string
+   |  |  |  +--ro cost-algorithm    string
+   |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  +--ro fixed-latency-characteristic?      string
+   |  |  |  +--ro jitter-characteristic?             string
+   |  |  |  +--ro wander-characteristic?             string
+   |  |  |  +--ro traffic-property-name              string
+   |  |  |  +--ro traffic-property-queing-latency    string
+   |  |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  +--ro include-route* [local-id]
+   |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  +--ro local-id           string
+   |  |  |  +--ro name* [value-name]
+   |  |  |     +--ro value-name    string
+   |  |  |     +--ro value?        string
+   |  |  +--ro exclude-route* [local-id]
+   |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  +--ro local-id           string
+   |  |  |  +--ro name* [value-name]
+   |  |  |     +--ro value-name    string
+   |  |  |     +--ro value?        string
+   |  |  +--rw local-id?                    string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw schedule
+   |  |  +--rw end-time?     date-and-time
+   |  |  +--rw start-time?   date-and-time
+   |  +--rw state
+   |  |  +--rw administrative-state?   administrative-state
+   |  |  +--rw operational-state?      operational-state
+   |  |  +--rw lifecycle-state?        lifecycle-state
+   |  +--rw direction?             tapi-common:forwarding-direction
+   |  +--rw layer-protocol-name?   tapi-common:layer-protocol-name
+   |  +--rw uuid                   universal-id
+   |  +--rw name* [value-name]
+   |  |  +--rw value-name    string
+   |  |  +--rw value?        string
+   |  +--rw label* [value-name]
+   |     +--rw value-name    string
+   |     +--rw value?        string
+   +--ro connection* [uuid]
+      +--ro connection-end-point* [uuid]
+      |  +--ro layer-protocol* [local-id]
+      |  |  +--ro layer-protocol-name?     layer-protocol-name
+      |  |  +--ro termination-direction?   termination-direction
+      |  |  +--ro termination-state?       termination-state
+      |  |  +--ro local-id                 string
+      |  |  +--ro name* [value-name]
+      |  |     +--ro value-name    string
+      |  |     +--ro value?        string
+      |  +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
+      |  +--ro state
+      |  |  +--ro operational-state?   operational-state
+      |  |  +--ro lifecycle-state?     lifecycle-state
+      |  +--ro termination-direction?       tapi-common:termination-direction
+      |  +--ro connection-port-direction?   tapi-common:port-direction
+      |  +--ro connection-port-role?        tapi-common:port-role
+      |  +--ro uuid                         universal-id
+      |  +--ro name* [value-name]
+      |  |  +--ro value-name    string
+      |  |  +--ro value?        string
+      |  +--ro label* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro route* [local-id]
+      |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
+      |  +--ro local-id            string
+      |  +--ro name* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
+      +--ro state
+      |  +--ro operational-state?   operational-state
+      |  +--ro lifecycle-state?     lifecycle-state
+      +--ro layer-protocol-name?    tapi-common:layer-protocol-name
+      +--ro direction?              tapi-common:forwarding-direction
+      +--ro uuid                    universal-id
+      +--ro name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro label* [value-name]
+         +--ro value-name    string
+         +--ro value?        string
+rpcs:
+   +---x get-connection-details
+   |  +---w input
+   |  |  +---w service-id-or-name?      string
+   |  |  +---w connection-id-or-name?   string
+   |  +--ro output
+   |     +--ro connection
+   |        +--ro connection-end-point* [uuid]
+   |        |  +--ro layer-protocol* [local-id]
+   |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  |  +--ro termination-direction?   termination-direction
+   |        |  |  +--ro termination-state?       termination-state
+   |        |  |  +--ro local-id                 string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
+   |        |  +--ro state
+   |        |  |  +--ro operational-state?   operational-state
+   |        |  |  +--ro lifecycle-state?     lifecycle-state
+   |        |  +--ro termination-direction?       tapi-common:termination-direction
+   |        |  +--ro connection-port-direction?   tapi-common:port-direction
+   |        |  +--ro connection-port-role?        tapi-common:port-role
+   |        |  +--ro uuid                         universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro route* [local-id]
+   |        |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |        |  +--ro local-id            string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        +--ro state
+   |        |  +--ro operational-state?   operational-state
+   |        |  +--ro lifecycle-state?     lifecycle-state
+   |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
+   |        +--ro direction?              tapi-common:forwarding-direction
+   |        +--ro uuid?                   universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-connectivity-service-list
+   |  +--ro output
+   |     +--ro conn-service*
+   |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                  tapi-common:port-role
+   |        |  +--ro direction?             tapi-common:port-direction
+   |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        |  +--ro local-id               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro conn-constraint
+   |        |  +--ro service-type?                service-type
+   |        |  +--ro service-level?               string
+   |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro include-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                    string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro direction?             tapi-common:forwarding-direction
+   |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-connection-end-point-details
+   |  +---w input
+   |  |  +---w service-id-or-name?      string
+   |  |  +---w connection-id-or-name?   string
+   |  |  +---w conn-epid-or-name?       string
+   |  +--ro output
+   |     +--ro conn-ep
+   |        +--ro layer-protocol* [local-id]
+   |        |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  +--ro termination-direction?   termination-direction
+   |        |  +--ro termination-state?       termination-state
+   |        |  +--ro local-id                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
+   |        +--ro state
+   |        |  +--ro operational-state?   operational-state
+   |        |  +--ro lifecycle-state?     lifecycle-state
+   |        +--ro termination-direction?       tapi-common:termination-direction
+   |        +--ro connection-port-direction?   tapi-common:port-direction
+   |        +--ro connection-port-role?        tapi-common:port-role
+   |        +--ro uuid?                        universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-connectivity-service-details
+   |  +---w input
+   |  |  +---w service-id-or-name?   string
+   |  +--ro output
+   |     +--ro conn-service
+   |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                  tapi-common:port-role
+   |        |  +--ro direction?             tapi-common:port-direction
+   |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        |  +--ro local-id               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro conn-constraint
+   |        |  +--ro service-type?                service-type
+   |        |  +--ro service-level?               string
+   |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro include-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                    string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro direction?             tapi-common:forwarding-direction
+   |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x create-connectivity-service
+   |  +---w input
+   |  |  +---w service-port*
+   |  |  |  +---w service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |  |  |  +---w role?                  tapi-common:port-role
+   |  |  |  +---w direction?             tapi-common:port-direction
+   |  |  |  +---w layer-protocol-name?   tapi-common:layer-protocol-name
+   |  |  |  +---w local-id?              string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w conn-constraint
+   |  |  |  +---w service-type?                service-type
+   |  |  |  +---w service-level?               string
+   |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
+   |  |  |  +---w requested-capacity
+   |  |  |  |  +---w total-size?                   fixed-capacity-value
+   |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  |  +---w committed-information-rate?   uint64
+   |  |  |  |  +---w committed-burst-size?         uint64
+   |  |  |  |  +---w peak-information-rate?        uint64
+   |  |  |  |  +---w peak-burst-size?              uint64
+   |  |  |  |  +---w color-aware?                  boolean
+   |  |  |  |  +---w coupling-flag?                boolean
+   |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  |  +---w cost-name         string
+   |  |  |  |  +---w cost-value        string
+   |  |  |  |  +---w cost-algorithm    string
+   |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  |  +---w fixed-latency-characteristic?      string
+   |  |  |  |  +---w jitter-characteristic?             string
+   |  |  |  |  +---w wander-characteristic?             string
+   |  |  |  |  +---w traffic-property-name              string
+   |  |  |  |  +---w traffic-property-queing-latency    string
+   |  |  |  +---w coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  |  +---w diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  |  +---w include-route* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w exclude-route* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w local-id?                    string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w conn-schedule?     string
+   |  +--ro output
+   |     +--ro conn-service
+   |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                  tapi-common:port-role
+   |        |  +--ro direction?             tapi-common:port-direction
+   |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        |  +--ro local-id               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro conn-constraint
+   |        |  +--ro service-type?                service-type
+   |        |  +--ro service-level?               string
+   |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro include-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                    string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro direction?             tapi-common:forwarding-direction
+   |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x update-connectivity-service
+   |  +---w input
+   |  |  +---w service-id-or-name?   string
+   |  |  +---w conn-constraint
+   |  |  |  +---w service-type?                service-type
+   |  |  |  +---w service-level?               string
+   |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
+   |  |  |  +---w requested-capacity
+   |  |  |  |  +---w total-size?                   fixed-capacity-value
+   |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  |  +---w committed-information-rate?   uint64
+   |  |  |  |  +---w committed-burst-size?         uint64
+   |  |  |  |  +---w peak-information-rate?        uint64
+   |  |  |  |  +---w peak-burst-size?              uint64
+   |  |  |  |  +---w color-aware?                  boolean
+   |  |  |  |  +---w coupling-flag?                boolean
+   |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  |  +---w cost-name         string
+   |  |  |  |  +---w cost-value        string
+   |  |  |  |  +---w cost-algorithm    string
+   |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  |  +---w fixed-latency-characteristic?      string
+   |  |  |  |  +---w jitter-characteristic?             string
+   |  |  |  |  +---w wander-characteristic?             string
+   |  |  |  |  +---w traffic-property-name              string
+   |  |  |  |  +---w traffic-property-queing-latency    string
+   |  |  |  +---w coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  |  +---w diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  |  |  +---w include-route* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w exclude-route* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w local-id?                    string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w conn-schedule?        string
+   |  +--ro output
+   |     +--ro conn-service
+   |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                  tapi-common:port-role
+   |        |  +--ro direction?             tapi-common:port-direction
+   |        |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        |  +--ro local-id               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro conn-constraint
+   |        |  +--ro service-type?                service-type
+   |        |  +--ro service-level?               string
+   |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+   |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        |  +--ro include-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-route* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                    string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro direction?             tapi-common:forwarding-direction
+   |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x delete-connectivity-service
+      +---w input
+      |  +---w service-id-or-name?   string
+      +--ro output
+         +--ro conn-service
+            +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
+            +--ro service-port* [local-id]
+            |  +--ro service-end-point?     -> /tapi-common:context/service-end-point/uuid
+            |  +--ro role?                  tapi-common:port-role
+            |  +--ro direction?             tapi-common:port-direction
+            |  +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+            |  +--ro local-id               string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro conn-constraint
+            |  +--ro service-type?                service-type
+            |  +--ro service-level?               string
+            |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
+            |  +--ro requested-capacity
+            |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  +--ro committed-information-rate?   uint64
+            |  |  +--ro committed-burst-size?         uint64
+            |  |  +--ro peak-information-rate?        uint64
+            |  |  +--ro peak-burst-size?              uint64
+            |  |  +--ro color-aware?                  boolean
+            |  |  +--ro coupling-flag?                boolean
+            |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+            |  |  +--ro cost-name         string
+            |  |  +--ro cost-value        string
+            |  |  +--ro cost-algorithm    string
+            |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+            |  |  +--ro fixed-latency-characteristic?      string
+            |  |  +--ro jitter-characteristic?             string
+            |  |  +--ro wander-characteristic?             string
+            |  |  +--ro traffic-property-name              string
+            |  |  +--ro traffic-property-queing-latency    string
+            |  +--ro coroute-inclusion?           -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+            |  +--ro diversity-exclusion*         -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+            |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
+            |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
+            |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+            |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
+            |  +--ro include-route* [local-id]
+            |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+            |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  |  +--ro local-id           string
+            |  |  +--ro name* [value-name]
+            |  |     +--ro value-name    string
+            |  |     +--ro value?        string
+            |  +--ro exclude-route* [local-id]
+            |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+            |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  |  +--ro local-id           string
+            |  |  +--ro name* [value-name]
+            |  |     +--ro value-name    string
+            |  |     +--ro value?        string
+            |  +--ro local-id?                    string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro schedule
+            |  +--ro end-time?     date-and-time
+            |  +--ro start-time?   date-and-time
+            +--ro state
+            |  +--ro administrative-state?   administrative-state
+            |  +--ro operational-state?      operational-state
+            |  +--ro lifecycle-state?        lifecycle-state
+            +--ro direction?             tapi-common:forwarding-direction
+            +--ro layer-protocol-name?   tapi-common:layer-protocol-name
+            +--ro uuid?                  universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string

--- a/YANG/tree/tapi-eth.tree
+++ b/YANG/tree/tapi-eth.tree
@@ -1,98 +1,98 @@
 module: tapi-eth
-  augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
-    +--ro termination-spec
-    |  +--ro priority-regenerate
-    |  |  +--ro priority0?   uint64
-    |  |  +--ro priority1?   uint64
-    |  |  +--ro priority2?   uint64
-    |  |  +--ro priority3?   uint64
-    |  |  +--ro priority4?   uint64
-    |  |  +--ro priority5?   uint64
-    |  |  +--ro priority6?   uint64
-    |  |  +--ro priority7?   uint64
-    |  +--ro ether-type?                   vlan-type
-    |  +--ro filter-config*                mac-address
-    |  +--ro frametype-config?             frame-type
-    |  +--ro port-vid?                     vid
-    |  +--ro priority-code-point-config?   pcp-coding
-    +--ro adapter-spec
-       +--ro auxiliary-function-position-sequence*   uint64
-       +--ro vlan-config?                            uint64
-       +--ro csf-rdi-fdi-enable?                     boolean
-       +--ro csf-report?                             boolean
-       +--ro filter-config-snk*                      mac-address
-       +--ro mac-length?                             uint64
-       +--ro filter-config
-       |  +--ro c2-00-00-10?   boolean
-       |  +--ro c2-00-00-00?   boolean
-       |  +--ro c2-00-00-01?   boolean
-       |  +--ro c2-00-00-02?   boolean
-       |  +--ro c2-00-00-03?   boolean
-       |  +--ro c2-00-00-04?   boolean
-       |  +--ro c2-00-00-05?   boolean
-       |  +--ro c2-00-00-06?   boolean
-       |  +--ro c2-00-00-07?   boolean
-       |  +--ro c2-00-00-08?   boolean
-       |  +--ro c2-00-00-09?   boolean
-       |  +--ro c2-00-00-0a?   boolean
-       |  +--ro c2-00-00-0b?   boolean
-       |  +--ro c2-00-00-0c?   boolean
-       |  +--ro c2-00-00-0d?   boolean
-       |  +--ro c2-00-00-0e?   boolean
-       |  +--ro c2-00-00-0f?   boolean
-       |  +--ro c2-00-00-20?   boolean
-       |  +--ro c2-00-00-21?   boolean
-       |  +--ro c2-00-00-22?   boolean
-       |  +--ro c2-00-00-23?   boolean
-       |  +--ro c2-00-00-24?   boolean
-       |  +--ro c2-00-00-25?   boolean
-       |  +--ro c2-00-00-26?   boolean
-       |  +--ro c2-00-00-27?   boolean
-       |  +--ro c2-00-00-28?   boolean
-       |  +--ro c2-00-00-29?   boolean
-       |  +--ro c2-00-00-2a?   boolean
-       |  +--ro c2-00-00-2b?   boolean
-       |  +--ro c2-00-00-2c?   boolean
-       |  +--ro c2-00-00-2d?   boolean
-       |  +--ro c2-00-00-2e?   boolean
-       |  +--ro c2-00-00-2f?   boolean
-       +--ro is-ssf-reported?                        boolean
-       +--ro pll-thr?                                uint64
-       +--ro actor-oper-key?                         uint64
-       +--ro actor-system-id?                        mac-address
-       +--ro actor-system-priority?                  uint64
-       +--ro collector-max-delay?                    uint64
-       +--ro data-rate?                              uint64
-       +--ro partner-oper-key?                       uint64
-       +--ro partner-system-id?                      mac-address
-       +--ro partner-system-priority?                uint64
-       +--ro csf-config?                             csf-config
-       +--ro traffic-shaping
-       |  +--ro prio-config-list*
-       |  |  +--ro priority?   uint64
-       |  |  +--ro queue-id?   uint64
-       |  +--ro queue-config-list*
-       |  |  +--ro queue-id?          uint64
-       |  |  +--ro queue-depth?       uint64
-       |  |  +--ro queue-threshold?   uint64
-       |  +--ro sched-config?        scheduling-configuration
-       |  +--ro codirectional?       boolean
-       +--ro traffic-conditioning
-          +--ro prio-config-list*
-          |  +--ro priority?   uint64
-          |  +--ro queue-id?   uint64
-          +--ro cond-config-list*
-          |  +--ro cir?             uint64
-          |  +--ro cbs?             uint64
-          |  +--ro eir?             uint64
-          |  +--ro ebs?             uint64
-          |  +--ro coupling-flag?   boolean
-          |  +--ro colour-mode?     colour-mode
-          |  +--ro queue-id?        uint64
-          +--ro codirectional?      boolean
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
-    +--ro termination-spec
-       +--ro is-fts-enabled?        boolean
-       +--ro is-tx-pause-enabled?   boolean
-       +--ro phy-type?              ety-phy-type
-       +--ro phy-type-list*         ety-phy-type
+augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
+   +--ro termination-spec
+   |  +--ro priority-regenerate
+   |  |  +--ro priority0?   uint64
+   |  |  +--ro priority1?   uint64
+   |  |  +--ro priority2?   uint64
+   |  |  +--ro priority3?   uint64
+   |  |  +--ro priority4?   uint64
+   |  |  +--ro priority5?   uint64
+   |  |  +--ro priority6?   uint64
+   |  |  +--ro priority7?   uint64
+   |  +--ro ether-type?                   vlan-type
+   |  +--ro filter-config*                mac-address
+   |  +--ro frametype-config?             frame-type
+   |  +--ro port-vid?                     vid
+   |  +--ro priority-code-point-config?   pcp-coding
+   +--ro adapter-spec
+      +--ro auxiliary-function-position-sequence*   uint64
+      +--ro vlan-config?                            uint64
+      +--ro csf-rdi-fdi-enable?                     boolean
+      +--ro csf-report?                             boolean
+      +--ro filter-config-snk*                      mac-address
+      +--ro mac-length?                             uint64
+      +--ro filter-config
+      |  +--ro c2-00-00-10?   boolean
+      |  +--ro c2-00-00-00?   boolean
+      |  +--ro c2-00-00-01?   boolean
+      |  +--ro c2-00-00-02?   boolean
+      |  +--ro c2-00-00-03?   boolean
+      |  +--ro c2-00-00-04?   boolean
+      |  +--ro c2-00-00-05?   boolean
+      |  +--ro c2-00-00-06?   boolean
+      |  +--ro c2-00-00-07?   boolean
+      |  +--ro c2-00-00-08?   boolean
+      |  +--ro c2-00-00-09?   boolean
+      |  +--ro c2-00-00-0a?   boolean
+      |  +--ro c2-00-00-0b?   boolean
+      |  +--ro c2-00-00-0c?   boolean
+      |  +--ro c2-00-00-0d?   boolean
+      |  +--ro c2-00-00-0e?   boolean
+      |  +--ro c2-00-00-0f?   boolean
+      |  +--ro c2-00-00-20?   boolean
+      |  +--ro c2-00-00-21?   boolean
+      |  +--ro c2-00-00-22?   boolean
+      |  +--ro c2-00-00-23?   boolean
+      |  +--ro c2-00-00-24?   boolean
+      |  +--ro c2-00-00-25?   boolean
+      |  +--ro c2-00-00-26?   boolean
+      |  +--ro c2-00-00-27?   boolean
+      |  +--ro c2-00-00-28?   boolean
+      |  +--ro c2-00-00-29?   boolean
+      |  +--ro c2-00-00-2a?   boolean
+      |  +--ro c2-00-00-2b?   boolean
+      |  +--ro c2-00-00-2c?   boolean
+      |  +--ro c2-00-00-2d?   boolean
+      |  +--ro c2-00-00-2e?   boolean
+      |  +--ro c2-00-00-2f?   boolean
+      +--ro is-ssf-reported?                        boolean
+      +--ro pll-thr?                                uint64
+      +--ro actor-oper-key?                         uint64
+      +--ro actor-system-id?                        mac-address
+      +--ro actor-system-priority?                  uint64
+      +--ro collector-max-delay?                    uint64
+      +--ro data-rate?                              uint64
+      +--ro partner-oper-key?                       uint64
+      +--ro partner-system-id?                      mac-address
+      +--ro partner-system-priority?                uint64
+      +--ro csf-config?                             csf-config
+      +--ro traffic-shaping
+      |  +--ro prio-config-list*
+      |  |  +--ro priority?   uint64
+      |  |  +--ro queue-id?   uint64
+      |  +--ro queue-config-list*
+      |  |  +--ro queue-id?          uint64
+      |  |  +--ro queue-depth?       uint64
+      |  |  +--ro queue-threshold?   uint64
+      |  +--ro sched-config?        scheduling-configuration
+      |  +--ro codirectional?       boolean
+      +--ro traffic-conditioning
+         +--ro prio-config-list*
+         |  +--ro priority?   uint64
+         |  +--ro queue-id?   uint64
+         +--ro cond-config-list*
+         |  +--ro cir?             uint64
+         |  +--ro cbs?             uint64
+         |  +--ro eir?             uint64
+         |  +--ro ebs?             uint64
+         |  +--ro coupling-flag?   boolean
+         |  +--ro colour-mode?     colour-mode
+         |  +--ro queue-id?        uint64
+         +--ro codirectional?      boolean
+augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
+   +--ro termination-spec
+      +--ro is-fts-enabled?        boolean
+      +--ro is-tx-pause-enabled?   boolean
+      +--ro phy-type?              ety-phy-type
+      +--ro phy-type-list*         ety-phy-type

--- a/YANG/tree/tapi-notification.tree
+++ b/YANG/tree/tapi-notification.tree
@@ -1,456 +1,454 @@
 module: tapi-notification
-  augment /tapi-common:context:
-    +--ro notif-subscription* [uuid]
-    |  +--ro notification* [uuid]
-    |  |  +--ro notification-type?          notification-type
-    |  |  +--ro target-object-type?         object-type
-    |  |  +--ro target-object-identifier?   tapi-common:universal-id
-    |  |  +--ro target-object-name* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |  |  +--ro sequence-number?            uint64
-    |  |  +--ro source-indicator?           source-indicator
-    |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |  |  +--ro changed-attributes* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro old-value?    string
-    |  |  |  +--ro new-value?    string
-    |  |  +--ro additional-info* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro additional-text?            string
-    |  |  +--ro uuid                        universal-id
-    |  |  +--ro name* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro label* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro notification-channel
-    |  |  +--ro stream-address?     string
-    |  |  +--ro next-sequence-no?   uint64
-    |  |  +--ro local-id?           string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro subscription-filter
-    |  |  +--ro requested-notification-types*   notification-type
-    |  |  +--ro requested-object-types*         object-type
-    |  |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |  |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |  |  +--ro include-content?                boolean
-    |  |  +--ro local-id?                       string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro subscription-state?             subscription-state
-    |  +--ro supported-notification-types*   notification-type
-    |  +--ro supported-object-types*         object-type
-    |  +--ro uuid                            universal-id
-    |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro label* [value-name]
-    |     +--ro value-name    string
-    |     +--ro value?        string
-    +--ro notification* [uuid]
-       +--ro notification-type?          notification-type
-       +--ro target-object-type?         object-type
-       +--ro target-object-identifier?   tapi-common:universal-id
-       +--ro target-object-name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro event-time-stamp?           tapi-common:date-and-time
-       +--ro sequence-number?            uint64
-       +--ro source-indicator?           source-indicator
-       +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-       +--ro changed-attributes* [value-name]
-       |  +--ro value-name    string
-       |  +--ro old-value?    string
-       |  +--ro new-value?    string
-       +--ro additional-info* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro additional-text?            string
-       +--ro uuid                        universal-id
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
-
-  rpcs:
-    +---x get-supported-notification-types
-    |  +--ro output
-    |     +--ro supported-notification-types*   notification-type
-    |     +--ro supported-object-types*         object-type
-    +---x create-notification-subscription-service
-    |  +---w input
-    |  |  +---w subscription-filter
-    |  |  |  +---w requested-notification-types*   notification-type
-    |  |  |  +---w requested-object-types*         object-type
-    |  |  |  +---w requested-layer-protocols*      tapi-common:layer-protocol-name
-    |  |  |  +---w requested-object-identifier*    tapi-common:universal-id
-    |  |  |  +---w include-content?                boolean
-    |  |  |  +---w local-id?                       string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w subscription-state?    subscription-state
-    |  +--ro output
-    |     +--ro subscription-service
-    |        +--ro notification* [uuid]
-    |        |  +--ro notification-type?          notification-type
-    |        |  +--ro target-object-type?         object-type
-    |        |  +--ro target-object-identifier?   tapi-common:universal-id
-    |        |  +--ro target-object-name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |        |  +--ro sequence-number?            uint64
-    |        |  +--ro source-indicator?           source-indicator
-    |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |        |  +--ro changed-attributes* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro old-value?    string
-    |        |  |  +--ro new-value?    string
-    |        |  +--ro additional-info* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro additional-text?            string
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro notification-channel
-    |        |  +--ro stream-address?     string
-    |        |  +--ro next-sequence-no?   uint64
-    |        |  +--ro local-id?           string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-filter
-    |        |  +--ro requested-notification-types*   notification-type
-    |        |  +--ro requested-object-types*         object-type
-    |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |        |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |        |  +--ro include-content?                boolean
-    |        |  +--ro local-id?                       string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-state?             subscription-state
-    |        +--ro supported-notification-types*   notification-type
-    |        +--ro supported-object-types*         object-type
-    |        +--ro uuid?                           universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x update-notification-subscription-service
-    |  +---w input
-    |  |  +---w subscription-id-or-name?   string
-    |  |  +---w subscription-filter
-    |  |  |  +---w requested-notification-types*   notification-type
-    |  |  |  +---w requested-object-types*         object-type
-    |  |  |  +---w requested-layer-protocols*      tapi-common:layer-protocol-name
-    |  |  |  +---w requested-object-identifier*    tapi-common:universal-id
-    |  |  |  +---w include-content?                boolean
-    |  |  |  +---w local-id?                       string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w subscription-state?        subscription-state
-    |  +--ro output
-    |     +--ro subscription-service
-    |        +--ro notification* [uuid]
-    |        |  +--ro notification-type?          notification-type
-    |        |  +--ro target-object-type?         object-type
-    |        |  +--ro target-object-identifier?   tapi-common:universal-id
-    |        |  +--ro target-object-name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |        |  +--ro sequence-number?            uint64
-    |        |  +--ro source-indicator?           source-indicator
-    |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |        |  +--ro changed-attributes* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro old-value?    string
-    |        |  |  +--ro new-value?    string
-    |        |  +--ro additional-info* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro additional-text?            string
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro notification-channel
-    |        |  +--ro stream-address?     string
-    |        |  +--ro next-sequence-no?   uint64
-    |        |  +--ro local-id?           string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-filter
-    |        |  +--ro requested-notification-types*   notification-type
-    |        |  +--ro requested-object-types*         object-type
-    |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |        |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |        |  +--ro include-content?                boolean
-    |        |  +--ro local-id?                       string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-state?             subscription-state
-    |        +--ro supported-notification-types*   notification-type
-    |        +--ro supported-object-types*         object-type
-    |        +--ro uuid?                           universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x delete-notification-subscription-service
-    |  +---w input
-    |  |  +---w subscription-id-or-name?   string
-    |  +--ro output
-    |     +--ro subscription-service
-    |        +--ro notification* [uuid]
-    |        |  +--ro notification-type?          notification-type
-    |        |  +--ro target-object-type?         object-type
-    |        |  +--ro target-object-identifier?   tapi-common:universal-id
-    |        |  +--ro target-object-name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |        |  +--ro sequence-number?            uint64
-    |        |  +--ro source-indicator?           source-indicator
-    |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |        |  +--ro changed-attributes* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro old-value?    string
-    |        |  |  +--ro new-value?    string
-    |        |  +--ro additional-info* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro additional-text?            string
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro notification-channel
-    |        |  +--ro stream-address?     string
-    |        |  +--ro next-sequence-no?   uint64
-    |        |  +--ro local-id?           string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-filter
-    |        |  +--ro requested-notification-types*   notification-type
-    |        |  +--ro requested-object-types*         object-type
-    |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |        |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |        |  +--ro include-content?                boolean
-    |        |  +--ro local-id?                       string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-state?             subscription-state
-    |        +--ro supported-notification-types*   notification-type
-    |        +--ro supported-object-types*         object-type
-    |        +--ro uuid?                           universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-notification-subscription-service-details
-    |  +---w input
-    |  |  +---w subscription-id-or-name?   string
-    |  +--ro output
-    |     +--ro subscription-service
-    |        +--ro notification* [uuid]
-    |        |  +--ro notification-type?          notification-type
-    |        |  +--ro target-object-type?         object-type
-    |        |  +--ro target-object-identifier?   tapi-common:universal-id
-    |        |  +--ro target-object-name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |        |  +--ro sequence-number?            uint64
-    |        |  +--ro source-indicator?           source-indicator
-    |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |        |  +--ro changed-attributes* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro old-value?    string
-    |        |  |  +--ro new-value?    string
-    |        |  +--ro additional-info* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro additional-text?            string
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro notification-channel
-    |        |  +--ro stream-address?     string
-    |        |  +--ro next-sequence-no?   uint64
-    |        |  +--ro local-id?           string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-filter
-    |        |  +--ro requested-notification-types*   notification-type
-    |        |  +--ro requested-object-types*         object-type
-    |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |        |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |        |  +--ro include-content?                boolean
-    |        |  +--ro local-id?                       string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-state?             subscription-state
-    |        +--ro supported-notification-types*   notification-type
-    |        +--ro supported-object-types*         object-type
-    |        +--ro uuid?                           universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-notification-subscription-service-list
-    |  +--ro output
-    |     +--ro subscription-service*
-    |        +--ro notification* [uuid]
-    |        |  +--ro notification-type?          notification-type
-    |        |  +--ro target-object-type?         object-type
-    |        |  +--ro target-object-identifier?   tapi-common:universal-id
-    |        |  +--ro target-object-name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro event-time-stamp?           tapi-common:date-and-time
-    |        |  +--ro sequence-number?            uint64
-    |        |  +--ro source-indicator?           source-indicator
-    |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-    |        |  +--ro changed-attributes* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro old-value?    string
-    |        |  |  +--ro new-value?    string
-    |        |  +--ro additional-info* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro additional-text?            string
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro notification-channel
-    |        |  +--ro stream-address?     string
-    |        |  +--ro next-sequence-no?   uint64
-    |        |  +--ro local-id?           string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-filter
-    |        |  +--ro requested-notification-types*   notification-type
-    |        |  +--ro requested-object-types*         object-type
-    |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
-    |        |  +--ro requested-object-identifier*    tapi-common:universal-id
-    |        |  +--ro include-content?                boolean
-    |        |  +--ro local-id?                       string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro subscription-state?             subscription-state
-    |        +--ro supported-notification-types*   notification-type
-    |        +--ro supported-object-types*         object-type
-    |        +--ro uuid?                           universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-notification-list
-       +---w input
-       |  +---w subscription-id-or-name?   string
-       |  +---w time-period?               string
-       +--ro output
-          +--ro notification*
-             +--ro notification-type?          notification-type
-             +--ro target-object-type?         object-type
-             +--ro target-object-identifier?   tapi-common:universal-id
-             +--ro target-object-name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro event-time-stamp?           tapi-common:date-and-time
-             +--ro sequence-number?            uint64
-             +--ro source-indicator?           source-indicator
-             +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-             +--ro changed-attributes* [value-name]
-             |  +--ro value-name    string
-             |  +--ro old-value?    string
-             |  +--ro new-value?    string
-             +--ro additional-info* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro additional-text?            string
-             +--ro uuid?                       universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
-
-  notifications:
-    +---n notification
-       +--ro notification-type?          notification-type
-       +--ro target-object-type?         object-type
-       +--ro target-object-identifier?   tapi-common:universal-id
-       +--ro target-object-name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro event-time-stamp?           tapi-common:date-and-time
-       +--ro sequence-number?            uint64
-       +--ro source-indicator?           source-indicator
-       +--ro layer-protocol-name?        tapi-common:layer-protocol-name
-       +--ro changed-attributes* [value-name]
-       |  +--ro value-name    string
-       |  +--ro old-value?    string
-       |  +--ro new-value?    string
-       +--ro additional-info* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro additional-text?            string
-       +--ro uuid?                       universal-id
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+augment /tapi-common:context:
+   +--rw notif-subscription* [uuid]
+   |  +--ro notification* [uuid]
+   |  |  +--ro notification-type?          notification-type
+   |  |  +--ro target-object-type?         object-type
+   |  |  +--ro target-object-identifier?   tapi-common:universal-id
+   |  |  +--ro target-object-name* [value-name]
+   |  |  |  +--ro value-name    string
+   |  |  |  +--ro value?        string
+   |  |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |  |  +--ro sequence-number?            uint64
+   |  |  +--ro source-indicator?           source-indicator
+   |  |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |  |  +--ro changed-attributes* [value-name]
+   |  |  |  +--ro value-name    string
+   |  |  |  +--ro old-value?    string
+   |  |  |  +--ro new-value?    string
+   |  |  +--ro additional-info* [value-name]
+   |  |  |  +--ro value-name    string
+   |  |  |  +--ro value?        string
+   |  |  +--ro additional-text?            string
+   |  |  +--ro uuid                        universal-id
+   |  |  +--ro name* [value-name]
+   |  |  |  +--ro value-name    string
+   |  |  |  +--ro value?        string
+   |  |  +--ro label* [value-name]
+   |  |     +--ro value-name    string
+   |  |     +--ro value?        string
+   |  +--rw notification-channel
+   |  |  +--ro stream-address?     string
+   |  |  +--ro next-sequence-no?   uint64
+   |  |  +--rw local-id?           string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw subscription-filter
+   |  |  +--ro requested-notification-types*   notification-type
+   |  |  +--ro requested-object-types*         object-type
+   |  |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |  |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |  |  +--ro include-content?                boolean
+   |  |  +--rw local-id?                       string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw subscription-state?             subscription-state
+   |  +--ro supported-notification-types*   notification-type
+   |  +--ro supported-object-types*         object-type
+   |  +--rw uuid                            universal-id
+   |  +--rw name* [value-name]
+   |  |  +--rw value-name    string
+   |  |  +--rw value?        string
+   |  +--rw label* [value-name]
+   |     +--rw value-name    string
+   |     +--rw value?        string
+   +--ro notification* [uuid]
+      +--ro notification-type?          notification-type
+      +--ro target-object-type?         object-type
+      +--ro target-object-identifier?   tapi-common:universal-id
+      +--ro target-object-name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro event-time-stamp?           tapi-common:date-and-time
+      +--ro sequence-number?            uint64
+      +--ro source-indicator?           source-indicator
+      +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+      +--ro changed-attributes* [value-name]
+      |  +--ro value-name    string
+      |  +--ro old-value?    string
+      |  +--ro new-value?    string
+      +--ro additional-info* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro additional-text?            string
+      +--ro uuid                        universal-id
+      +--ro name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro label* [value-name]
+         +--ro value-name    string
+         +--ro value?        string
+rpcs:
+   +---x get-supported-notification-types
+   |  +--ro output
+   |     +--ro supported-notification-types*   notification-type
+   |     +--ro supported-object-types*         object-type
+   +---x create-notification-subscription-service
+   |  +---w input
+   |  |  +---w subscription-filter
+   |  |  |  +---w requested-notification-types*   notification-type
+   |  |  |  +---w requested-object-types*         object-type
+   |  |  |  +---w requested-layer-protocols*      tapi-common:layer-protocol-name
+   |  |  |  +---w requested-object-identifier*    tapi-common:universal-id
+   |  |  |  +---w include-content?                boolean
+   |  |  |  +---w local-id?                       string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w subscription-state?    subscription-state
+   |  +--ro output
+   |     +--ro subscription-service
+   |        +--ro notification* [uuid]
+   |        |  +--ro notification-type?          notification-type
+   |        |  +--ro target-object-type?         object-type
+   |        |  +--ro target-object-identifier?   tapi-common:universal-id
+   |        |  +--ro target-object-name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |        |  +--ro sequence-number?            uint64
+   |        |  +--ro source-indicator?           source-indicator
+   |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |        |  +--ro changed-attributes* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro old-value?    string
+   |        |  |  +--ro new-value?    string
+   |        |  +--ro additional-info* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro additional-text?            string
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro notification-channel
+   |        |  +--ro stream-address?     string
+   |        |  +--ro next-sequence-no?   uint64
+   |        |  +--ro local-id?           string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-filter
+   |        |  +--ro requested-notification-types*   notification-type
+   |        |  +--ro requested-object-types*         object-type
+   |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |        |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |        |  +--ro include-content?                boolean
+   |        |  +--ro local-id?                       string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-state?             subscription-state
+   |        +--ro supported-notification-types*   notification-type
+   |        +--ro supported-object-types*         object-type
+   |        +--ro uuid?                           universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x update-notification-subscription-service
+   |  +---w input
+   |  |  +---w subscription-id-or-name?   string
+   |  |  +---w subscription-filter
+   |  |  |  +---w requested-notification-types*   notification-type
+   |  |  |  +---w requested-object-types*         object-type
+   |  |  |  +---w requested-layer-protocols*      tapi-common:layer-protocol-name
+   |  |  |  +---w requested-object-identifier*    tapi-common:universal-id
+   |  |  |  +---w include-content?                boolean
+   |  |  |  +---w local-id?                       string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w subscription-state?        subscription-state
+   |  +--ro output
+   |     +--ro subscription-service
+   |        +--ro notification* [uuid]
+   |        |  +--ro notification-type?          notification-type
+   |        |  +--ro target-object-type?         object-type
+   |        |  +--ro target-object-identifier?   tapi-common:universal-id
+   |        |  +--ro target-object-name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |        |  +--ro sequence-number?            uint64
+   |        |  +--ro source-indicator?           source-indicator
+   |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |        |  +--ro changed-attributes* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro old-value?    string
+   |        |  |  +--ro new-value?    string
+   |        |  +--ro additional-info* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro additional-text?            string
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro notification-channel
+   |        |  +--ro stream-address?     string
+   |        |  +--ro next-sequence-no?   uint64
+   |        |  +--ro local-id?           string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-filter
+   |        |  +--ro requested-notification-types*   notification-type
+   |        |  +--ro requested-object-types*         object-type
+   |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |        |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |        |  +--ro include-content?                boolean
+   |        |  +--ro local-id?                       string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-state?             subscription-state
+   |        +--ro supported-notification-types*   notification-type
+   |        +--ro supported-object-types*         object-type
+   |        +--ro uuid?                           universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x delete-notification-subscription-service
+   |  +---w input
+   |  |  +---w subscription-id-or-name?   string
+   |  +--ro output
+   |     +--ro subscription-service
+   |        +--ro notification* [uuid]
+   |        |  +--ro notification-type?          notification-type
+   |        |  +--ro target-object-type?         object-type
+   |        |  +--ro target-object-identifier?   tapi-common:universal-id
+   |        |  +--ro target-object-name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |        |  +--ro sequence-number?            uint64
+   |        |  +--ro source-indicator?           source-indicator
+   |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |        |  +--ro changed-attributes* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro old-value?    string
+   |        |  |  +--ro new-value?    string
+   |        |  +--ro additional-info* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro additional-text?            string
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro notification-channel
+   |        |  +--ro stream-address?     string
+   |        |  +--ro next-sequence-no?   uint64
+   |        |  +--ro local-id?           string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-filter
+   |        |  +--ro requested-notification-types*   notification-type
+   |        |  +--ro requested-object-types*         object-type
+   |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |        |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |        |  +--ro include-content?                boolean
+   |        |  +--ro local-id?                       string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-state?             subscription-state
+   |        +--ro supported-notification-types*   notification-type
+   |        +--ro supported-object-types*         object-type
+   |        +--ro uuid?                           universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-notification-subscription-service-details
+   |  +---w input
+   |  |  +---w subscription-id-or-name?   string
+   |  +--ro output
+   |     +--ro subscription-service
+   |        +--ro notification* [uuid]
+   |        |  +--ro notification-type?          notification-type
+   |        |  +--ro target-object-type?         object-type
+   |        |  +--ro target-object-identifier?   tapi-common:universal-id
+   |        |  +--ro target-object-name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |        |  +--ro sequence-number?            uint64
+   |        |  +--ro source-indicator?           source-indicator
+   |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |        |  +--ro changed-attributes* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro old-value?    string
+   |        |  |  +--ro new-value?    string
+   |        |  +--ro additional-info* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro additional-text?            string
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro notification-channel
+   |        |  +--ro stream-address?     string
+   |        |  +--ro next-sequence-no?   uint64
+   |        |  +--ro local-id?           string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-filter
+   |        |  +--ro requested-notification-types*   notification-type
+   |        |  +--ro requested-object-types*         object-type
+   |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |        |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |        |  +--ro include-content?                boolean
+   |        |  +--ro local-id?                       string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-state?             subscription-state
+   |        +--ro supported-notification-types*   notification-type
+   |        +--ro supported-object-types*         object-type
+   |        +--ro uuid?                           universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-notification-subscription-service-list
+   |  +--ro output
+   |     +--ro subscription-service*
+   |        +--ro notification* [uuid]
+   |        |  +--ro notification-type?          notification-type
+   |        |  +--ro target-object-type?         object-type
+   |        |  +--ro target-object-identifier?   tapi-common:universal-id
+   |        |  +--ro target-object-name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro event-time-stamp?           tapi-common:date-and-time
+   |        |  +--ro sequence-number?            uint64
+   |        |  +--ro source-indicator?           source-indicator
+   |        |  +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+   |        |  +--ro changed-attributes* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro old-value?    string
+   |        |  |  +--ro new-value?    string
+   |        |  +--ro additional-info* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro additional-text?            string
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro notification-channel
+   |        |  +--ro stream-address?     string
+   |        |  +--ro next-sequence-no?   uint64
+   |        |  +--ro local-id?           string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-filter
+   |        |  +--ro requested-notification-types*   notification-type
+   |        |  +--ro requested-object-types*         object-type
+   |        |  +--ro requested-layer-protocols*      tapi-common:layer-protocol-name
+   |        |  +--ro requested-object-identifier*    tapi-common:universal-id
+   |        |  +--ro include-content?                boolean
+   |        |  +--ro local-id?                       string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro subscription-state?             subscription-state
+   |        +--ro supported-notification-types*   notification-type
+   |        +--ro supported-object-types*         object-type
+   |        +--ro uuid?                           universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-notification-list
+      +---w input
+      |  +---w subscription-id-or-name?   string
+      |  +---w time-period?               string
+      +--ro output
+         +--ro notification*
+            +--ro notification-type?          notification-type
+            +--ro target-object-type?         object-type
+            +--ro target-object-identifier?   tapi-common:universal-id
+            +--ro target-object-name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro event-time-stamp?           tapi-common:date-and-time
+            +--ro sequence-number?            uint64
+            +--ro source-indicator?           source-indicator
+            +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+            +--ro changed-attributes* [value-name]
+            |  +--ro value-name    string
+            |  +--ro old-value?    string
+            |  +--ro new-value?    string
+            +--ro additional-info* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro additional-text?            string
+            +--ro uuid?                       universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string
+notifications:
+   +---n notification
+      +--ro notification-type?          notification-type
+      +--ro target-object-type?         object-type
+      +--ro target-object-identifier?   tapi-common:universal-id
+      +--ro target-object-name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro event-time-stamp?           tapi-common:date-and-time
+      +--ro sequence-number?            uint64
+      +--ro source-indicator?           source-indicator
+      +--ro layer-protocol-name?        tapi-common:layer-protocol-name
+      +--ro changed-attributes* [value-name]
+      |  +--ro value-name    string
+      |  +--ro old-value?    string
+      |  +--ro new-value?    string
+      +--ro additional-info* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro additional-text?            string
+      +--ro uuid?                       universal-id
+      +--ro name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro label* [value-name]
+         +--ro value-name    string
+         +--ro value?        string

--- a/YANG/tree/tapi-och.tree
+++ b/YANG/tree/tapi-och.tree
@@ -1,16 +1,16 @@
 module: tapi-och
-  augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
-    +--ro adapter-spec
-    |  +--ro monitored-direction?   monitored-direction
-    +--ro termination-spec
-       +--ro selected-application-identifier
-       |  +--ro application-identifier-type?    string
-       |  +--ro application-identifier-value?   string
-       +--ro nominal-central-frequency-or-wavelength
-          +--ro link-type?                                 string
-          +--ro nominal-central-frequency-or-wavelength?   string
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
-    +--ro och-pool-property-spec
-       +--ro client-capacity?        uint64
-       +--ro max-client-instances?   uint64
-       +--ro max-client-size?        uint64
+augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
+   +--ro adapter-spec
+   |  +--ro monitored-direction?   monitored-direction
+   +--ro termination-spec
+      +--ro selected-application-identifier
+      |  +--ro application-identifier-type?    string
+      |  +--ro application-identifier-value?   string
+      +--ro nominal-central-frequency-or-wavelength
+         +--ro link-type?                                 string
+         +--ro nominal-central-frequency-or-wavelength?   string
+augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
+   +--ro och-pool-property-spec
+      +--ro client-capacity?        uint64
+      +--ro max-client-instances?   uint64
+      +--ro max-client-size?        uint64

--- a/YANG/tree/tapi-odu.tree
+++ b/YANG/tree/tapi-odu.tree
@@ -1,41 +1,41 @@
 module: tapi-odu
-  augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
-    +--ro termination-spec
-    |  +--ro rate?               string
-    |  +--ro dm-source?          boolean
-    |  +--ro dm-value?           boolean
-    |  +--ro acti?               bit-string
-    |  +--ro deg-m?              uint64
-    |  +--ro deg-thr
-    |  |  +--ro deg-thr-value?            string
-    |  |  +--ro deg-thr-type?             string
-    |  |  +--ro percentage-granularity?   string
-    |  +--ro ex-dapi?            bit-string
-    |  +--ro ex-sapi?            bit-string
-    |  +--ro tim-act-disabled?   boolean
-    |  +--ro tim-det-mode?       tim-det-mo
-    |  +--ro txti?               bit-string
-    +--ro adapter-spec
-       +--ro adaptation-active?                   boolean
-       +--ro aps-enable?                          boolean
-       +--ro aps-level?                           uint64
-       +--ro k?                                   oduk-ctp-kbit-rate
-       +--ro odu-type-and-rate?                   uint64
-       +--ro position-seq*                        oduk-tcm-or-gcc-choice
-       +--ro tributary-slot-list*                 uint64
-       +--ro applicable-problems?                 oduk-ctp-problem-list
-       +--ro expected-msi?                        string
-       +--ro accepted-msi?                        string
-       +--ro accepted-payload-type?               string
-       +--ro transmitted-msi?                     string
-       +--ro auto-payload-type?                   boolean
-       +--ro inserted-payload-type?               string
-       +--ro current-number-of-tributary-slots*   uint64
-       +--ro nominal-bit-rate-and-tolerance
-          +--ro tolerance?   uint64
-          +--ro frequency?   string
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
-    +--ro odu-pool-property-spec
-       +--ro client-capacity?        uint64
-       +--ro max-client-instances?   uint64
-       +--ro max-client-size?        uint64
+augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
+   +--ro termination-spec
+   |  +--ro rate?               string
+   |  +--ro dm-source?          boolean
+   |  +--ro dm-value?           boolean
+   |  +--ro acti?               bit-string
+   |  +--ro deg-m?              uint64
+   |  +--ro deg-thr
+   |  |  +--ro deg-thr-value?            string
+   |  |  +--ro deg-thr-type?             string
+   |  |  +--ro percentage-granularity?   string
+   |  +--ro ex-dapi?            bit-string
+   |  +--ro ex-sapi?            bit-string
+   |  +--ro tim-act-disabled?   boolean
+   |  +--ro tim-det-mode?       tim-det-mo
+   |  +--ro txti?               bit-string
+   +--ro adapter-spec
+      +--ro adaptation-active?                   boolean
+      +--ro aps-enable?                          boolean
+      +--ro aps-level?                           uint64
+      +--ro k?                                   oduk-ctp-kbit-rate
+      +--ro odu-type-and-rate?                   uint64
+      +--ro position-seq*                        oduk-tcm-or-gcc-choice
+      +--ro tributary-slot-list*                 uint64
+      +--ro applicable-problems?                 oduk-ctp-problem-list
+      +--ro expected-msi?                        string
+      +--ro accepted-msi?                        string
+      +--ro accepted-payload-type?               string
+      +--ro transmitted-msi?                     string
+      +--ro auto-payload-type?                   boolean
+      +--ro inserted-payload-type?               string
+      +--ro current-number-of-tributary-slots*   uint64
+      +--ro nominal-bit-rate-and-tolerance
+         +--ro tolerance?   uint64
+         +--ro frequency?   string
+augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
+   +--ro odu-pool-property-spec
+      +--ro client-capacity?        uint64
+      +--ro max-client-instances?   uint64
+      +--ro max-client-size?        uint64

--- a/YANG/tree/tapi-path-computation.tree
+++ b/YANG/tree/tapi-path-computation.tree
@@ -1,495 +1,494 @@
 module: tapi-path-computation
-  augment /tapi-common:context:
-    +--ro path-comp-service* [uuid]
-    |  +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  +--ro service-port* [local-id]
-    |  |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |  |  +--ro role?                tapi-common:port-role
-    |  |  +--ro direction?           tapi-common:port-direction
-    |  |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |  |  +--ro local-id             string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro routing-constraint
-    |  |  +--ro requested-capacity
-    |  |  |  +--ro total-size?                   fixed-capacity-value
-    |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  +--ro committed-information-rate?   uint64
-    |  |  |  +--ro committed-burst-size?         uint64
-    |  |  |  +--ro peak-information-rate?        uint64
-    |  |  |  +--ro peak-burst-size?              uint64
-    |  |  |  +--ro color-aware?                  boolean
-    |  |  |  +--ro coupling-flag?                boolean
-    |  |  +--ro service-level?            string
-    |  |  +--ro path-layer*               tapi-common:layer-protocol-name
-    |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  +--ro cost-name         string
-    |  |  |  +--ro cost-value        string
-    |  |  |  +--ro cost-algorithm    string
-    |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  +--ro fixed-latency-characteristic?      string
-    |  |  |  +--ro jitter-characteristic?             string
-    |  |  |  +--ro wander-characteristic?             string
-    |  |  |  +--ro traffic-property-name              string
-    |  |  |  +--ro traffic-property-queing-latency    string
-    |  |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro include-path* [local-id]
-    |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  +--ro local-id           string
-    |  |  |  +--ro name* [value-name]
-    |  |  |     +--ro value-name    string
-    |  |  |     +--ro value?        string
-    |  |  +--ro exclude-path* [local-id]
-    |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  +--ro local-id           string
-    |  |  |  +--ro name* [value-name]
-    |  |  |     +--ro value-name    string
-    |  |  |     +--ro value?        string
-    |  |  +--ro local-id?                 string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro objective-function
-    |  |  +--ro bandwidth-optimization?   tapi-common:directive-value
-    |  |  +--ro concurrent-paths?         tapi-common:directive-value
-    |  |  +--ro cost-optimization?        tapi-common:directive-value
-    |  |  +--ro link-utilization?         tapi-common:directive-value
-    |  |  +--ro resource-sharing?         tapi-common:directive-value
-    |  |  +--ro local-id?                 string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro optimization-constraint
-    |  |  +--ro traffic-interruption?   tapi-common:directive-value
-    |  |  +--ro local-id?               string
-    |  |  +--ro name* [value-name]
-    |  |     +--ro value-name    string
-    |  |     +--ro value?        string
-    |  +--ro uuid                       universal-id
-    |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro label* [value-name]
-    |     +--ro value-name    string
-    |     +--ro value?        string
-    +--ro path* [uuid]
-       +--ro telink* [local-id]
-       |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro local-id           string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro routing-constraint
-       |  +--ro requested-capacity
-       |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  +--ro committed-information-rate?   uint64
-       |  |  +--ro committed-burst-size?         uint64
-       |  |  +--ro peak-information-rate?        uint64
-       |  |  +--ro peak-burst-size?              uint64
-       |  |  +--ro color-aware?                  boolean
-       |  |  +--ro coupling-flag?                boolean
-       |  +--ro service-level?            string
-       |  +--ro path-layer*               tapi-common:layer-protocol-name
-       |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-       |  |  +--ro cost-name         string
-       |  |  +--ro cost-value        string
-       |  |  +--ro cost-algorithm    string
-       |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-       |  |  +--ro fixed-latency-characteristic?      string
-       |  |  +--ro jitter-characteristic?             string
-       |  |  +--ro wander-characteristic?             string
-       |  |  +--ro traffic-property-name              string
-       |  |  +--ro traffic-property-queing-latency    string
-       |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro include-path* [local-id]
-       |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro local-id           string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro exclude-path* [local-id]
-       |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro local-id           string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro local-id?                 string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro uuid                  universal-id
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
-
-  rpcs:
-    +---x compute-p2ppath
-    |  +---w input
-    |  |  +---w service-port*
-    |  |  |  +---w service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |  |  |  +---w role?                tapi-common:port-role
-    |  |  |  +---w direction?           tapi-common:port-direction
-    |  |  |  +---w service-layer?       tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?            string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w routing-constraint
-    |  |  |  +---w requested-capacity
-    |  |  |  |  +---w total-size?                   fixed-capacity-value
-    |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  |  +---w committed-information-rate?   uint64
-    |  |  |  |  +---w committed-burst-size?         uint64
-    |  |  |  |  +---w peak-information-rate?        uint64
-    |  |  |  |  +---w peak-burst-size?              uint64
-    |  |  |  |  +---w color-aware?                  boolean
-    |  |  |  |  +---w coupling-flag?                boolean
-    |  |  |  +---w service-level?            string
-    |  |  |  +---w path-layer*               tapi-common:layer-protocol-name
-    |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  |  +---w cost-name         string
-    |  |  |  |  +---w cost-value        string
-    |  |  |  |  +---w cost-algorithm    string
-    |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  |  +---w fixed-latency-characteristic?      string
-    |  |  |  |  +---w jitter-characteristic?             string
-    |  |  |  |  +---w wander-characteristic?             string
-    |  |  |  |  +---w traffic-property-name              string
-    |  |  |  |  +---w traffic-property-queing-latency    string
-    |  |  |  +---w include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w include-path* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w exclude-path* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w local-id?                 string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w objective-function
-    |  |     +---w bandwidth-optimization?   tapi-common:directive-value
-    |  |     +---w concurrent-paths?         tapi-common:directive-value
-    |  |     +---w cost-optimization?        tapi-common:directive-value
-    |  |     +---w link-utilization?         tapi-common:directive-value
-    |  |     +---w resource-sharing?         tapi-common:directive-value
-    |  |     +---w local-id?                 string
-    |  |     +---w name* [value-name]
-    |  |        +---w value-name    string
-    |  |        +---w value?        string
-    |  +--ro output
-    |     +--ro path-comp-service
-    |        +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                tapi-common:port-role
-    |        |  +--ro direction?           tapi-common:port-direction
-    |        |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |        |  +--ro local-id             string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro routing-constraint
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro service-level?            string
-    |        |  +--ro path-layer*               tapi-common:layer-protocol-name
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-path* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro objective-function
-    |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
-    |        |  +--ro concurrent-paths?         tapi-common:directive-value
-    |        |  +--ro cost-optimization?        tapi-common:directive-value
-    |        |  +--ro link-utilization?         tapi-common:directive-value
-    |        |  +--ro resource-sharing?         tapi-common:directive-value
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro optimization-constraint
-    |        |  +--ro traffic-interruption?   tapi-common:directive-value
-    |        |  +--ro local-id?               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                      universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x optimize-p2ppath
-    |  +---w input
-    |  |  +---w path-id-or-name?           string
-    |  |  +---w routing-constraint
-    |  |  |  +---w requested-capacity
-    |  |  |  |  +---w total-size?                   fixed-capacity-value
-    |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  |  +---w committed-information-rate?   uint64
-    |  |  |  |  +---w committed-burst-size?         uint64
-    |  |  |  |  +---w peak-information-rate?        uint64
-    |  |  |  |  +---w peak-burst-size?              uint64
-    |  |  |  |  +---w color-aware?                  boolean
-    |  |  |  |  +---w coupling-flag?                boolean
-    |  |  |  +---w service-level?            string
-    |  |  |  +---w path-layer*               tapi-common:layer-protocol-name
-    |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  |  +---w cost-name         string
-    |  |  |  |  +---w cost-value        string
-    |  |  |  |  +---w cost-algorithm    string
-    |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  |  +---w fixed-latency-characteristic?      string
-    |  |  |  |  +---w jitter-characteristic?             string
-    |  |  |  |  +---w wander-characteristic?             string
-    |  |  |  |  +---w traffic-property-name              string
-    |  |  |  |  +---w traffic-property-queing-latency    string
-    |  |  |  +---w include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  |  +---w include-path* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w exclude-path* [local-id]
-    |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |  |  |  |  +---w local-id           string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
-    |  |  |  +---w local-id?                 string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w optimization-constraint
-    |  |  |  +---w traffic-interruption?   tapi-common:directive-value
-    |  |  |  +---w local-id?               string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w objective-function
-    |  |     +---w bandwidth-optimization?   tapi-common:directive-value
-    |  |     +---w concurrent-paths?         tapi-common:directive-value
-    |  |     +---w cost-optimization?        tapi-common:directive-value
-    |  |     +---w link-utilization?         tapi-common:directive-value
-    |  |     +---w resource-sharing?         tapi-common:directive-value
-    |  |     +---w local-id?                 string
-    |  |     +---w name* [value-name]
-    |  |        +---w value-name    string
-    |  |        +---w value?        string
-    |  +--ro output
-    |     +--ro path-comp-service
-    |        +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                tapi-common:port-role
-    |        |  +--ro direction?           tapi-common:port-direction
-    |        |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |        |  +--ro local-id             string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro routing-constraint
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro service-level?            string
-    |        |  +--ro path-layer*               tapi-common:layer-protocol-name
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro exclude-path* [local-id]
-    |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro local-id           string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro objective-function
-    |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
-    |        |  +--ro concurrent-paths?         tapi-common:directive-value
-    |        |  +--ro cost-optimization?        tapi-common:directive-value
-    |        |  +--ro link-utilization?         tapi-common:directive-value
-    |        |  +--ro resource-sharing?         tapi-common:directive-value
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro optimization-constraint
-    |        |  +--ro traffic-interruption?   tapi-common:directive-value
-    |        |  +--ro local-id?               string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                      universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x delete-p2ppath
-       +---w input
-       |  +---w path-id-or-name?   string
-       +--ro output
-          +--ro path-comp-service
-             +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
-             +--ro service-port* [local-id]
-             |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-             |  +--ro role?                tapi-common:port-role
-             |  +--ro direction?           tapi-common:port-direction
-             |  +--ro service-layer?       tapi-common:layer-protocol-name
-             |  +--ro local-id             string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro routing-constraint
-             |  +--ro requested-capacity
-             |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  +--ro committed-information-rate?   uint64
-             |  |  +--ro committed-burst-size?         uint64
-             |  |  +--ro peak-information-rate?        uint64
-             |  |  +--ro peak-burst-size?              uint64
-             |  |  +--ro color-aware?                  boolean
-             |  |  +--ro coupling-flag?                boolean
-             |  +--ro service-level?            string
-             |  +--ro path-layer*               tapi-common:layer-protocol-name
-             |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-             |  |  +--ro cost-name         string
-             |  |  +--ro cost-value        string
-             |  |  +--ro cost-algorithm    string
-             |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-             |  |  +--ro fixed-latency-characteristic?      string
-             |  |  +--ro jitter-characteristic?             string
-             |  |  +--ro wander-characteristic?             string
-             |  |  +--ro traffic-property-name              string
-             |  |  +--ro traffic-property-queing-latency    string
-             |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro include-path* [local-id]
-             |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro local-id           string
-             |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro exclude-path* [local-id]
-             |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro local-id           string
-             |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro local-id?                 string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro objective-function
-             |  +--ro bandwidth-optimization?   tapi-common:directive-value
-             |  +--ro concurrent-paths?         tapi-common:directive-value
-             |  +--ro cost-optimization?        tapi-common:directive-value
-             |  +--ro link-utilization?         tapi-common:directive-value
-             |  +--ro resource-sharing?         tapi-common:directive-value
-             |  +--ro local-id?                 string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro optimization-constraint
-             |  +--ro traffic-interruption?   tapi-common:directive-value
-             |  +--ro local-id?               string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro uuid?                      universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+augment /tapi-common:context:
+   +--rw path-comp-service* [uuid]
+   |  +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
+   |  +--rw service-port* [local-id]
+   |  |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |  |  +--ro role?                tapi-common:port-role
+   |  |  +--ro direction?           tapi-common:port-direction
+   |  |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |  |  +--rw local-id             string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw routing-constraint
+   |  |  +--ro requested-capacity
+   |  |  |  +--ro total-size?                   fixed-capacity-value
+   |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  +--ro committed-information-rate?   uint64
+   |  |  |  +--ro committed-burst-size?         uint64
+   |  |  |  +--ro peak-information-rate?        uint64
+   |  |  |  +--ro peak-burst-size?              uint64
+   |  |  |  +--ro color-aware?                  boolean
+   |  |  |  +--ro coupling-flag?                boolean
+   |  |  +--ro service-level?            string
+   |  |  +--ro path-layer*               tapi-common:layer-protocol-name
+   |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  +--ro cost-name         string
+   |  |  |  +--ro cost-value        string
+   |  |  |  +--ro cost-algorithm    string
+   |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  +--ro fixed-latency-characteristic?      string
+   |  |  |  +--ro jitter-characteristic?             string
+   |  |  |  +--ro wander-characteristic?             string
+   |  |  |  +--ro traffic-property-name              string
+   |  |  |  +--ro traffic-property-queing-latency    string
+   |  |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  +--ro include-path* [local-id]
+   |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  +--ro local-id           string
+   |  |  |  +--ro name* [value-name]
+   |  |  |     +--ro value-name    string
+   |  |  |     +--ro value?        string
+   |  |  +--ro exclude-path* [local-id]
+   |  |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  +--ro local-id           string
+   |  |  |  +--ro name* [value-name]
+   |  |  |     +--ro value-name    string
+   |  |  |     +--ro value?        string
+   |  |  +--rw local-id?                 string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw objective-function
+   |  |  +--ro bandwidth-optimization?   tapi-common:directive-value
+   |  |  +--ro concurrent-paths?         tapi-common:directive-value
+   |  |  +--ro cost-optimization?        tapi-common:directive-value
+   |  |  +--ro link-utilization?         tapi-common:directive-value
+   |  |  +--ro resource-sharing?         tapi-common:directive-value
+   |  |  +--rw local-id?                 string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw optimization-constraint
+   |  |  +--ro traffic-interruption?   tapi-common:directive-value
+   |  |  +--rw local-id?               string
+   |  |  +--rw name* [value-name]
+   |  |     +--rw value-name    string
+   |  |     +--rw value?        string
+   |  +--rw uuid                       universal-id
+   |  +--rw name* [value-name]
+   |  |  +--rw value-name    string
+   |  |  +--rw value?        string
+   |  +--rw label* [value-name]
+   |     +--rw value-name    string
+   |     +--rw value?        string
+   +--ro path* [uuid]
+      +--ro telink* [local-id]
+      |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+      |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro local-id           string
+      |  +--ro name* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro routing-constraint
+      |  +--ro requested-capacity
+      |  |  +--ro total-size?                   fixed-capacity-value
+      |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  +--ro committed-information-rate?   uint64
+      |  |  +--ro committed-burst-size?         uint64
+      |  |  +--ro peak-information-rate?        uint64
+      |  |  +--ro peak-burst-size?              uint64
+      |  |  +--ro color-aware?                  boolean
+      |  |  +--ro coupling-flag?                boolean
+      |  +--ro service-level?            string
+      |  +--ro path-layer*               tapi-common:layer-protocol-name
+      |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+      |  |  +--ro cost-name         string
+      |  |  +--ro cost-value        string
+      |  |  +--ro cost-algorithm    string
+      |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+      |  |  +--ro fixed-latency-characteristic?      string
+      |  |  +--ro jitter-characteristic?             string
+      |  |  +--ro wander-characteristic?             string
+      |  |  +--ro traffic-property-name              string
+      |  |  +--ro traffic-property-queing-latency    string
+      |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+      |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+      |  +--ro include-path* [local-id]
+      |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+      |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  |  +--ro local-id           string
+      |  |  +--ro name* [value-name]
+      |  |     +--ro value-name    string
+      |  |     +--ro value?        string
+      |  +--ro exclude-path* [local-id]
+      |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+      |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  |  +--ro local-id           string
+      |  |  +--ro name* [value-name]
+      |  |     +--ro value-name    string
+      |  |     +--ro value?        string
+      |  +--ro local-id?                 string
+      |  +--ro name* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro uuid                  universal-id
+      +--ro name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro label* [value-name]
+         +--ro value-name    string
+         +--ro value?        string
+rpcs:
+   +---x compute-p2ppath
+   |  +---w input
+   |  |  +---w service-port*
+   |  |  |  +---w service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |  |  |  +---w role?                tapi-common:port-role
+   |  |  |  +---w direction?           tapi-common:port-direction
+   |  |  |  +---w service-layer?       tapi-common:layer-protocol-name
+   |  |  |  +---w local-id?            string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w routing-constraint
+   |  |  |  +---w requested-capacity
+   |  |  |  |  +---w total-size?                   fixed-capacity-value
+   |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  |  +---w committed-information-rate?   uint64
+   |  |  |  |  +---w committed-burst-size?         uint64
+   |  |  |  |  +---w peak-information-rate?        uint64
+   |  |  |  |  +---w peak-burst-size?              uint64
+   |  |  |  |  +---w color-aware?                  boolean
+   |  |  |  |  +---w coupling-flag?                boolean
+   |  |  |  +---w service-level?            string
+   |  |  |  +---w path-layer*               tapi-common:layer-protocol-name
+   |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  |  +---w cost-name         string
+   |  |  |  |  +---w cost-value        string
+   |  |  |  |  +---w cost-algorithm    string
+   |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  |  +---w fixed-latency-characteristic?      string
+   |  |  |  |  +---w jitter-characteristic?             string
+   |  |  |  |  +---w wander-characteristic?             string
+   |  |  |  |  +---w traffic-property-name              string
+   |  |  |  |  +---w traffic-property-queing-latency    string
+   |  |  |  +---w include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w include-path* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w exclude-path* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w local-id?                 string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w objective-function
+   |  |     +---w bandwidth-optimization?   tapi-common:directive-value
+   |  |     +---w concurrent-paths?         tapi-common:directive-value
+   |  |     +---w cost-optimization?        tapi-common:directive-value
+   |  |     +---w link-utilization?         tapi-common:directive-value
+   |  |     +---w resource-sharing?         tapi-common:directive-value
+   |  |     +---w local-id?                 string
+   |  |     +---w name* [value-name]
+   |  |        +---w value-name    string
+   |  |        +---w value?        string
+   |  +--ro output
+   |     +--ro path-comp-service
+   |        +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                tapi-common:port-role
+   |        |  +--ro direction?           tapi-common:port-direction
+   |        |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |        |  +--ro local-id             string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro routing-constraint
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro service-level?            string
+   |        |  +--ro path-layer*               tapi-common:layer-protocol-name
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-path* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro objective-function
+   |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
+   |        |  +--ro concurrent-paths?         tapi-common:directive-value
+   |        |  +--ro cost-optimization?        tapi-common:directive-value
+   |        |  +--ro link-utilization?         tapi-common:directive-value
+   |        |  +--ro resource-sharing?         tapi-common:directive-value
+   |        |  +--ro local-id?                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro optimization-constraint
+   |        |  +--ro traffic-interruption?   tapi-common:directive-value
+   |        |  +--ro local-id?               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro uuid?                      universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x optimize-p2ppath
+   |  +---w input
+   |  |  +---w path-id-or-name?           string
+   |  |  +---w routing-constraint
+   |  |  |  +---w requested-capacity
+   |  |  |  |  +---w total-size?                   fixed-capacity-value
+   |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  |  +---w committed-information-rate?   uint64
+   |  |  |  |  +---w committed-burst-size?         uint64
+   |  |  |  |  +---w peak-information-rate?        uint64
+   |  |  |  |  +---w peak-burst-size?              uint64
+   |  |  |  |  +---w color-aware?                  boolean
+   |  |  |  |  +---w coupling-flag?                boolean
+   |  |  |  +---w service-level?            string
+   |  |  |  +---w path-layer*               tapi-common:layer-protocol-name
+   |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  |  +---w cost-name         string
+   |  |  |  |  +---w cost-value        string
+   |  |  |  |  +---w cost-algorithm    string
+   |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  |  +---w fixed-latency-characteristic?      string
+   |  |  |  |  +---w jitter-characteristic?             string
+   |  |  |  |  +---w wander-characteristic?             string
+   |  |  |  |  +---w traffic-property-name              string
+   |  |  |  |  +---w traffic-property-queing-latency    string
+   |  |  |  +---w include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+   |  |  |  +---w include-path* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w exclude-path* [local-id]
+   |  |  |  |  +---w node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |  |  |  |  +---w node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |  |  |  |  +---w local-id           string
+   |  |  |  |  +---w name* [value-name]
+   |  |  |  |     +---w value-name    string
+   |  |  |  |     +---w value?        string
+   |  |  |  +---w local-id?                 string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w optimization-constraint
+   |  |  |  +---w traffic-interruption?   tapi-common:directive-value
+   |  |  |  +---w local-id?               string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w objective-function
+   |  |     +---w bandwidth-optimization?   tapi-common:directive-value
+   |  |     +---w concurrent-paths?         tapi-common:directive-value
+   |  |     +---w cost-optimization?        tapi-common:directive-value
+   |  |     +---w link-utilization?         tapi-common:directive-value
+   |  |     +---w resource-sharing?         tapi-common:directive-value
+   |  |     +---w local-id?                 string
+   |  |     +---w name* [value-name]
+   |  |        +---w value-name    string
+   |  |        +---w value?        string
+   |  +--ro output
+   |     +--ro path-comp-service
+   |        +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                tapi-common:port-role
+   |        |  +--ro direction?           tapi-common:port-direction
+   |        |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |        |  +--ro local-id             string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro routing-constraint
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro service-level?            string
+   |        |  +--ro path-layer*               tapi-common:layer-protocol-name
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro include-path* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro exclude-path* [local-id]
+   |        |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro local-id           string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro local-id?                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro objective-function
+   |        |  +--ro bandwidth-optimization?   tapi-common:directive-value
+   |        |  +--ro concurrent-paths?         tapi-common:directive-value
+   |        |  +--ro cost-optimization?        tapi-common:directive-value
+   |        |  +--ro link-utilization?         tapi-common:directive-value
+   |        |  +--ro resource-sharing?         tapi-common:directive-value
+   |        |  +--ro local-id?                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro optimization-constraint
+   |        |  +--ro traffic-interruption?   tapi-common:directive-value
+   |        |  +--ro local-id?               string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro uuid?                      universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x delete-p2ppath
+      +---w input
+      |  +---w path-id-or-name?   string
+      +--ro output
+         +--ro path-comp-service
+            +--ro path*                      -> /tapi-common:context/tapi-path-computation:path/uuid
+            +--ro service-port* [local-id]
+            |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+            |  +--ro role?                tapi-common:port-role
+            |  +--ro direction?           tapi-common:port-direction
+            |  +--ro service-layer?       tapi-common:layer-protocol-name
+            |  +--ro local-id             string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro routing-constraint
+            |  +--ro requested-capacity
+            |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  +--ro committed-information-rate?   uint64
+            |  |  +--ro committed-burst-size?         uint64
+            |  |  +--ro peak-information-rate?        uint64
+            |  |  +--ro peak-burst-size?              uint64
+            |  |  +--ro color-aware?                  boolean
+            |  |  +--ro coupling-flag?                boolean
+            |  +--ro service-level?            string
+            |  +--ro path-layer*               tapi-common:layer-protocol-name
+            |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+            |  |  +--ro cost-name         string
+            |  |  +--ro cost-value        string
+            |  |  +--ro cost-algorithm    string
+            |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+            |  |  +--ro fixed-latency-characteristic?      string
+            |  |  +--ro jitter-characteristic?             string
+            |  |  +--ro wander-characteristic?             string
+            |  |  +--ro traffic-property-name              string
+            |  |  +--ro traffic-property-queing-latency    string
+            |  +--ro include-topology*         -> /tapi-common:context/tapi-topology:topology/uuid
+            |  +--ro avoid-topology*           -> /tapi-common:context/tapi-topology:topology/uuid
+            |  +--ro include-path* [local-id]
+            |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+            |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  |  +--ro local-id           string
+            |  |  +--ro name* [value-name]
+            |  |     +--ro value-name    string
+            |  |     +--ro value?        string
+            |  +--ro exclude-path* [local-id]
+            |  |  +--ro node*              -> /tapi-common:context/tapi-topology:topology/node/uuid
+            |  |  +--ro node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  |  +--ro local-id           string
+            |  |  +--ro name* [value-name]
+            |  |     +--ro value-name    string
+            |  |     +--ro value?        string
+            |  +--ro local-id?                 string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro objective-function
+            |  +--ro bandwidth-optimization?   tapi-common:directive-value
+            |  +--ro concurrent-paths?         tapi-common:directive-value
+            |  +--ro cost-optimization?        tapi-common:directive-value
+            |  +--ro link-utilization?         tapi-common:directive-value
+            |  +--ro resource-sharing?         tapi-common:directive-value
+            |  +--ro local-id?                 string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro optimization-constraint
+            |  +--ro traffic-interruption?   tapi-common:directive-value
+            |  +--ro local-id?               string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro uuid?                      universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string

--- a/YANG/tree/tapi-topology.tree
+++ b/YANG/tree/tapi-topology.tree
@@ -1,743 +1,742 @@
 module: tapi-topology
-  augment /tapi-common:context:
-    +--ro nw-topology-service
-    |  +--ro topology*   -> /tapi-common:context/tapi-topology:topology/uuid
-    |  +--ro uuid?       universal-id
-    |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro label* [value-name]
-    |     +--ro value-name    string
-    |     +--ro value?        string
-    +--rw topology* [uuid]
-       +--ro node* [uuid]
-       |  +--ro owned-node-edge-point* [uuid]
-       |  |  +--ro layer-protocol* [local-id]
-       |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-       |  |  |  +--ro termination-direction?   termination-direction
-       |  |  |  +--ro termination-state?       termination-state
-       |  |  |  +--ro local-id                 string
-       |  |  |  +--ro name* [value-name]
-       |  |  |     +--ro value-name    string
-       |  |  |     +--ro value?        string
-       |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
-       |  |  +--ro state
-       |  |  |  +--ro administrative-state?   administrative-state
-       |  |  |  +--ro operational-state?      operational-state
-       |  |  |  +--ro lifecycle-state?        lifecycle-state
-       |  |  +--ro termination-direction?      tapi-common:termination-direction
-       |  |  +--ro link-port-direction?        tapi-common:port-direction
-       |  |  +--ro link-port-role?             tapi-common:port-role
-       |  |  +--ro uuid                        universal-id
-       |  |  +--ro name* [value-name]
-       |  |  |  +--ro value-name    string
-       |  |  |  +--ro value?        string
-       |  |  +--ro label* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro state
-       |  |  +--ro administrative-state?   administrative-state
-       |  |  +--ro operational-state?      operational-state
-       |  |  +--ro lifecycle-state?        lifecycle-state
-       |  +--ro transfer-capacity
-       |  |  +--ro total-potential-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-interaction-algorithm?   string
-       |  +--ro transfer-cost
-       |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-       |  |     +--ro cost-name         string
-       |  |     +--ro cost-value        string
-       |  |     +--ro cost-algorithm    string
-       |  +--ro transfer-integrity
-       |  |  +--ro error-characteristic?                      string
-       |  |  +--ro loss-characteristic?                       string
-       |  |  +--ro repeat-delivery-characteristic?            string
-       |  |  +--ro delivery-order-characteristic?             string
-       |  |  +--ro unavailable-time-characteristic?           string
-       |  |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro transfer-timing
-       |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-       |  |     +--ro fixed-latency-characteristic?      string
-       |  |     +--ro jitter-characteristic?             string
-       |  |     +--ro wander-characteristic?             string
-       |  |     +--ro traffic-property-name              string
-       |  |     +--ro traffic-property-queing-latency    string
-       |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-       |  +--ro uuid                          universal-id
-       |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro link* [uuid]
-       |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro state
-       |  |  +--ro administrative-state?   administrative-state
-       |  |  +--ro operational-state?      operational-state
-       |  |  +--ro lifecycle-state?        lifecycle-state
-       |  +--ro transfer-capacity
-       |  |  +--ro total-potential-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-interaction-algorithm?   string
-       |  +--ro transfer-cost
-       |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-       |  |     +--ro cost-name         string
-       |  |     +--ro cost-value        string
-       |  |     +--ro cost-algorithm    string
-       |  +--ro transfer-integrity
-       |  |  +--ro error-characteristic?                      string
-       |  |  +--ro loss-characteristic?                       string
-       |  |  +--ro repeat-delivery-characteristic?            string
-       |  |  +--ro delivery-order-characteristic?             string
-       |  |  +--ro unavailable-time-characteristic?           string
-       |  |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro transfer-timing
-       |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-       |  |     +--ro fixed-latency-characteristic?      string
-       |  |     +--ro jitter-characteristic?             string
-       |  |     +--ro wander-characteristic?             string
-       |  |     +--ro traffic-property-name              string
-       |  |     +--ro traffic-property-queing-latency    string
-       |  +--ro risk-parameter
-       |  |  +--ro risk-characteristic* [risk-characteristic-name]
-       |  |     +--ro risk-characteristic-name    string
-       |  |     +--ro risk-identifier-list*       string
-       |  +--ro validation
-       |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
-       |  |     +--ro validation-mechanism                  string
-       |  |     +--ro layer-protocol-adjacency-validated    string
-       |  |     +--ro validation-robustness                 string
-       |  +--ro lp-transition
-       |  |  +--ro transitioned-layer-protocol-name*   string
-       |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-       |  +--ro direction?             tapi-common:forwarding-direction
-       |  +--ro uuid                   universal-id
-       |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-       +--rw uuid                   universal-id
-       +--rw name* [value-name]
-       |  +--rw value-name    string
-       |  +--rw value?        string
-       +--rw label* [value-name]
-          +--rw value-name    string
-          +--rw value?        string
-
-  rpcs:
-    +---x get-topology-details
-    |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  +--ro output
-    |     +--ro topology
-    |        +--ro node* [uuid]
-    |        |  +--ro owned-node-edge-point* [uuid]
-    |        |  |  +--ro layer-protocol* [local-id]
-    |        |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  |  +--ro termination-direction?   termination-direction
-    |        |  |  |  +--ro termination-state?       termination-state
-    |        |  |  |  +--ro local-id                 string
-    |        |  |  |  +--ro name* [value-name]
-    |        |  |  |     +--ro value-name    string
-    |        |  |  |     +--ro value?        string
-    |        |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
-    |        |  |  +--ro state
-    |        |  |  |  +--ro administrative-state?   administrative-state
-    |        |  |  |  +--ro operational-state?      operational-state
-    |        |  |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  |  +--ro termination-direction?      tapi-common:termination-direction
-    |        |  |  +--ro link-port-direction?        tapi-common:port-direction
-    |        |  |  +--ro link-port-role?             tapi-common:port-role
-    |        |  |  +--ro uuid                        universal-id
-    |        |  |  +--ro name* [value-name]
-    |        |  |  |  +--ro value-name    string
-    |        |  |  |  +--ro value?        string
-    |        |  |  +--ro label* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro transfer-capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-interaction-algorithm?   string
-    |        |  +--ro transfer-cost
-    |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |     +--ro cost-name         string
-    |        |  |     +--ro cost-value        string
-    |        |  |     +--ro cost-algorithm    string
-    |        |  +--ro transfer-integrity
-    |        |  |  +--ro error-characteristic?                      string
-    |        |  |  +--ro loss-characteristic?                       string
-    |        |  |  +--ro repeat-delivery-characteristic?            string
-    |        |  |  +--ro delivery-order-characteristic?             string
-    |        |  |  +--ro unavailable-time-characteristic?           string
-    |        |  |  +--ro server-integrity-process-characteristic?   string
-    |        |  +--ro transfer-timing
-    |        |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |     +--ro fixed-latency-characteristic?      string
-    |        |  |     +--ro jitter-characteristic?             string
-    |        |  |     +--ro wander-characteristic?             string
-    |        |  |     +--ro traffic-property-name              string
-    |        |  |     +--ro traffic-property-queing-latency    string
-    |        |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-    |        |  +--ro uuid                          universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro link* [uuid]
-    |        |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro transfer-capacity
-    |        |  |  +--ro total-potential-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-interaction-algorithm?   string
-    |        |  +--ro transfer-cost
-    |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |     +--ro cost-name         string
-    |        |  |     +--ro cost-value        string
-    |        |  |     +--ro cost-algorithm    string
-    |        |  +--ro transfer-integrity
-    |        |  |  +--ro error-characteristic?                      string
-    |        |  |  +--ro loss-characteristic?                       string
-    |        |  |  +--ro repeat-delivery-characteristic?            string
-    |        |  |  +--ro delivery-order-characteristic?             string
-    |        |  |  +--ro unavailable-time-characteristic?           string
-    |        |  |  +--ro server-integrity-process-characteristic?   string
-    |        |  +--ro transfer-timing
-    |        |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |     +--ro fixed-latency-characteristic?      string
-    |        |  |     +--ro jitter-characteristic?             string
-    |        |  |     +--ro wander-characteristic?             string
-    |        |  |     +--ro traffic-property-name              string
-    |        |  |     +--ro traffic-property-queing-latency    string
-    |        |  +--ro risk-parameter
-    |        |  |  +--ro risk-characteristic* [risk-characteristic-name]
-    |        |  |     +--ro risk-characteristic-name    string
-    |        |  |     +--ro risk-identifier-list*       string
-    |        |  +--ro validation
-    |        |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
-    |        |  |     +--ro validation-mechanism                  string
-    |        |  |     +--ro layer-protocol-adjacency-validated    string
-    |        |  |     +--ro validation-robustness                 string
-    |        |  +--ro lp-transition
-    |        |  |  +--ro transitioned-layer-protocol-name*   string
-    |        |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        |  +--ro direction?             tapi-common:forwarding-direction
-    |        |  +--ro uuid                   universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-node-details
-    |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w node-id-or-name?       string
-    |  +--ro output
-    |     +--ro node
-    |        +--ro owned-node-edge-point* [uuid]
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro termination-direction?      tapi-common:termination-direction
-    |        |  +--ro link-port-direction?        tapi-common:port-direction
-    |        |  +--ro link-port-role?             tapi-common:port-role
-    |        |  +--ro uuid                        universal-id
-    |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro transfer-capacity
-    |        |  +--ro total-potential-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro available-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-interaction-algorithm?   string
-    |        +--ro transfer-cost
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |     +--ro cost-name         string
-    |        |     +--ro cost-value        string
-    |        |     +--ro cost-algorithm    string
-    |        +--ro transfer-integrity
-    |        |  +--ro error-characteristic?                      string
-    |        |  +--ro loss-characteristic?                       string
-    |        |  +--ro repeat-delivery-characteristic?            string
-    |        |  +--ro delivery-order-characteristic?             string
-    |        |  +--ro unavailable-time-characteristic?           string
-    |        |  +--ro server-integrity-process-characteristic?   string
-    |        +--ro transfer-timing
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |     +--ro fixed-latency-characteristic?      string
-    |        |     +--ro jitter-characteristic?             string
-    |        |     +--ro wander-characteristic?             string
-    |        |     +--ro traffic-property-name              string
-    |        |     +--ro traffic-property-queing-latency    string
-    |        +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-    |        +--ro uuid?                         universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-node-edge-point-details
-    |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w node-id-or-name?       string
-    |  |  +---w ep-id-or-name?         string
-    |  +--ro output
-    |     +--ro node-edge-point
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro termination-direction?      tapi-common:termination-direction
-    |        +--ro link-port-direction?        tapi-common:port-direction
-    |        +--ro link-port-role?             tapi-common:port-role
-    |        +--ro uuid?                       universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-link-details
-    |  +---w input
-    |  |  +---w topology-id-or-name?   string
-    |  |  +---w link-id-or-name?       string
-    |  +--ro output
-    |     +--ro link
-    |        +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro transfer-capacity
-    |        |  +--ro total-potential-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro available-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-interaction-algorithm?   string
-    |        +--ro transfer-cost
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |     +--ro cost-name         string
-    |        |     +--ro cost-value        string
-    |        |     +--ro cost-algorithm    string
-    |        +--ro transfer-integrity
-    |        |  +--ro error-characteristic?                      string
-    |        |  +--ro loss-characteristic?                       string
-    |        |  +--ro repeat-delivery-characteristic?            string
-    |        |  +--ro delivery-order-characteristic?             string
-    |        |  +--ro unavailable-time-characteristic?           string
-    |        |  +--ro server-integrity-process-characteristic?   string
-    |        +--ro transfer-timing
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |     +--ro fixed-latency-characteristic?      string
-    |        |     +--ro jitter-characteristic?             string
-    |        |     +--ro wander-characteristic?             string
-    |        |     +--ro traffic-property-name              string
-    |        |     +--ro traffic-property-queing-latency    string
-    |        +--ro risk-parameter
-    |        |  +--ro risk-characteristic* [risk-characteristic-name]
-    |        |     +--ro risk-characteristic-name    string
-    |        |     +--ro risk-identifier-list*       string
-    |        +--ro validation
-    |        |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
-    |        |     +--ro validation-mechanism                  string
-    |        |     +--ro layer-protocol-adjacency-validated    string
-    |        |     +--ro validation-robustness                 string
-    |        +--ro lp-transition
-    |        |  +--ro transitioned-layer-protocol-name*   string
-    |        |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro direction?             tapi-common:forwarding-direction
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-topology-list
-       +--ro output
-          +--ro topology*
-             +--ro node* [uuid]
-             |  +--ro owned-node-edge-point* [uuid]
-             |  |  +--ro layer-protocol* [local-id]
-             |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-             |  |  |  +--ro termination-direction?   termination-direction
-             |  |  |  +--ro termination-state?       termination-state
-             |  |  |  +--ro local-id                 string
-             |  |  |  +--ro name* [value-name]
-             |  |  |     +--ro value-name    string
-             |  |  |     +--ro value?        string
-             |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
-             |  |  +--ro state
-             |  |  |  +--ro administrative-state?   administrative-state
-             |  |  |  +--ro operational-state?      operational-state
-             |  |  |  +--ro lifecycle-state?        lifecycle-state
-             |  |  +--ro termination-direction?      tapi-common:termination-direction
-             |  |  +--ro link-port-direction?        tapi-common:port-direction
-             |  |  +--ro link-port-role?             tapi-common:port-role
-             |  |  +--ro uuid                        universal-id
-             |  |  +--ro name* [value-name]
-             |  |  |  +--ro value-name    string
-             |  |  |  +--ro value?        string
-             |  |  +--ro label* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro state
-             |  |  +--ro administrative-state?   administrative-state
-             |  |  +--ro operational-state?      operational-state
-             |  |  +--ro lifecycle-state?        lifecycle-state
-             |  +--ro transfer-capacity
-             |  |  +--ro total-potential-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro available-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-interaction-algorithm?   string
-             |  +--ro transfer-cost
-             |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-             |  |     +--ro cost-name         string
-             |  |     +--ro cost-value        string
-             |  |     +--ro cost-algorithm    string
-             |  +--ro transfer-integrity
-             |  |  +--ro error-characteristic?                      string
-             |  |  +--ro loss-characteristic?                       string
-             |  |  +--ro repeat-delivery-characteristic?            string
-             |  |  +--ro delivery-order-characteristic?             string
-             |  |  +--ro unavailable-time-characteristic?           string
-             |  |  +--ro server-integrity-process-characteristic?   string
-             |  +--ro transfer-timing
-             |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-             |  |     +--ro fixed-latency-characteristic?      string
-             |  |     +--ro jitter-characteristic?             string
-             |  |     +--ro wander-characteristic?             string
-             |  |     +--ro traffic-property-name              string
-             |  |     +--ro traffic-property-queing-latency    string
-             |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-             |  +--ro uuid                          universal-id
-             |  +--ro name* [value-name]
-             |  |  +--ro value-name    string
-             |  |  +--ro value?        string
-             |  +--ro label* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro link* [uuid]
-             |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  +--ro state
-             |  |  +--ro administrative-state?   administrative-state
-             |  |  +--ro operational-state?      operational-state
-             |  |  +--ro lifecycle-state?        lifecycle-state
-             |  +--ro transfer-capacity
-             |  |  +--ro total-potential-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro available-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-interaction-algorithm?   string
-             |  +--ro transfer-cost
-             |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-             |  |     +--ro cost-name         string
-             |  |     +--ro cost-value        string
-             |  |     +--ro cost-algorithm    string
-             |  +--ro transfer-integrity
-             |  |  +--ro error-characteristic?                      string
-             |  |  +--ro loss-characteristic?                       string
-             |  |  +--ro repeat-delivery-characteristic?            string
-             |  |  +--ro delivery-order-characteristic?             string
-             |  |  +--ro unavailable-time-characteristic?           string
-             |  |  +--ro server-integrity-process-characteristic?   string
-             |  +--ro transfer-timing
-             |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-             |  |     +--ro fixed-latency-characteristic?      string
-             |  |     +--ro jitter-characteristic?             string
-             |  |     +--ro wander-characteristic?             string
-             |  |     +--ro traffic-property-name              string
-             |  |     +--ro traffic-property-queing-latency    string
-             |  +--ro risk-parameter
-             |  |  +--ro risk-characteristic* [risk-characteristic-name]
-             |  |     +--ro risk-characteristic-name    string
-             |  |     +--ro risk-identifier-list*       string
-             |  +--ro validation
-             |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
-             |  |     +--ro validation-mechanism                  string
-             |  |     +--ro layer-protocol-adjacency-validated    string
-             |  |     +--ro validation-robustness                 string
-             |  +--ro lp-transition
-             |  |  +--ro transitioned-layer-protocol-name*   string
-             |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-             |  +--ro direction?             tapi-common:forwarding-direction
-             |  +--ro uuid                   universal-id
-             |  +--ro name* [value-name]
-             |  |  +--ro value-name    string
-             |  |  +--ro value?        string
-             |  +--ro label* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-             +--ro uuid?                  universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+augment /tapi-common:context:
+   +--ro nw-topology-service
+   |  +--ro topology*   -> /tapi-common:context/tapi-topology:topology/uuid
+   |  +--ro uuid?       universal-id
+   |  +--ro name* [value-name]
+   |  |  +--ro value-name    string
+   |  |  +--ro value?        string
+   |  +--ro label* [value-name]
+   |     +--ro value-name    string
+   |     +--ro value?        string
+   +--ro topology* [uuid]
+      +--ro node* [uuid]
+      |  +--ro owned-node-edge-point* [uuid]
+      |  |  +--ro layer-protocol* [local-id]
+      |  |  |  +--ro layer-protocol-name?     layer-protocol-name
+      |  |  |  +--ro termination-direction?   termination-direction
+      |  |  |  +--ro termination-state?       termination-state
+      |  |  |  +--ro local-id                 string
+      |  |  |  +--ro name* [value-name]
+      |  |  |     +--ro value-name    string
+      |  |  |     +--ro value?        string
+      |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
+      |  |  +--ro state
+      |  |  |  +--ro administrative-state?   administrative-state
+      |  |  |  +--ro operational-state?      operational-state
+      |  |  |  +--ro lifecycle-state?        lifecycle-state
+      |  |  +--ro termination-direction?      tapi-common:termination-direction
+      |  |  +--ro link-port-direction?        tapi-common:port-direction
+      |  |  +--ro link-port-role?             tapi-common:port-role
+      |  |  +--ro uuid                        universal-id
+      |  |  +--ro name* [value-name]
+      |  |  |  +--ro value-name    string
+      |  |  |  +--ro value?        string
+      |  |  +--ro label* [value-name]
+      |  |     +--ro value-name    string
+      |  |     +--ro value?        string
+      |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
+      |  +--ro state
+      |  |  +--ro administrative-state?   administrative-state
+      |  |  +--ro operational-state?      operational-state
+      |  |  +--ro lifecycle-state?        lifecycle-state
+      |  +--ro transfer-capacity
+      |  |  +--ro total-potential-capacity
+      |  |  |  +--ro total-size?                   fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro available-capacity
+      |  |  |  +--ro total-size?                   fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro capacity-assigned-to-user-view* [total-size]
+      |  |  |  +--ro total-size                    fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro capacity-interaction-algorithm?   string
+      |  +--ro transfer-cost
+      |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+      |  |     +--ro cost-name         string
+      |  |     +--ro cost-value        string
+      |  |     +--ro cost-algorithm    string
+      |  +--ro transfer-integrity
+      |  |  +--ro error-characteristic?                      string
+      |  |  +--ro loss-characteristic?                       string
+      |  |  +--ro repeat-delivery-characteristic?            string
+      |  |  +--ro delivery-order-characteristic?             string
+      |  |  +--ro unavailable-time-characteristic?           string
+      |  |  +--ro server-integrity-process-characteristic?   string
+      |  +--ro transfer-timing
+      |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+      |  |     +--ro fixed-latency-characteristic?      string
+      |  |     +--ro jitter-characteristic?             string
+      |  |     +--ro wander-characteristic?             string
+      |  |     +--ro traffic-property-name              string
+      |  |     +--ro traffic-property-queing-latency    string
+      |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
+      |  +--ro uuid                          universal-id
+      |  +--ro name* [value-name]
+      |  |  +--ro value-name    string
+      |  |  +--ro value?        string
+      |  +--ro label* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro link* [uuid]
+      |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
+      |  +--ro state
+      |  |  +--ro administrative-state?   administrative-state
+      |  |  +--ro operational-state?      operational-state
+      |  |  +--ro lifecycle-state?        lifecycle-state
+      |  +--ro transfer-capacity
+      |  |  +--ro total-potential-capacity
+      |  |  |  +--ro total-size?                   fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro available-capacity
+      |  |  |  +--ro total-size?                   fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro capacity-assigned-to-user-view* [total-size]
+      |  |  |  +--ro total-size                    fixed-capacity-value
+      |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+      |  |  |  +--ro committed-information-rate?   uint64
+      |  |  |  +--ro committed-burst-size?         uint64
+      |  |  |  +--ro peak-information-rate?        uint64
+      |  |  |  +--ro peak-burst-size?              uint64
+      |  |  |  +--ro color-aware?                  boolean
+      |  |  |  +--ro coupling-flag?                boolean
+      |  |  +--ro capacity-interaction-algorithm?   string
+      |  +--ro transfer-cost
+      |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+      |  |     +--ro cost-name         string
+      |  |     +--ro cost-value        string
+      |  |     +--ro cost-algorithm    string
+      |  +--ro transfer-integrity
+      |  |  +--ro error-characteristic?                      string
+      |  |  +--ro loss-characteristic?                       string
+      |  |  +--ro repeat-delivery-characteristic?            string
+      |  |  +--ro delivery-order-characteristic?             string
+      |  |  +--ro unavailable-time-characteristic?           string
+      |  |  +--ro server-integrity-process-characteristic?   string
+      |  +--ro transfer-timing
+      |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+      |  |     +--ro fixed-latency-characteristic?      string
+      |  |     +--ro jitter-characteristic?             string
+      |  |     +--ro wander-characteristic?             string
+      |  |     +--ro traffic-property-name              string
+      |  |     +--ro traffic-property-queing-latency    string
+      |  +--ro risk-parameter
+      |  |  +--ro risk-characteristic* [risk-characteristic-name]
+      |  |     +--ro risk-characteristic-name    string
+      |  |     +--ro risk-identifier-list*       string
+      |  +--ro validation
+      |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
+      |  |     +--ro validation-mechanism                  string
+      |  |     +--ro layer-protocol-adjacency-validated    string
+      |  |     +--ro validation-robustness                 string
+      |  +--ro lp-transition
+      |  |  +--ro transitioned-layer-protocol-name*   string
+      |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+      |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+      |  +--ro direction?             tapi-common:forwarding-direction
+      |  +--ro uuid                   universal-id
+      |  +--ro name* [value-name]
+      |  |  +--ro value-name    string
+      |  |  +--ro value?        string
+      |  +--ro label* [value-name]
+      |     +--ro value-name    string
+      |     +--ro value?        string
+      +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+      +--ro uuid                   universal-id
+      +--ro name* [value-name]
+      |  +--ro value-name    string
+      |  +--ro value?        string
+      +--ro label* [value-name]
+         +--ro value-name    string
+         +--ro value?        string
+rpcs:
+   +---x get-topology-details
+   |  +---w input
+   |  |  +---w topology-id-or-name?   string
+   |  +--ro output
+   |     +--ro topology
+   |        +--ro node* [uuid]
+   |        |  +--ro owned-node-edge-point* [uuid]
+   |        |  |  +--ro layer-protocol* [local-id]
+   |        |  |  |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  |  |  +--ro termination-direction?   termination-direction
+   |        |  |  |  +--ro termination-state?       termination-state
+   |        |  |  |  +--ro local-id                 string
+   |        |  |  |  +--ro name* [value-name]
+   |        |  |  |     +--ro value-name    string
+   |        |  |  |     +--ro value?        string
+   |        |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
+   |        |  |  +--ro state
+   |        |  |  |  +--ro administrative-state?   administrative-state
+   |        |  |  |  +--ro operational-state?      operational-state
+   |        |  |  |  +--ro lifecycle-state?        lifecycle-state
+   |        |  |  +--ro termination-direction?      tapi-common:termination-direction
+   |        |  |  +--ro link-port-direction?        tapi-common:port-direction
+   |        |  |  +--ro link-port-role?             tapi-common:port-role
+   |        |  |  +--ro uuid                        universal-id
+   |        |  |  +--ro name* [value-name]
+   |        |  |  |  +--ro value-name    string
+   |        |  |  |  +--ro value?        string
+   |        |  |  +--ro label* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
+   |        |  +--ro state
+   |        |  |  +--ro administrative-state?   administrative-state
+   |        |  |  +--ro operational-state?      operational-state
+   |        |  |  +--ro lifecycle-state?        lifecycle-state
+   |        |  +--ro transfer-capacity
+   |        |  |  +--ro total-potential-capacity
+   |        |  |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro available-capacity
+   |        |  |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
+   |        |  |  |  +--ro total-size                    fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro capacity-interaction-algorithm?   string
+   |        |  +--ro transfer-cost
+   |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |     +--ro cost-name         string
+   |        |  |     +--ro cost-value        string
+   |        |  |     +--ro cost-algorithm    string
+   |        |  +--ro transfer-integrity
+   |        |  |  +--ro error-characteristic?                      string
+   |        |  |  +--ro loss-characteristic?                       string
+   |        |  |  +--ro repeat-delivery-characteristic?            string
+   |        |  |  +--ro delivery-order-characteristic?             string
+   |        |  |  +--ro unavailable-time-characteristic?           string
+   |        |  |  +--ro server-integrity-process-characteristic?   string
+   |        |  +--ro transfer-timing
+   |        |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |     +--ro fixed-latency-characteristic?      string
+   |        |  |     +--ro jitter-characteristic?             string
+   |        |  |     +--ro wander-characteristic?             string
+   |        |  |     +--ro traffic-property-name              string
+   |        |  |     +--ro traffic-property-queing-latency    string
+   |        |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
+   |        |  +--ro uuid                          universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro link* [uuid]
+   |        |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        |  +--ro state
+   |        |  |  +--ro administrative-state?   administrative-state
+   |        |  |  +--ro operational-state?      operational-state
+   |        |  |  +--ro lifecycle-state?        lifecycle-state
+   |        |  +--ro transfer-capacity
+   |        |  |  +--ro total-potential-capacity
+   |        |  |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro available-capacity
+   |        |  |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
+   |        |  |  |  +--ro total-size                    fixed-capacity-value
+   |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  |  +--ro committed-information-rate?   uint64
+   |        |  |  |  +--ro committed-burst-size?         uint64
+   |        |  |  |  +--ro peak-information-rate?        uint64
+   |        |  |  |  +--ro peak-burst-size?              uint64
+   |        |  |  |  +--ro color-aware?                  boolean
+   |        |  |  |  +--ro coupling-flag?                boolean
+   |        |  |  +--ro capacity-interaction-algorithm?   string
+   |        |  +--ro transfer-cost
+   |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |     +--ro cost-name         string
+   |        |  |     +--ro cost-value        string
+   |        |  |     +--ro cost-algorithm    string
+   |        |  +--ro transfer-integrity
+   |        |  |  +--ro error-characteristic?                      string
+   |        |  |  +--ro loss-characteristic?                       string
+   |        |  |  +--ro repeat-delivery-characteristic?            string
+   |        |  |  +--ro delivery-order-characteristic?             string
+   |        |  |  +--ro unavailable-time-characteristic?           string
+   |        |  |  +--ro server-integrity-process-characteristic?   string
+   |        |  +--ro transfer-timing
+   |        |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |     +--ro fixed-latency-characteristic?      string
+   |        |  |     +--ro jitter-characteristic?             string
+   |        |  |     +--ro wander-characteristic?             string
+   |        |  |     +--ro traffic-property-name              string
+   |        |  |     +--ro traffic-property-queing-latency    string
+   |        |  +--ro risk-parameter
+   |        |  |  +--ro risk-characteristic* [risk-characteristic-name]
+   |        |  |     +--ro risk-characteristic-name    string
+   |        |  |     +--ro risk-identifier-list*       string
+   |        |  +--ro validation
+   |        |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
+   |        |  |     +--ro validation-mechanism                  string
+   |        |  |     +--ro layer-protocol-adjacency-validated    string
+   |        |  |     +--ro validation-robustness                 string
+   |        |  +--ro lp-transition
+   |        |  |  +--ro transitioned-layer-protocol-name*   string
+   |        |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        |  +--ro direction?             tapi-common:forwarding-direction
+   |        |  +--ro uuid                   universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-node-details
+   |  +---w input
+   |  |  +---w topology-id-or-name?   string
+   |  |  +---w node-id-or-name?       string
+   |  +--ro output
+   |     +--ro node
+   |        +--ro owned-node-edge-point* [uuid]
+   |        |  +--ro layer-protocol* [local-id]
+   |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  |  +--ro termination-direction?   termination-direction
+   |        |  |  +--ro termination-state?       termination-state
+   |        |  |  +--ro local-id                 string
+   |        |  |  +--ro name* [value-name]
+   |        |  |     +--ro value-name    string
+   |        |  |     +--ro value?        string
+   |        |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro state
+   |        |  |  +--ro administrative-state?   administrative-state
+   |        |  |  +--ro operational-state?      operational-state
+   |        |  |  +--ro lifecycle-state?        lifecycle-state
+   |        |  +--ro termination-direction?      tapi-common:termination-direction
+   |        |  +--ro link-port-direction?        tapi-common:port-direction
+   |        |  +--ro link-port-role?             tapi-common:port-role
+   |        |  +--ro uuid                        universal-id
+   |        |  +--ro name* [value-name]
+   |        |  |  +--ro value-name    string
+   |        |  |  +--ro value?        string
+   |        |  +--ro label* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro transfer-capacity
+   |        |  +--ro total-potential-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro available-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro capacity-assigned-to-user-view* [total-size]
+   |        |  |  +--ro total-size                    fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro capacity-interaction-algorithm?   string
+   |        +--ro transfer-cost
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |     +--ro cost-name         string
+   |        |     +--ro cost-value        string
+   |        |     +--ro cost-algorithm    string
+   |        +--ro transfer-integrity
+   |        |  +--ro error-characteristic?                      string
+   |        |  +--ro loss-characteristic?                       string
+   |        |  +--ro repeat-delivery-characteristic?            string
+   |        |  +--ro delivery-order-characteristic?             string
+   |        |  +--ro unavailable-time-characteristic?           string
+   |        |  +--ro server-integrity-process-characteristic?   string
+   |        +--ro transfer-timing
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |     +--ro fixed-latency-characteristic?      string
+   |        |     +--ro jitter-characteristic?             string
+   |        |     +--ro wander-characteristic?             string
+   |        |     +--ro traffic-property-name              string
+   |        |     +--ro traffic-property-queing-latency    string
+   |        +--ro layer-protocol-name*          tapi-common:layer-protocol-name
+   |        +--ro uuid?                         universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-node-edge-point-details
+   |  +---w input
+   |  |  +---w topology-id-or-name?   string
+   |  |  +---w node-id-or-name?       string
+   |  |  +---w ep-id-or-name?         string
+   |  +--ro output
+   |     +--ro node-edge-point
+   |        +--ro layer-protocol* [local-id]
+   |        |  +--ro layer-protocol-name?     layer-protocol-name
+   |        |  +--ro termination-direction?   termination-direction
+   |        |  +--ro termination-state?       termination-state
+   |        |  +--ro local-id                 string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro termination-direction?      tapi-common:termination-direction
+   |        +--ro link-port-direction?        tapi-common:port-direction
+   |        +--ro link-port-role?             tapi-common:port-role
+   |        +--ro uuid?                       universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-link-details
+   |  +---w input
+   |  |  +---w topology-id-or-name?   string
+   |  |  +---w link-id-or-name?       string
+   |  +--ro output
+   |     +--ro link
+   |        +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro transfer-capacity
+   |        |  +--ro total-potential-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro available-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro capacity-assigned-to-user-view* [total-size]
+   |        |  |  +--ro total-size                    fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro capacity-interaction-algorithm?   string
+   |        +--ro transfer-cost
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |     +--ro cost-name         string
+   |        |     +--ro cost-value        string
+   |        |     +--ro cost-algorithm    string
+   |        +--ro transfer-integrity
+   |        |  +--ro error-characteristic?                      string
+   |        |  +--ro loss-characteristic?                       string
+   |        |  +--ro repeat-delivery-characteristic?            string
+   |        |  +--ro delivery-order-characteristic?             string
+   |        |  +--ro unavailable-time-characteristic?           string
+   |        |  +--ro server-integrity-process-characteristic?   string
+   |        +--ro transfer-timing
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |     +--ro fixed-latency-characteristic?      string
+   |        |     +--ro jitter-characteristic?             string
+   |        |     +--ro wander-characteristic?             string
+   |        |     +--ro traffic-property-name              string
+   |        |     +--ro traffic-property-queing-latency    string
+   |        +--ro risk-parameter
+   |        |  +--ro risk-characteristic* [risk-characteristic-name]
+   |        |     +--ro risk-characteristic-name    string
+   |        |     +--ro risk-identifier-list*       string
+   |        +--ro validation
+   |        |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
+   |        |     +--ro validation-mechanism                  string
+   |        |     +--ro layer-protocol-adjacency-validated    string
+   |        |     +--ro validation-robustness                 string
+   |        +--ro lp-transition
+   |        |  +--ro transitioned-layer-protocol-name*   string
+   |        |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+   |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        +--ro direction?             tapi-common:forwarding-direction
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-topology-list
+      +--ro output
+         +--ro topology*
+            +--ro node* [uuid]
+            |  +--ro owned-node-edge-point* [uuid]
+            |  |  +--ro layer-protocol* [local-id]
+            |  |  |  +--ro layer-protocol-name?     layer-protocol-name
+            |  |  |  +--ro termination-direction?   termination-direction
+            |  |  |  +--ro termination-state?       termination-state
+            |  |  |  +--ro local-id                 string
+            |  |  |  +--ro name* [value-name]
+            |  |  |     +--ro value-name    string
+            |  |  |     +--ro value?        string
+            |  |  +--ro client-node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  |  +--ro mapped-service-end-point*   -> /tapi-common:context/service-end-point/uuid
+            |  |  +--ro state
+            |  |  |  +--ro administrative-state?   administrative-state
+            |  |  |  +--ro operational-state?      operational-state
+            |  |  |  +--ro lifecycle-state?        lifecycle-state
+            |  |  +--ro termination-direction?      tapi-common:termination-direction
+            |  |  +--ro link-port-direction?        tapi-common:port-direction
+            |  |  +--ro link-port-role?             tapi-common:port-role
+            |  |  +--ro uuid                        universal-id
+            |  |  +--ro name* [value-name]
+            |  |  |  +--ro value-name    string
+            |  |  |  +--ro value?        string
+            |  |  +--ro label* [value-name]
+            |  |     +--ro value-name    string
+            |  |     +--ro value?        string
+            |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
+            |  +--ro state
+            |  |  +--ro administrative-state?   administrative-state
+            |  |  +--ro operational-state?      operational-state
+            |  |  +--ro lifecycle-state?        lifecycle-state
+            |  +--ro transfer-capacity
+            |  |  +--ro total-potential-capacity
+            |  |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro available-capacity
+            |  |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro capacity-assigned-to-user-view* [total-size]
+            |  |  |  +--ro total-size                    fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro capacity-interaction-algorithm?   string
+            |  +--ro transfer-cost
+            |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+            |  |     +--ro cost-name         string
+            |  |     +--ro cost-value        string
+            |  |     +--ro cost-algorithm    string
+            |  +--ro transfer-integrity
+            |  |  +--ro error-characteristic?                      string
+            |  |  +--ro loss-characteristic?                       string
+            |  |  +--ro repeat-delivery-characteristic?            string
+            |  |  +--ro delivery-order-characteristic?             string
+            |  |  +--ro unavailable-time-characteristic?           string
+            |  |  +--ro server-integrity-process-characteristic?   string
+            |  +--ro transfer-timing
+            |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+            |  |     +--ro fixed-latency-characteristic?      string
+            |  |     +--ro jitter-characteristic?             string
+            |  |     +--ro wander-characteristic?             string
+            |  |     +--ro traffic-property-name              string
+            |  |     +--ro traffic-property-queing-latency    string
+            |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
+            |  +--ro uuid                          universal-id
+            |  +--ro name* [value-name]
+            |  |  +--ro value-name    string
+            |  |  +--ro value?        string
+            |  +--ro label* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro link* [uuid]
+            |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
+            |  +--ro state
+            |  |  +--ro administrative-state?   administrative-state
+            |  |  +--ro operational-state?      operational-state
+            |  |  +--ro lifecycle-state?        lifecycle-state
+            |  +--ro transfer-capacity
+            |  |  +--ro total-potential-capacity
+            |  |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro available-capacity
+            |  |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro capacity-assigned-to-user-view* [total-size]
+            |  |  |  +--ro total-size                    fixed-capacity-value
+            |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  |  +--ro committed-information-rate?   uint64
+            |  |  |  +--ro committed-burst-size?         uint64
+            |  |  |  +--ro peak-information-rate?        uint64
+            |  |  |  +--ro peak-burst-size?              uint64
+            |  |  |  +--ro color-aware?                  boolean
+            |  |  |  +--ro coupling-flag?                boolean
+            |  |  +--ro capacity-interaction-algorithm?   string
+            |  +--ro transfer-cost
+            |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+            |  |     +--ro cost-name         string
+            |  |     +--ro cost-value        string
+            |  |     +--ro cost-algorithm    string
+            |  +--ro transfer-integrity
+            |  |  +--ro error-characteristic?                      string
+            |  |  +--ro loss-characteristic?                       string
+            |  |  +--ro repeat-delivery-characteristic?            string
+            |  |  +--ro delivery-order-characteristic?             string
+            |  |  +--ro unavailable-time-characteristic?           string
+            |  |  +--ro server-integrity-process-characteristic?   string
+            |  +--ro transfer-timing
+            |  |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+            |  |     +--ro fixed-latency-characteristic?      string
+            |  |     +--ro jitter-characteristic?             string
+            |  |     +--ro wander-characteristic?             string
+            |  |     +--ro traffic-property-name              string
+            |  |     +--ro traffic-property-queing-latency    string
+            |  +--ro risk-parameter
+            |  |  +--ro risk-characteristic* [risk-characteristic-name]
+            |  |     +--ro risk-characteristic-name    string
+            |  |     +--ro risk-identifier-list*       string
+            |  +--ro validation
+            |  |  +--ro validation-mechanism* [validation-mechanism layer-protocol-adjacency-validated validation-robustness]
+            |  |     +--ro validation-mechanism                  string
+            |  |     +--ro layer-protocol-adjacency-validated    string
+            |  |     +--ro validation-robustness                 string
+            |  +--ro lp-transition
+            |  |  +--ro transitioned-layer-protocol-name*   string
+            |  |  +--ro node-edge-point*                    -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+            |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+            |  +--ro direction?             tapi-common:forwarding-direction
+            |  +--ro uuid                   universal-id
+            |  +--ro name* [value-name]
+            |  |  +--ro value-name    string
+            |  |  +--ro value?        string
+            |  +--ro label* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+            +--ro uuid?                  universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string

--- a/YANG/tree/tapi-virtual-network.tree
+++ b/YANG/tree/tapi-virtual-network.tree
@@ -1,331 +1,330 @@
 module: tapi-virtual-network
-  augment /tapi-common:context:
-    +--ro virtual-nw-service* [uuid]
-       +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
-       +--ro service-port* [local-id]
-       |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-       |  +--ro role?                tapi-common:port-role
-       |  +--ro direction?           tapi-common:port-direction
-       |  +--ro service-layer?       tapi-common:layer-protocol-name
-       |  +--ro local-id             string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro vnw-constraint* [local-id]
-       |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-       |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-       |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-       |  +--ro requested-capacity
-       |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  +--ro committed-information-rate?   uint64
-       |  |  +--ro committed-burst-size?         uint64
-       |  |  +--ro peak-information-rate?        uint64
-       |  |  +--ro peak-burst-size?              uint64
-       |  |  +--ro color-aware?                  boolean
-       |  |  +--ro coupling-flag?                boolean
-       |  +--ro service-level?            string
-       |  +--ro service-layer*            tapi-common:layer-protocol-name
-       |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-       |  |  +--ro cost-name         string
-       |  |  +--ro cost-value        string
-       |  |  +--ro cost-algorithm    string
-       |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-       |  |  +--ro fixed-latency-characteristic?      string
-       |  |  +--ro jitter-characteristic?             string
-       |  |  +--ro wander-characteristic?             string
-       |  |  +--ro traffic-property-name              string
-       |  |  +--ro traffic-property-queing-latency    string
-       |  +--ro local-id                  string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro schedule
-       |  +--ro end-time?     date-and-time
-       |  +--ro start-time?   date-and-time
-       +--ro state
-       |  +--ro administrative-state?   administrative-state
-       |  +--ro operational-state?      operational-state
-       |  +--ro lifecycle-state?        lifecycle-state
-       +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-       +--ro uuid                   universal-id
-       +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
-
-  rpcs:
-    +---x create-virtual-network-service
-    |  +---w input
-    |  |  +---w service-port*
-    |  |  |  +---w service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |  |  |  +---w role?                tapi-common:port-role
-    |  |  |  +---w direction?           tapi-common:port-direction
-    |  |  |  +---w service-layer?       tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?            string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w vnw-constraint
-    |  |  |  +---w src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-    |  |  |  +---w sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |  |  |  +---w diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-    |  |  |  +---w requested-capacity
-    |  |  |  |  +---w total-size?                   fixed-capacity-value
-    |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
-    |  |  |  |  +---w committed-information-rate?   uint64
-    |  |  |  |  +---w committed-burst-size?         uint64
-    |  |  |  |  +---w peak-information-rate?        uint64
-    |  |  |  |  +---w peak-burst-size?              uint64
-    |  |  |  |  +---w color-aware?                  boolean
-    |  |  |  |  +---w coupling-flag?                boolean
-    |  |  |  +---w service-level?            string
-    |  |  |  +---w service-layer*            tapi-common:layer-protocol-name
-    |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
-    |  |  |  |  +---w cost-name         string
-    |  |  |  |  +---w cost-value        string
-    |  |  |  |  +---w cost-algorithm    string
-    |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |  |  |  |  +---w fixed-latency-characteristic?      string
-    |  |  |  |  +---w jitter-characteristic?             string
-    |  |  |  |  +---w wander-characteristic?             string
-    |  |  |  |  +---w traffic-property-name              string
-    |  |  |  |  +---w traffic-property-queing-latency    string
-    |  |  |  +---w local-id?                 string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
-    |  |  +---w conn-schedule?    string
-    |  +--ro output
-    |     +--ro vnw-service
-    |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                tapi-common:port-role
-    |        |  +--ro direction?           tapi-common:port-direction
-    |        |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |        |  +--ro local-id             string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro vnw-constraint* [local-id]
-    |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro service-level?            string
-    |        |  +--ro service-layer*            tapi-common:layer-protocol-name
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro local-id                  string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x delete-virtual-network-service
-    |  +---w input
-    |  |  +---w service-id-or-name?   string
-    |  +--ro output
-    |     +--ro vnw-service
-    |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                tapi-common:port-role
-    |        |  +--ro direction?           tapi-common:port-direction
-    |        |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |        |  +--ro local-id             string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro vnw-constraint* [local-id]
-    |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro service-level?            string
-    |        |  +--ro service-layer*            tapi-common:layer-protocol-name
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro local-id                  string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-virtual-network-service-details
-    |  +---w input
-    |  |  +---w service-id-or-name?   string
-    |  +--ro output
-    |     +--ro vnw-service
-    |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        +--ro service-port* [local-id]
-    |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro role?                tapi-common:port-role
-    |        |  +--ro direction?           tapi-common:port-direction
-    |        |  +--ro service-layer?       tapi-common:layer-protocol-name
-    |        |  +--ro local-id             string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro vnw-constraint* [local-id]
-    |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro service-level?            string
-    |        |  +--ro service-layer*            tapi-common:layer-protocol-name
-    |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value        string
-    |        |  |  +--ro cost-algorithm    string
-    |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-    |        |  |  +--ro fixed-latency-characteristic?      string
-    |        |  |  +--ro jitter-characteristic?             string
-    |        |  |  +--ro wander-characteristic?             string
-    |        |  |  +--ro traffic-property-name              string
-    |        |  |  +--ro traffic-property-queing-latency    string
-    |        |  +--ro local-id                  string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro schedule
-    |        |  +--ro end-time?     date-and-time
-    |        |  +--ro start-time?   date-and-time
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro uuid?                  universal-id
-    |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
-    +---x get-virtual-network-service-list
-       +--ro output
-          +--ro vnw-service*
-             +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
-             +--ro service-port* [local-id]
-             |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
-             |  +--ro role?                tapi-common:port-role
-             |  +--ro direction?           tapi-common:port-direction
-             |  +--ro service-layer?       tapi-common:layer-protocol-name
-             |  +--ro local-id             string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro vnw-constraint* [local-id]
-             |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
-             |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
-             |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
-             |  +--ro requested-capacity
-             |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  +--ro committed-information-rate?   uint64
-             |  |  +--ro committed-burst-size?         uint64
-             |  |  +--ro peak-information-rate?        uint64
-             |  |  +--ro peak-burst-size?              uint64
-             |  |  +--ro color-aware?                  boolean
-             |  |  +--ro coupling-flag?                boolean
-             |  +--ro service-level?            string
-             |  +--ro service-layer*            tapi-common:layer-protocol-name
-             |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
-             |  |  +--ro cost-name         string
-             |  |  +--ro cost-value        string
-             |  |  +--ro cost-algorithm    string
-             |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
-             |  |  +--ro fixed-latency-characteristic?      string
-             |  |  +--ro jitter-characteristic?             string
-             |  |  +--ro wander-characteristic?             string
-             |  |  +--ro traffic-property-name              string
-             |  |  +--ro traffic-property-queing-latency    string
-             |  +--ro local-id                  string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro schedule
-             |  +--ro end-time?     date-and-time
-             |  +--ro start-time?   date-and-time
-             +--ro state
-             |  +--ro administrative-state?   administrative-state
-             |  +--ro operational-state?      operational-state
-             |  +--ro lifecycle-state?        lifecycle-state
-             +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-             +--ro uuid?                  universal-id
-             +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+augment /tapi-common:context:
+   +--rw virtual-nw-service* [uuid]
+      +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
+      +--rw service-port* [local-id]
+      |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+      |  +--ro role?                tapi-common:port-role
+      |  +--ro direction?           tapi-common:port-direction
+      |  +--ro service-layer?       tapi-common:layer-protocol-name
+      |  +--rw local-id             string
+      |  +--rw name* [value-name]
+      |     +--rw value-name    string
+      |     +--rw value?        string
+      +--rw vnw-constraint* [local-id]
+      |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+      |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+      |  +--rw diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+      |  +--rw requested-capacity
+      |  |  +--rw total-size?                   fixed-capacity-value
+      |  |  +--rw packet-bw-profile-type?       bandwidth-profile-type
+      |  |  +--rw committed-information-rate?   uint64
+      |  |  +--rw committed-burst-size?         uint64
+      |  |  +--rw peak-information-rate?        uint64
+      |  |  +--rw peak-burst-size?              uint64
+      |  |  +--rw color-aware?                  boolean
+      |  |  +--rw coupling-flag?                boolean
+      |  +--rw service-level?            string
+      |  +--rw service-layer*            tapi-common:layer-protocol-name
+      |  +--rw cost-characteristic* [cost-name cost-value cost-algorithm]
+      |  |  +--rw cost-name         string
+      |  |  +--rw cost-value        string
+      |  |  +--rw cost-algorithm    string
+      |  +--rw latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+      |  |  +--ro fixed-latency-characteristic?      string
+      |  |  +--ro jitter-characteristic?             string
+      |  |  +--ro wander-characteristic?             string
+      |  |  +--rw traffic-property-name              string
+      |  |  +--rw traffic-property-queing-latency    string
+      |  +--rw local-id                  string
+      |  +--rw name* [value-name]
+      |     +--rw value-name    string
+      |     +--rw value?        string
+      +--rw schedule
+      |  +--rw end-time?     date-and-time
+      |  +--rw start-time?   date-and-time
+      +--rw state
+      |  +--rw administrative-state?   administrative-state
+      |  +--rw operational-state?      operational-state
+      |  +--rw lifecycle-state?        lifecycle-state
+      +--rw layer-protocol-name*   tapi-common:layer-protocol-name
+      +--rw uuid                   universal-id
+      +--rw name* [value-name]
+      |  +--rw value-name    string
+      |  +--rw value?        string
+      +--rw label* [value-name]
+         +--rw value-name    string
+         +--rw value?        string
+rpcs:
+   +---x create-virtual-network-service
+   |  +---w input
+   |  |  +---w service-port*
+   |  |  |  +---w service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |  |  |  +---w role?                tapi-common:port-role
+   |  |  |  +---w direction?           tapi-common:port-direction
+   |  |  |  +---w service-layer?       tapi-common:layer-protocol-name
+   |  |  |  +---w local-id?            string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w vnw-constraint
+   |  |  |  +---w src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+   |  |  |  +---w sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |  |  |  +---w diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+   |  |  |  +---w requested-capacity
+   |  |  |  |  +---w total-size?                   fixed-capacity-value
+   |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+   |  |  |  |  +---w committed-information-rate?   uint64
+   |  |  |  |  +---w committed-burst-size?         uint64
+   |  |  |  |  +---w peak-information-rate?        uint64
+   |  |  |  |  +---w peak-burst-size?              uint64
+   |  |  |  |  +---w color-aware?                  boolean
+   |  |  |  |  +---w coupling-flag?                boolean
+   |  |  |  +---w service-level?            string
+   |  |  |  +---w service-layer*            tapi-common:layer-protocol-name
+   |  |  |  +---w cost-characteristic* [cost-name cost-value cost-algorithm]
+   |  |  |  |  +---w cost-name         string
+   |  |  |  |  +---w cost-value        string
+   |  |  |  |  +---w cost-algorithm    string
+   |  |  |  +---w latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |  |  |  |  +---w fixed-latency-characteristic?      string
+   |  |  |  |  +---w jitter-characteristic?             string
+   |  |  |  |  +---w wander-characteristic?             string
+   |  |  |  |  +---w traffic-property-name              string
+   |  |  |  |  +---w traffic-property-queing-latency    string
+   |  |  |  +---w local-id?                 string
+   |  |  |  +---w name* [value-name]
+   |  |  |     +---w value-name    string
+   |  |  |     +---w value?        string
+   |  |  +---w conn-schedule?    string
+   |  +--ro output
+   |     +--ro vnw-service
+   |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                tapi-common:port-role
+   |        |  +--ro direction?           tapi-common:port-direction
+   |        |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |        |  +--ro local-id             string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro vnw-constraint* [local-id]
+   |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro service-level?            string
+   |        |  +--ro service-layer*            tapi-common:layer-protocol-name
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro local-id                  string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x delete-virtual-network-service
+   |  +---w input
+   |  |  +---w service-id-or-name?   string
+   |  +--ro output
+   |     +--ro vnw-service
+   |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                tapi-common:port-role
+   |        |  +--ro direction?           tapi-common:port-direction
+   |        |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |        |  +--ro local-id             string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro vnw-constraint* [local-id]
+   |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro service-level?            string
+   |        |  +--ro service-layer*            tapi-common:layer-protocol-name
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro local-id                  string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-virtual-network-service-details
+   |  +---w input
+   |  |  +---w service-id-or-name?   string
+   |  +--ro output
+   |     +--ro vnw-service
+   |        +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
+   |        +--ro service-port* [local-id]
+   |        |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro role?                tapi-common:port-role
+   |        |  +--ro direction?           tapi-common:port-direction
+   |        |  +--ro service-layer?       tapi-common:layer-protocol-name
+   |        |  +--ro local-id             string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro vnw-constraint* [local-id]
+   |        |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+   |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+   |        |  +--ro requested-capacity
+   |        |  |  +--ro total-size?                   fixed-capacity-value
+   |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+   |        |  |  +--ro committed-information-rate?   uint64
+   |        |  |  +--ro committed-burst-size?         uint64
+   |        |  |  +--ro peak-information-rate?        uint64
+   |        |  |  +--ro peak-burst-size?              uint64
+   |        |  |  +--ro color-aware?                  boolean
+   |        |  |  +--ro coupling-flag?                boolean
+   |        |  +--ro service-level?            string
+   |        |  +--ro service-layer*            tapi-common:layer-protocol-name
+   |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+   |        |  |  +--ro cost-name         string
+   |        |  |  +--ro cost-value        string
+   |        |  |  +--ro cost-algorithm    string
+   |        |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+   |        |  |  +--ro fixed-latency-characteristic?      string
+   |        |  |  +--ro jitter-characteristic?             string
+   |        |  |  +--ro wander-characteristic?             string
+   |        |  |  +--ro traffic-property-name              string
+   |        |  |  +--ro traffic-property-queing-latency    string
+   |        |  +--ro local-id                  string
+   |        |  +--ro name* [value-name]
+   |        |     +--ro value-name    string
+   |        |     +--ro value?        string
+   |        +--ro schedule
+   |        |  +--ro end-time?     date-and-time
+   |        |  +--ro start-time?   date-and-time
+   |        +--ro state
+   |        |  +--ro administrative-state?   administrative-state
+   |        |  +--ro operational-state?      operational-state
+   |        |  +--ro lifecycle-state?        lifecycle-state
+   |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+   |        +--ro uuid?                  universal-id
+   |        +--ro name* [value-name]
+   |        |  +--ro value-name    string
+   |        |  +--ro value?        string
+   |        +--ro label* [value-name]
+   |           +--ro value-name    string
+   |           +--ro value?        string
+   +---x get-virtual-network-service-list
+      +--ro output
+         +--ro vnw-service*
+            +--ro topology?              -> /tapi-common:context/tapi-topology:topology/uuid
+            +--ro service-port* [local-id]
+            |  +--ro service-end-point?   -> /tapi-common:context/service-end-point/uuid
+            |  +--ro role?                tapi-common:port-role
+            |  +--ro direction?           tapi-common:port-direction
+            |  +--ro service-layer?       tapi-common:layer-protocol-name
+            |  +--ro local-id             string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro vnw-constraint* [local-id]
+            |  +--ro src-service-end-point?    -> /tapi-common:context/service-end-point/uuid
+            |  +--ro sink-service-end-point?   -> /tapi-common:context/service-end-point/uuid
+            |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-virtual-network:virtual-nw-service/vnw-constraint/local-id
+            |  +--ro requested-capacity
+            |  |  +--ro total-size?                   fixed-capacity-value
+            |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+            |  |  +--ro committed-information-rate?   uint64
+            |  |  +--ro committed-burst-size?         uint64
+            |  |  +--ro peak-information-rate?        uint64
+            |  |  +--ro peak-burst-size?              uint64
+            |  |  +--ro color-aware?                  boolean
+            |  |  +--ro coupling-flag?                boolean
+            |  +--ro service-level?            string
+            |  +--ro service-layer*            tapi-common:layer-protocol-name
+            |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
+            |  |  +--ro cost-name         string
+            |  |  +--ro cost-value        string
+            |  |  +--ro cost-algorithm    string
+            |  +--ro latency-characteristic* [traffic-property-name traffic-property-queing-latency]
+            |  |  +--ro fixed-latency-characteristic?      string
+            |  |  +--ro jitter-characteristic?             string
+            |  |  +--ro wander-characteristic?             string
+            |  |  +--ro traffic-property-name              string
+            |  |  +--ro traffic-property-queing-latency    string
+            |  +--ro local-id                  string
+            |  +--ro name* [value-name]
+            |     +--ro value-name    string
+            |     +--ro value?        string
+            +--ro schedule
+            |  +--ro end-time?     date-and-time
+            |  +--ro start-time?   date-and-time
+            +--ro state
+            |  +--ro administrative-state?   administrative-state
+            |  +--ro operational-state?      operational-state
+            |  +--ro lifecycle-state?        lifecycle-state
+            +--ro layer-protocol-name*   tapi-common:layer-protocol-name
+            +--ro uuid?                  universal-id
+            +--ro name* [value-name]
+            |  +--ro value-name    string
+            |  +--ro value?        string
+            +--ro label* [value-name]
+               +--ro value-name    string
+               +--ro value?        string


### PR DESCRIPTION
During the split-up of TapiCommon:Context into individual module-specific contexts, the read-only property for the context's attributes that were moved to the module-specific contexts were not correctly set.

note: The pyang_uml image files have not been generated.