### PR TITLE
Rename sep & serviceEndPoint to endPoint

### DIFF
--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -263,7 +263,7 @@
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9VJvEeWcs7ZjyujtOg" name="service" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_AnTcAKU5EeWkWNPM1BHzGA" name="createConnectivityService">
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="serviceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="create">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="endPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="create">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hoAc0KU5EeWkWNPM1BHzGA" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hoJmwKU5EeWkWNPM1BHzGA" value="*"/>
           </ownedParameter>
@@ -286,7 +286,7 @@
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_JqtJcL2TEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_n_cMYP6cEea_VPdGG2-szQ" name="sep" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="update"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_n_cMYP6cEea_VPdGG2-szQ" name="endPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" effect="update"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="update">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HkOeQP6cEea_VPdGG2-szQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HllJIP6cEea_VPdGG2-szQ" value="1"/>
@@ -453,7 +453,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YteN0EUdEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YtgqEEUdEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_4Es8M2kIEeWZEqTYAF8eqA" name="_serviceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" aggregation="composite" association="_4Es8MGkIEeWZEqTYAF8eqA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4Es8M2kIEeWZEqTYAF8eqA" name="_endPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" aggregation="composite" association="_4Es8MGkIEeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9mgX4GkIEeWZEqTYAF8eqA" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9mgX4WkIEeWZEqTYAF8eqA" value="*"/>
         </ownedAttribute>


### PR DESCRIPTION
As suggested in email thread, this is a PR to consistently name the ConnectivityServiceEndPoint attrs as endPoint.