### PR TITLE
Change sep to serviceEndPoint

### DIFF
--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -263,7 +263,7 @@
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9VJvEeWcs7ZjyujtOg" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_AnTcAKU5EeWkWNPM1BHzGA" name="createConnectivityService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="sep" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="create">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="serviceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="create">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hoAc0KU5EeWkWNPM1BHzGA" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hoJmwKU5EeWkWNPM1BHzGA" value="*"/>
           </ownedParameter>


### PR DESCRIPTION
This makes input param in ConnectivityService.createConnectivityService
consistent with the field name in the model and return value.