### PR TITLE
Yang Validation Fix - removed readOnly for uuId & localId

### DIFF
--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -35,7 +35,7 @@
         <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjkd8AEeW-BtRsuJPbqg" annotatedElement="_xEvjkN8AEeW-BtRsuJPbqg">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjm98AEeW-BtRsuJPbqg" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjm98AEeW-BtRsuJPbqg" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
           <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjnN8AEeW-BtRsuJPbqg" annotatedElement="_xEvjm98AEeW-BtRsuJPbqg">
             <body>UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.&#xD;
 UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.&#xD;
@@ -100,7 +100,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
         <ownedComment xmi:type="uml:Comment" xmi:id="_UhrZod8qEeWT9tG0gGLRFw" annotatedElement="_UhrZoN8qEeWT9tG0gGLRFw">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_dlarAN8qEeWT9tG0gGLRFw" name="localId" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dlarAN8qEeWT9tG0gGLRFw" name="localId">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MP7aAJLQEeaqpNd__7dv4w" name="name" type="_6efrYNnVEeWIOYiRCk5bbQ">

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -33,7 +33,6 @@ module tapi-common {
         grouping global-class-g {
             leaf uuid {
                 type universal-id;
-                config false;
                 description "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.
                     UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
                     Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
@@ -82,7 +81,6 @@ module tapi-common {
         grouping local-class-g {
             leaf local-id {
                 type string;
-                config false;
                 description "none";
             }
             list name {


### PR DESCRIPTION
Apparently since these attributes are used as keys in configurable (RW)
lists, this fails strict yang validation tests. The only other way to
fix this is to have two separate copies of groupings for GlobalClass and
LocalClass  - RO & RW versions of these attributes to used in state and
config trees respectively