### PR TITLE
Fixes for issues #191, #199, #200, #201, #215, #224, #225

### DIFF
--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -445,6 +445,154 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWf73DK8EeaULOmJRJKM0Q" x="219" y="166"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_5m41MEwBEeewALXL7BvPYw" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5m5cQEwBEeewALXL7BvPYw" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5m5cQUwBEeewALXL7BvPYw" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5m5cQkwBEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5m6DUEwBEeewALXL7BvPYw" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_6mFBUEwBEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6mFBUUwBEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_6mFoYEwBEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_6mFoYUwBEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5m6DUUwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5m6DUkwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5m6DU0wBEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5m6DVEwBEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5m6DVUwBEeewALXL7BvPYw" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5m6DVkwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5m6DV0wBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5m6DWEwBEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5m6DWUwBEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5m6DWkwBEeewALXL7BvPYw" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5m6DW0wBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5m6DXEwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5m6DXUwBEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5m6DXkwBEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5m41MUwBEeewALXL7BvPYw" x="517" y="379" height="79"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5nFCc0wBEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5nFCdEwBEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5nFCdkwBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5nFCdUwBEeewALXL7BvPYw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__NLvUEwBEeewALXL7BvPYw" type="2010">
+      <children xmi:type="notation:DecorationNode" xmi:id="__NM9cEwBEeewALXL7BvPYw" type="5035"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="__NM9cUwBEeewALXL7BvPYw" type="8502">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__NM9ckwBEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__NNkgEwBEeewALXL7BvPYw" type="7020">
+        <children xmi:type="notation:Shape" xmi:id="_ALOE4EwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_rNbewr1-EeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALOE4UwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALOr8EwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_zB_30D6iEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALOr8UwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALOr8kwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_FKRr0D6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALOr80wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALPTAEwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_VJ4jID6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALPTAUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALPTAkwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_aMoEQD6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALPTA0wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALPTBEwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_g9oeAD6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALPTBUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALP6EEwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_or7mcD6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALP6EUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ALP6EkwCEeewALXL7BvPYw" type="3018">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_u_PXkD6jEeai_egNtQKqQA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ALP6E0wCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="__NNkgUwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__NNkgkwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__NNkg0wBEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__NNkhEwBEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__NNkhUwBEeewALXL7BvPYw" type="7021">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__NNkhkwBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__NNkh0wBEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__NNkiEwBEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__NNkiUwBEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:DataType" href="TapiCommon.uml#_rNbewL1-EeWdore3Cxez9g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__NLvUUwBEeewALXL7BvPYw" x="28" y="428" height="184"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_B90q8EwCEeewALXL7BvPYw" type="2006">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B91SAEwCEeewALXL7BvPYw" type="5023"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B91SAUwCEeewALXL7BvPYw" type="8508">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B91SAkwCEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_B91SA0wCEeewALXL7BvPYw" type="7015">
+        <children xmi:type="notation:Shape" xmi:id="_DAQYUEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_HBQVkL2AEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAQYUUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DAQ_YEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_1YyV8L1yEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAQ_YUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DARmcEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_z7f4kL1yEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DARmcUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DARmckwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_7cCR0L1yEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DARmc0wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DARmdEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_gyYdML1zEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DARmdUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DASNgEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_Ye91gL1zEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DASNgUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DASNgkwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_bhtNwL1zEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DASNg0wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DASNhEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_x85d4L1yEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DASNhUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DAS0kEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_oRItwL1zEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAS0kUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_DAS0kkwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiCommon.uml#_mXlyML1zEeWdore3Cxez9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_DAS0k0wCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_B91SBEwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_B91SBUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_B91SBkwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B91SB0wCEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_smkSYL1yEeWdore3Cxez9g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B90q8UwCEeewALXL7BvPYw" x="343" y="404"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_6CIXQTA_Eea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_6CIXQjA_Eea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_6CIXQzA_Eea4fKwSGMr6CA">
@@ -570,6 +718,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWf74DK8EeaULOmJRJKM0Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWf74TK8EeaULOmJRJKM0Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWf74jK8EeaULOmJRJKM0Q"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5nFCd0wBEeewALXL7BvPYw" type="StereotypeCommentLink" source="_5m41MEwBEeewALXL7BvPYw" target="_5nFCc0wBEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5nFCeEwBEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5nFpgEwBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5nFCeUwBEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5nFCekwBEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5nFCe0wBEeewALXL7BvPYw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_iE1WsD3fEea-1_BGg-qcjQ" type="PapyrusUMLClassDiagram" name="Context" measurementUnit="Pixel">
@@ -812,6 +970,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ypTRf6tEea_VPdGG2-szQ" x="214" y="-87"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_pgFwwEwBEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_pgFwwUwBEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pgFww0wBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pgFwwkwBEeewALXL7BvPYw" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xDHdUEwBEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_xDHdUUwBEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xDHdU0wBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xDHdUkwBEeewALXL7BvPYw" x="214" y="-116"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_iE1Wsz3fEea-1_BGg-qcjQ">
@@ -856,10 +1030,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_O3-EAMhqEeaVlemTikmRHw" type="4001" source="_jiNToD3fEea-1_BGg-qcjQ" target="_OAvhEMhqEeaVlemTikmRHw">
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EA8hqEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBMhqEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBMhqEeaVlemTikmRHw" x="7" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EBchqEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBshqEeaVlemTikmRHw" x="-4" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBshqEeaVlemTikmRHw" x="-11" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EB8hqEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-ECMhqEeaVlemTikmRHw" y="-20"/>
@@ -1029,6 +1203,26 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ypTSv6tEea_VPdGG2-szQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ypTS_6tEea_VPdGG2-szQ"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pgG-4EwBEeewALXL7BvPYw" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_pgFwwEwBEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_pgG-4UwBEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pgG-5UwBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pgG-4kwBEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pgG-40wBEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pgG-5EwBEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xDIEYEwBEeewALXL7BvPYw" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_xDHdUEwBEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_xDIEYUwBEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xDIEZUwBEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xDIEYkwBEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xDIEY0wBEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xDIEZEwBEeewALXL7BvPYw"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="__w77UE0WEeaqn4OIuRCwEg" type="2008">
@@ -1037,21 +1231,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__w77VE0WEeaqn4OIuRCwEg" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__w77VU0WEeaqn4OIuRCwEg" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_K6S1QsPPEeaiK6pYrNo12g" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_RgJT4EwDEeewALXL7BvPYw" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_aFAUM9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1Q8PPEeaiK6pYrNo12g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJT4UwDEeewALXL7BvPYw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_K6S1RMPPEeaiK6pYrNo12g" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_RgJ68EwDEeewALXL7BvPYw" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1RcPPEeaiK6pYrNo12g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJ68UwDEeewALXL7BvPYw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_FI8v8BMnEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_RgJ68kwDEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_AFxHsEwDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJ680wDEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_RgKiAEwDEeewALXL7BvPYw" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_FI8v8RMnEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgKiAUwDEeewALXL7BvPYw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_FI8v8hMnEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_RgKiAkwDEeewALXL7BvPYw" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_FI8v8xMnEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgKiA0wDEeewALXL7BvPYw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__w77Vk0WEeaqn4OIuRCwEg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__w77V00WEeaqn4OIuRCwEg"/>
@@ -1213,6 +1411,56 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__6JCfhMeEee0L_IMWjydgQ" x="686" y="68"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_9lEFgEwCEeewALXL7BvPYw" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9lF6sEwCEeewALXL7BvPYw" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_9lF6sUwCEeewALXL7BvPYw" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9lF6skwCEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9lF6s0wCEeewALXL7BvPYw" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_-iORUEwCEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-iORUUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_-iO4YEwCEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_-iO4YUwCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9lF6tEwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9lF6tUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9lF6tkwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lF6t0wCEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9lF6uEwCEeewALXL7BvPYw" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9lF6uUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9lF6ukwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9lF6u0wCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lF6vEwCEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_9lF6vUwCEeewALXL7BvPYw" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_9lF6vkwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_9lF6v0wCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_9lF6wEwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lF6wUwCEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lEFgUwCEeewALXL7BvPYw" x="26" y="388" height="91"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9lSvAEwCEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9lSvAUwCEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9lSvA0wCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lSvAkwCEeewALXL7BvPYw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Jvwgw0wDEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JvwgxEwDEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JvxH0EwDEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_AFtdUEwDEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JvwgxUwDEeewALXL7BvPYw" x="222" y="51"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_-RwAgU0WEeaqn4OIuRCwEg" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_-R5KcE0WEeaqn4OIuRCwEg"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_-R5KcU0WEeaqn4OIuRCwEg">
@@ -1328,6 +1576,51 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__6JCghMeEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6JCgxMeEee0L_IMWjydgQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__6JChBMeEee0L_IMWjydgQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9lSvBEwCEeewALXL7BvPYw" type="StereotypeCommentLink" source="_9lEFgEwCEeewALXL7BvPYw" target="_9lSvAEwCEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9lSvBUwCEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9lSvCUwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9lSvBkwCEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9lSvB0wCEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9lSvCEwCEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_AGncQEwDEeewALXL7BvPYw" type="4001" source="__w77UE0WEeaqn4OIuRCwEg" target="_9lEFgEwCEeewALXL7BvPYw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDUEwDEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDUUwDEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDUkwDEeewALXL7BvPYw" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDU0wDEeewALXL7BvPYw" x="-16" y="8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDVEwDEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDVUwDEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDVkwDEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDV0wDEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDWEwDEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDWUwDEeewALXL7BvPYw" x="10" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AGoDWkwDEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDW0wDEeewALXL7BvPYw" x="-17" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_AGncQUwDEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiCommon.uml#_AFtdUEwDEeewALXL7BvPYw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AGncQkwDEeewALXL7BvPYw" points="[71, 141, -57, -110]$[121, 235, -7, -16]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQEwDEeewALXL7BvPYw" id="(0.5529953917050692,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQUwDEeewALXL7BvPYw" id="(0.5248868778280543,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JvxH0UwDEeewALXL7BvPYw" type="StereotypeCommentLink" source="_AGncQEwDEeewALXL7BvPYw" target="_Jvwgw0wDEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JvxH0kwDEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JvxH1kwDEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_AFtdUEwDEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JvxH00wDEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JvxH1EwDEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JvxH1UwDEeewALXL7BvPYw"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -1045,10 +1045,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1RcPPEeaiK6pYrNo12g"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_K6S1RsPPEeaiK6pYrNo12g" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_9hsOkKU7EeWkWNPM1BHzGA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_K6S1R8PPEeaiK6pYrNo12g"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_FI8v8BMnEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_FI8v8RMnEee0L_IMWjydgQ"/>

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -594,10 +594,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_-wOTUxMmEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_-wOTVBMmEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_-wOTVRMmEee0L_IMWjydgQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_jiNTpj3fEea-1_BGg-qcjQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_jiNTpz3fEea-1_BGg-qcjQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_jiNTqD3fEea-1_BGg-qcjQ"/>
@@ -1060,10 +1056,6 @@
         <children xmi:type="notation:Shape" xmi:id="_FI8v8hMnEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_FI8v8xMnEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_FI8v9BMnEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_FI8v9RMnEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__w77Vk0WEeaqn4OIuRCwEg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__w77V00WEeaqn4OIuRCwEg"/>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -20,6 +20,12 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_O3TVpchqEeaVlemTikmRHw" name="context" type="_sfccMOK0EeSq5fATALSQkQ" association="_O3NPAMhqEeaVlemTikmRHw"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_AFtdUEwDEeewALXL7BvPYw" name="SIPHasCapacityPac" memberEnd="_AFxHsEwDEeewALXL7BvPYw _AFxuwUwDEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AFv5kEwDEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AFv5kUwDEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_AFxuwUwDEeewALXL7BvPYw" name="serviceinterfacepoint" type="_It0sYEG-EeWMO5szP8dKiA" association="_AFtdUEwDEeewALXL7BvPYw"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_XqBXAC5wEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_ZA31MC5wEea0_JngOlSKcA" name="ObjectClasses">
@@ -151,6 +157,31 @@ The structure of LTP supports all transport protocols including circuit and pack
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_oJg1UN79EeW-BtRsuJPbqg" isReadOnly="true" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AFxHsEwDEeewALXL7BvPYw" name="_capacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_AFtdUEwDEeewALXL7BvPYw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="CapacityPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXM9yKEeWXdJnxZxtFYA">
+          <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
+A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
+A TopologicalEntity may be directly used in the view or may be assigned to another view for use.&#xD;
+The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.&#xD;
+Represents the capacity available to user (client) along with client interaction and usage. &#xD;
+A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXNdyKEeWXdJnxZxtFYA" name="totalPotentialCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXNdyKEeWXdJnxZxtFYA">
+            <body>An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXN9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXONyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXOdyKEeWXdJnxZxtFYA" name="availableCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXOtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXOdyKEeWXdJnxZxtFYA">
+            <body>Capacity available to be assigned.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXO9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXPNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_aoZMoC5wEea0_JngOlSKcA" name="TypeDefinitions">
@@ -428,6 +459,73 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FRi-RdnWEeWIOYiRCk5bbQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_rNbewL1-EeWdore3Cxez9g" name="Capacity" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_rNbewb1-EeWdore3Cxez9g" annotatedElement="_rNbewL1-EeWdore3Cxez9g">
+          <body>Information on capacity of a particular TopologicalEntity.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rNbewr1-EeWdore3Cxez9g" name="totalSize" visibility="public" type="_smkSYL1yEeWdore3Cxez9g">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rNbew71-EeWdore3Cxez9g" annotatedElement="_rNbewr1-EeWdore3Cxez9g">
+            <body>Total capacity of the TopologicalEntity in MB/s</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNbexL1-EeWdore3Cxez9g" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNbexb1-EeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zB_30D6iEeai_egNtQKqQA" name="packetBwProfileType" type="_EuZIcD6gEeai_egNtQKqQA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FKRr0D6jEeai_egNtQKqQA" name="committedInformationRate">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HJt0AD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HJt0Aj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VJ4jID6jEeai_egNtQKqQA" name="committedBurstSize">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WDdPcD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WDdPcj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aMoEQD6jEeai_egNtQKqQA" name="peakInformationRate">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_btxt8D6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bt634D6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_g9oeAD6jEeai_egNtQKqQA" name="peakBurstSize">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iAAhAD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iAAhAj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_or7mcD6jEeai_egNtQKqQA" name="colorAware">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wk4fsD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wlCQsT6jEeai_egNtQKqQA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_or7mcT6jEeai_egNtQKqQA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u_PXkD6jEeai_egNtQKqQA" name="couplingFlag">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xq1bID6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xq1bIj6jEeai_egNtQKqQA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_u_PXkT6jEeai_egNtQKqQA"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_smkSYL1yEeWdore3Cxez9g" name="FixedCapacityValue" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_UEqsALvUEeWYrqoqXLgguw">
+          <body>The Capacity (Bandwidth) values that are applicable for digital layers. </body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HBQVkL2AEeWdore3Cxez9g" name="NOT_APPLICABLE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1YyV8L1yEeWdore3Cxez9g" name="10MBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z7f4kL1yEeWdore3Cxez9g" name="100MBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_7cCR0L1yEeWdore3Cxez9g" name="1GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gyYdML1zEeWdore3Cxez9g" name="2.4GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ye91gL1zEeWdore3Cxez9g" name="10GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_bhtNwL1zEeWdore3Cxez9g" name="40GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_x85d4L1yEeWdore3Cxez9g" name="100GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oRItwL1zEeWdore3Cxez9g" name="200GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mXlyML1zEeWdore3Cxez9g" name="400GBPS"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EuZIcD6gEeai_egNtQKqQA" name="BandwidthProfileType" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Lrs40D6gEeai_egNtQKqQA" name="NOT_APPLICABLE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PYdMgD6iEeai_egNtQKqQA" name="MEF_10.x"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_R0GvkD6iEeai_egNtQKqQA" name="RFC_2697"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VNVVMD6iEeai_egNtQKqQA" name="RFC_2698"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YMrbMD6iEeai_egNtQKqQA" name="RFC_4115"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_FhzwMHrqEeavcODnuX7FyA" name="Interfaces">
       <packagedElement xmi:type="uml:Interface" xmi:id="_JSfMgHrqEeavcODnuX7FyA" name="TapiService">
@@ -545,4 +643,31 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhBhrEeewCs0lkpWskw" base_Property="_6efrYtnVEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhRhrEeewCs0lkpWskw" base_Property="_6efrZtnVEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhhhrEeewCs0lkpWskw" base_Property="_FRi-QtnWEeWIOYiRCk5bbQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3RhsEeewCs0lkpWskw" base_Property="_rNbewr1-EeWdore3Cxez9g"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3hhsEeewCs0lkpWskw" base_Property="_zB_30D6iEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3xhsEeewCs0lkpWskw" base_Property="_FKRr0D6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcBhsEeewCs0lkpWskw" base_Property="_VJ4jID6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcRhsEeewCs0lkpWskw" base_Property="_aMoEQD6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMchhsEeewCs0lkpWskw" base_Property="_g9oeAD6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcxhsEeewCs0lkpWskw" base_Property="_or7mcD6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdBhsEeewCs0lkpWskw" base_Property="_u_PXkD6jEeai_egNtQKqQA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OxhsEeewCs0lkpWskw" base_Property="_KjZXNdyKEeWXdJnxZxtFYA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_PBhsEeewCs0lkpWskw" base_Property="_KjZXOdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zB_30j6iEeai_egNtQKqQA" base_StructuralFeature="_zB_30D6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FKRr0j6jEeai_egNtQKqQA" base_StructuralFeature="_FKRr0D6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VJ4jIj6jEeai_egNtQKqQA" base_StructuralFeature="_VJ4jID6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aMoEQj6jEeai_egNtQKqQA" base_StructuralFeature="_aMoEQD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_g9oeAj6jEeai_egNtQKqQA" base_StructuralFeature="_g9oeAD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_or7mcz6jEeai_egNtQKqQA" base_StructuralFeature="_or7mcD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_u_PXkz6jEeai_egNtQKqQA" base_StructuralFeature="_u_PXkD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Kk4ksdyKEeWXdJnxZxtFYA" base_Class="_KjZXM9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kstyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXNdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ks9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXOdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rO6sgL1-EeWdore3Cxez9g" base_StructuralFeature="_rNbewr1-EeWdore3Cxez9g" partOfObjectKey="1"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_pf6xoEwBEeewALXL7BvPYw" base_Association="_O3NPAMhqEeaVlemTikmRHw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AFxHsUwDEeewALXL7BvPYw" base_Property="_AFxHsEwDEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AFxuwEwDEeewALXL7BvPYw" base_StructuralFeature="_AFxHsEwDEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AFxuwkwDEeewALXL7BvPYw" base_Property="_AFxuwUwDEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AFxuw0wDEeewALXL7BvPYw" base_StructuralFeature="_AFxuwUwDEeewALXL7BvPYw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_JvqaIEwDEeewALXL7BvPYw" base_Association="_AFtdUEwDEeewALXL7BvPYw"/>
 </xmi:XMI>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -52,13 +52,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjod8AEeW-BtRsuJPbqg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjot8AEeW-BtRsuJPbqg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjo98AEeW-BtRsuJPbqg" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjpN8AEeW-BtRsuJPbqg">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjpd8AEeW-BtRsuJPbqg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjpt8AEeW-BtRsuJPbqg" value="*"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="LayerProtocol" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_r01pEb6nEeWRz-VHgA3LJQ" annotatedElement="_r01pEL6nEeWRz-VHgA3LJQ">
@@ -151,6 +144,9 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedComment>
         <generalization xmi:type="uml:Generalization" xmi:id="_6frNwO_nEeWLlrwIF3w0vA" general="_tjWBYD3fEea-1_BGg-qcjQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aFAUM9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" isReadOnly="true" aggregation="composite" association="_aFAUMNnYEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XMuBMEq7EeexQa2RWFy3AQ" annotatedElement="_aFAUM9nYEeWIOYiRCk5bbQ">
+            <body>Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental</body>
+          </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c7QIkNnYEeWIOYiRCk5bbQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
@@ -494,7 +490,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelAttribute xmi:id="_oJg1Vt79EeW-BtRsuJPbqg" base_StructuralFeature="_oJg1U979EeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRN8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjm98AEeW-BtRsuJPbqg" partOfObjectKey="1" isInvariant="true"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRd8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjn98AEeW-BtRsuJPbqg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRt8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjo98AEeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_dlarAd8qEeWT9tG0gGLRFw" base_StructuralFeature="_dlarAN8qEeWT9tG0gGLRFw" partOfObjectKey="1" isInvariant="true"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_l1lthO-pEeWLlrwIF3w0vA" base_StructuralFeature="_l1ltgO-pEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_j2GU1t78EeW-BtRsuJPbqg" base_Class="_j2GU0N78EeW-BtRsuJPbqg"/>
@@ -535,7 +530,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRBhrEeewCs0lkpWskw" base_Property="_ER7uAN79EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRRhrEeewCs0lkpWskw" base_Property="_xEvjm98AEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRhhrEeewCs0lkpWskw" base_Property="_xEvjn98AEeW-BtRsuJPbqg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRxhrEeewCs0lkpWskw" base_Property="_xEvjo98AEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmSBhrEeewCs0lkpWskw" base_Property="_r01pE76nEeWRz-VHgA3LJQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmSRhrEeewCs0lkpWskw" base_Property="_r01pH76nEeWRz-VHgA3LJQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmShhrEeewCs0lkpWskw" base_Property="_r01pI76nEeWRz-VHgA3LJQ"/>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -151,7 +151,6 @@ The structure of LTP supports all transport protocols including circuit and pack
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_oJg1UN79EeW-BtRsuJPbqg" isReadOnly="true" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_9hsOkKU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ" isReadOnly="true"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_aoZMoC5wEea0_JngOlSKcA" name="TypeDefinitions">
@@ -504,7 +503,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelClass xmi:id="_sfccQeK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_tjWBYj3fEea-1_BGg-qcjQ" base_Class="_tjWBYD3fEea-1_BGg-qcjQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_zC-54j3fEea-1_BGg-qcjQ" base_Class="_zC-54D3fEea-1_BGg-qcjQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_9hsOkaU7EeWkWNPM1BHzGA" base_StructuralFeature="_9hsOkKU7EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNNnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUM9nYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNtnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUNdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giA-_tEeWLlrwIF3w0vA"/>
@@ -543,7 +541,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs5xhrEeewCs0lkpWskw" base_Property="_O3TVoshqEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgBhrEeewCs0lkpWskw" base_Property="_aFAUM9nYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgRhrEeewCs0lkpWskw" base_Property="_S3giA-_tEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzghhrEeewCs0lkpWskw" base_Property="_9hsOkKU7EeWkWNPM1BHzGA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgxhrEeewCs0lkpWskw" base_Property="_l1ltgO-pEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhBhrEeewCs0lkpWskw" base_Property="_6efrYtnVEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhRhrEeewCs0lkpWskw" base_Property="_6efrZtnVEeWIOYiRCk5bbQ"/>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -333,7 +333,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkATBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkLzBFEeam35bpdXJzEw" x="752" y="-132" width="250" height="95"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkLzBFEeam35bpdXJzEw" x="729" y="-132" width="304" height="95"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHlMDBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHlMTBFEeam35bpdXJzEw" type="5029"/>
@@ -1043,8 +1043,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0G9xrTBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0G9xtDBFEeam35bpdXJzEw" points="[0, 0, 120, 63]$[-101, -53, 19, 10]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xtTBFEeam35bpdXJzEw" id="(0.6056338028169014,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xtjBFEeam35bpdXJzEw" id="(0.2838709677419355,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xtTBFEeam35bpdXJzEw" id="(0.5669014084507042,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xtjBFEeam35bpdXJzEw" id="(0.28102189781021897,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G9xtzBFEeam35bpdXJzEw" type="4001" source="_0HHjqDBFEeam35bpdXJzEw" target="_0HHioDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G9xuDBFEeam35bpdXJzEw" type="6001">
@@ -1068,8 +1068,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0G9xxDBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0G9xyzBFEeam35bpdXJzEw" points="[0, 0, 2, 214]$[-1, -70, 1, 144]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xzDBFEeam35bpdXJzEw" id="(0.172,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xzTBFEeam35bpdXJzEw" id="(0.1952054794520548,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xzDBFEeam35bpdXJzEw" id="(0.48355263157894735,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9xzTBFEeam35bpdXJzEw" id="(0.4726027397260274,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G9yWTBFEeam35bpdXJzEw" type="4001" source="_0G9yhzBFEeam35bpdXJzEw" target="_0G90ajBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G9yWjBFEeam35bpdXJzEw" type="6001">
@@ -1093,8 +1093,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0G9yZjBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nfDxoO_pEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0G9ybTBFEeam35bpdXJzEw" points="[0, 0, -38, -94]$[38, 94, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybjBFEeam35bpdXJzEw" id="(0.9064516129032258,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybzBFEeam35bpdXJzEw" id="(0.2099236641221374,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybjBFEeam35bpdXJzEw" id="(0.9233576642335767,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybzBFEeam35bpdXJzEw" id="(0.10687022900763359,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G9ycDBFEeam35bpdXJzEw" type="4001" source="_0HHioDBFEeam35bpdXJzEw" target="_0G9x2DBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G9ycTBFEeam35bpdXJzEw" type="6001">
@@ -1149,31 +1149,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aDBFEeam35bpdXJzEw" id="(0.0,0.0776255707762557)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aTBFEeam35bpdXJzEw" id="(1.0,0.21081081081081082)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0HHk8TBFEeam35bpdXJzEw" type="4001" source="_0HHjqDBFEeam35bpdXJzEw" target="_0HHioDBFEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk8jBFEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk8zBFEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk9DBFEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk9TBFEeam35bpdXJzEw" x="-15" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk9jBFEeam35bpdXJzEw" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk9zBFEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk-DBFEeam35bpdXJzEw" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk-TBFEeam35bpdXJzEw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk-jBFEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk-zBFEeam35bpdXJzEw" x="10" y="27"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_0HHk_DBFEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHk_TBFEeam35bpdXJzEw" x="-11" y="25"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_0HHk_jBFEeam35bpdXJzEw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlAjBFEeam35bpdXJzEw" points="[0, 0, 4, 201]$[-2, -57, 2, 144]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlAzBFEeam35bpdXJzEw" id="(0.884,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlBDBFEeam35bpdXJzEw" id="(0.8047945205479452,0.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0HHlBTBFEeam35bpdXJzEw" type="4001" source="_0G9yhzBFEeam35bpdXJzEw" target="_0G91CzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHlBjBFEeam35bpdXJzEw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlBzBFEeam35bpdXJzEw" x="7" y="1"/>
@@ -1196,8 +1171,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0HHlEjBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_oP678O_rEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlGTBFEeam35bpdXJzEw" points="[27, 15, -161, -96]$[170, 113, -18, 2]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlGjBFEeam35bpdXJzEw" id="(0.5129032258064516,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlGzBFEeam35bpdXJzEw" id="(0.5025906735751295,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlGjBFEeam35bpdXJzEw" id="(0.5109489051094891,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlGzBFEeam35bpdXJzEw" id="(0.38860103626943004,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0HHlHDBFEeam35bpdXJzEw" type="4001" source="_0HHioDBFEeam35bpdXJzEw" target="_0G9yhzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHlHTBFEeam35bpdXJzEw" type="6001">
@@ -1273,16 +1248,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0KiqFjBFEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0KiqFzBFEeam35bpdXJzEw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0KiqGDBFEeam35bpdXJzEw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0K_WBTBFEeam35bpdXJzEw" type="StereotypeCommentLink" source="_0HHk8TBFEeam35bpdXJzEw" target="_0K_WATBFEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_0K_WBjBFEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0K_WCjBFEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0K_WBzBFEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0K_WCDBFEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0K_WCTBFEeam35bpdXJzEw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0K_WGzBFEeam35bpdXJzEw" type="StereotypeCommentLink" source="_0G9xtzBFEeam35bpdXJzEw" target="_0K_WFzBFEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_0K_WHDBFEeam35bpdXJzEw"/>
@@ -1579,7 +1544,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0gzBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0sTBGEeam35bpdXJzEw" x="274" y="55" width="177" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0sTBGEeam35bpdXJzEw" x="243" y="55" width="208" height="64"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU0sjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU0szBGEeam35bpdXJzEw" type="5029"/>
@@ -1605,7 +1570,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0xDBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU08jBGEeam35bpdXJzEw" x="-96" y="262" height="67"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU08jBGEeam35bpdXJzEw" x="-96" y="288" height="67"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU1BDBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1BTBGEeam35bpdXJzEw" type="5029"/>
@@ -1631,7 +1596,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1FjBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1RDBGEeam35bpdXJzEw" x="493" y="256" width="155" height="63"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1RDBGEeam35bpdXJzEw" x="493" y="282" width="155" height="63"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU1WTBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1WjBGEeam35bpdXJzEw" type="5029"/>
@@ -1657,7 +1622,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1azBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="258" width="166" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="284" width="166" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU16TBGEeam35bpdXJzEw" type="2004">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1iHO4BMvEee0L_IMWjydgQ" source="displayNameLabelIcon">
@@ -1712,7 +1677,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2VDBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2gjBGEeam35bpdXJzEw" x="335" y="-146" width="118" height="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2gjBGEeam35bpdXJzEw" x="159" y="201" width="129" height="49"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU2tzBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2uDBGEeam35bpdXJzEw" type="5029"/>
@@ -1738,7 +1703,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2yTBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU29zBGEeam35bpdXJzEw" x="148" y="411" width="164" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU29zBGEeam35bpdXJzEw" x="148" y="437" width="164" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU3KDBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3KTBGEeam35bpdXJzEw" type="5029"/>
@@ -1770,7 +1735,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3yzBGEeam35bpdXJzEw" type="5037"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3zDBGEeam35bpdXJzEw" type="5159"/>
       <element xmi:type="uml:Constraint" href="TapiConnectivity.uml#_CIxSkLrhEeWYrqoqXLgguw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU33zBGEeam35bpdXJzEw" x="56" y="-34" height="46"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU33zBGEeam35bpdXJzEw" x="29" y="-34" height="46"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlelOjBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BlelOzBGEeam35bpdXJzEw" showTitle="true"/>
@@ -2280,7 +2245,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgsxMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="773" y="191" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="772" y="212" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6_LyABMjEee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_6_LyAhMjEee0L_IMWjydgQ" type="5029"/>
@@ -2390,6 +2355,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g66-okvpEee8IN5myVB_oQ" x="474" y="-45"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_Duxwk0wVEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DuxwlEwVEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DuxwlkwVEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DuxwlUwVEeewALXL7BvPYw" x="213" y="-396"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_9y8uwzBFEeam35bpdXJzEw">
@@ -2426,7 +2399,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1wzBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1xDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xTBGEeam35bpdXJzEw" x="1" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xTBGEeam35bpdXJzEw" x="16" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1xjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xzBGEeam35bpdXJzEw" y="-20"/>
@@ -2435,7 +2408,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yTBGEeam35bpdXJzEw" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1yjBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yzBGEeam35bpdXJzEw" x="9" y="-17"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yzBGEeam35bpdXJzEw" x="18" y="-16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1zDBGEeam35bpdXJzEw" type="6034">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1zTBGEeam35bpdXJzEw" x="-13" y="-16"/>
@@ -2443,15 +2416,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU1zjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU10jBGEeam35bpdXJzEw" points="[0, 0, -84, 79]$[84, -79, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU10zBGEeam35bpdXJzEw" id="(0.4774193548387097,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU11DBGEeam35bpdXJzEw" id="(0.46825396825396826,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU10zBGEeam35bpdXJzEw" id="(0.47096774193548385,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU11DBGEeam35bpdXJzEw" id="(0.46706586826347307,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU11TBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU11jBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12DBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-25"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-11" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12jBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12zBGEeam35bpdXJzEw" y="-20"/>
@@ -2468,8 +2441,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU14jBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU15jBGEeam35bpdXJzEw" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.480225988700565,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.536144578313253,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.5240384615384616,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.4939759036144578,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2LjBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2LzBGEeam35bpdXJzEw" type="6001">
@@ -2563,7 +2536,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3AjBGEeam35bpdXJzEw" x="7" y="-22"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3AzBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3BDBGEeam35bpdXJzEw" x="-8" y="-24"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3BDBGEeam35bpdXJzEw" x="18" y="-24"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3BTBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
@@ -2596,19 +2569,19 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.4550898203592814,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.265625)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BlU3IzBGEeam35bpdXJzEw" type="4014" source="_BlU3yjBGEeam35bpdXJzEw" target="_BlU3aTBGEeam35bpdXJzEw">
+    <edges xmi:type="notation:Connector" xmi:id="_BlU3IzBGEeam35bpdXJzEw" type="4014" source="_BlU3yjBGEeam35bpdXJzEw" target="_ijqBwEwPEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3JDBGEeam35bpdXJzEw"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3JTBGEeam35bpdXJzEw" points="[35, -9, -37, -11]$[72, 29, 0, 27]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3JjBGEeam35bpdXJzEw" id="(1.0,0.5869565217391305)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3JzBGEeam35bpdXJzEw" id="(0.5826086956521739,0.5608465608465608)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3JjBGEeam35bpdXJzEw" id="(1.0,0.5434782608695652)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3JzBGEeam35bpdXJzEw" id="(0.39285714285714285,0.1951219512195122)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BlU3aTBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU2QjBGEeam35bpdXJzEw">
+    <edges xmi:type="notation:Connector" xmi:id="_BlU3aTBGEeam35bpdXJzEw" type="4001" source="_BlU1WTBGEeam35bpdXJzEw" target="_BlU2QjBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3ajBGEeam35bpdXJzEw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3azBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="35" y="-15"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="17" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bzBGEeam35bpdXJzEw" y="-20"/>
@@ -2617,16 +2590,16 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3cTBGEeam35bpdXJzEw" x="7" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3cjBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3czBGEeam35bpdXJzEw" x="16" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3czBGEeam35bpdXJzEw" x="19" y="-19"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3dDBGEeam35bpdXJzEw" type="6034">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3dTBGEeam35bpdXJzEw" x="-11" y="21"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3djBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3ejBGEeam35bpdXJzEw" points="[-51, -37, -53, 160]$[-9, -164, -11, 33]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ezBGEeam35bpdXJzEw" id="(0.4124293785310734,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3fDBGEeam35bpdXJzEw" id="(0.1016949152542373,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3ejBGEeam35bpdXJzEw" points="[0, 0, 57, 62]$[-57, 0, 0, 62]$[-57, -62, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ezBGEeam35bpdXJzEw" id="(0.0,0.45161290322580644)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3fDBGEeam35bpdXJzEw" id="(0.4186046511627907,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3fTBGEeam35bpdXJzEw" type="4001" source="_BlU0sjBGEeam35bpdXJzEw" target="_BlU2tzBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3fjBGEeam35bpdXJzEw" type="6001">
@@ -2655,10 +2628,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3nTBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU2QjBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3njBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3nzBGEeam35bpdXJzEw" x="-15" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3nzBGEeam35bpdXJzEw" x="3" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3oDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3oTBGEeam35bpdXJzEw" x="-1" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3oTBGEeam35bpdXJzEw" x="-11" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3ojBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ozBGEeam35bpdXJzEw" y="-20"/>
@@ -2670,13 +2643,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3pzBGEeam35bpdXJzEw" x="14" y="-18"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3qDBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3qTBGEeam35bpdXJzEw" x="-11" y="-14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3qTBGEeam35bpdXJzEw" x="-7" y="-13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3qjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3sTBGEeam35bpdXJzEw" points="[0, 0, -12, 216]$[10, -188, -2, 28]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3sjBGEeam35bpdXJzEw" id="(0.9491525423728814,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3szBGEeam35bpdXJzEw" id="(0.9067796610169492,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3sjBGEeam35bpdXJzEw" id="(0.0673076923076923,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3szBGEeam35bpdXJzEw" id="(0.7596899224806202,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3tDBGEeam35bpdXJzEw" type="4001" source="_BlU0MDBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_BlU3tTBGEeam35bpdXJzEw" source="PapyrusCSSForceValue">
@@ -2938,7 +2911,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_l6tU8MhsEeaVlemTikmRHw" type="4001" source="_e4LtYMhsEeaVlemTikmRHw" target="_BlU0MDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU88hsEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9MhsEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9MhsEeaVlemTikmRHw" x="-73" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU9chsEeaVlemTikmRHw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9shsEeaVlemTikmRHw" x="-89" y="-10"/>
@@ -2958,8 +2931,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_l6tU8chsEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l6tU8shsEeaVlemTikmRHw" points="[0, 0, 50, -221]$[-50, 221, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8MhsEeaVlemTikmRHw" id="(0.09508196721311475,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8chsEeaVlemTikmRHw" id="(0.8875,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8MhsEeaVlemTikmRHw" id="(0.04918032786885246,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8chsEeaVlemTikmRHw" id="(0.8,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_l7R8t8hsEeaVlemTikmRHw" type="StereotypeCommentLink" source="_l6tU8MhsEeaVlemTikmRHw" target="_l7R8s8hsEeaVlemTikmRHw">
       <styles xmi:type="notation:FontStyle" xmi:id="_l7R8uMhsEeaVlemTikmRHw"/>
@@ -2973,7 +2946,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mwRD8MhsEeaVlemTikmRHw" type="4001" source="_e4LtYMhsEeaVlemTikmRHw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD88hsEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" x="39" y="-47"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" x="-79" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD9chsEeaVlemTikmRHw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9shsEeaVlemTikmRHw" x="-99" y="2"/>
@@ -2985,16 +2958,16 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD-shsEeaVlemTikmRHw" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD-8hsEeaVlemTikmRHw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD_MhsEeaVlemTikmRHw" x="10" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD_MhsEeaVlemTikmRHw" x="11" y="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD_chsEeaVlemTikmRHw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD_shsEeaVlemTikmRHw" x="-12" y="-16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD_shsEeaVlemTikmRHw" x="-11" y="14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_mwRD8chsEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mwRD8shsEeaVlemTikmRHw" points="[130, 45, -33, -12]$[147, 55, -16, -2]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUMhsEeaVlemTikmRHw" id="(0.9475409836065574,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.15819209039548024,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.28846153846153844,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lu32EBMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_lu32ExMjEee0L_IMWjydgQ" type="6001">
@@ -3017,9 +2990,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lu32ERMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -146, -16]$[146, 0, 0, -16]$[146, 16, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -145, -37]$[145, 0, 0, -37]$[145, 37, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32HxMjEee0L_IMWjydgQ" id="(1.0,0.7413793103448276)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.27,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.26666666666666666,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_piyMkBMjEee0L_IMWjydgQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_piyMkxMjEee0L_IMWjydgQ" type="6001">
@@ -3042,9 +3015,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_piyMkRMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -177, 35]$[177, 0, 0, 35]$[177, -35, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -176, 40]$[176, 0, 0, 40]$[176, -40, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMnxMjEee0L_IMWjydgQ" id="(1.0,0.4603174603174603)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.49523809523809526,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AFw8BMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw8xMjEee0L_IMWjydgQ" type="6001">
@@ -3093,8 +3066,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Fd7BwRMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fd7BwhMkEee0L_IMWjydgQ" points="[0, 0, 89, 177]$[-60, -118, 29, 59]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7619047619047619,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9694323144104804,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7523809523809524,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9606986899563319,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_tVhB4BMkEee0L_IMWjydgQ" type="4001" source="_6_LyABMjEee0L_IMWjydgQ" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB4xMkEee0L_IMWjydgQ" type="6001">
@@ -3178,7 +3151,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_n4p8MSNtEeenc_m30jt0Ow"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n4p8MiNtEeenc_m30jt0Ow" points="[56, 58, 4, -81]$[139, 139, 87, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n6kAsCNtEeenc_m30jt0Ow" id="(0.5188284518828452,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n6kAsCNtEeenc_m30jt0Ow" id="(0.516728624535316,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n6kAsSNtEeenc_m30jt0Ow" id=""/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_w2vdcEq9EeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_7AFw8BMjEee0L_IMWjydgQ" target="_w2u2YEq9EeexQa2RWFy3AQ">
@@ -3223,6 +3196,66 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7o5yQkvrEee8IN5myVB_oQ" points="[0, 0, 37, 177]$[106, -116, 143, 61]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sEvrEee8IN5myVB_oQ" id="(0.41875,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sUvrEee8IN5myVB_oQ" id="(0.6419753086419753,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VZoF4EwOEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF40wOEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5EwOEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF5UwOEeewALXL7BvPYw" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-101" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF50wOEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6EwOEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF6UwOEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6kwOEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF60wOEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF7EwOEeewALXL7BvPYw" x="11" y="-17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF7UwOEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF7kwOEeewALXL7BvPYw" x="-12" y="-16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_VZoF4UwOEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_U4H7UEwOEeewALXL7BvPYw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -353, -128]$[0, 128, -353, 0]$[353, 128, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbFecEwOEeewALXL7BvPYw" id="(0.8461538461538461,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbGFgEwOEeewALXL7BvPYw" id="(0.0,0.5932203389830508)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ijqBwEwPEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqBw0wPEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxEwPEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqBxUwPEeewALXL7BvPYw" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxkwPEeewALXL7BvPYw" x="-44" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqBx0wPEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqByEwPEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqo0EwPEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqo0UwPEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqo0kwPEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqo00wPEeewALXL7BvPYw" x="10" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ijqo1EwPEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqo1UwPEeewALXL7BvPYw" x="-12" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ijqBwUwPEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ihpPkEwPEeewALXL7BvPYw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ijqBwkwPEeewALXL7BvPYw" points="[0, 0, 88, 0]$[0, -91, 88, -91]$[-88, -91, 0, -91]$[-88, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ilYgEEwPEeewALXL7BvPYw" id="(0.8365384615384616,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ilYgEUwPEeewALXL7BvPYw" id="(0.41346153846153844,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Duxwl0wVEeewALXL7BvPYw" type="StereotypeCommentLink" source="_mwRD8MhsEeaVlemTikmRHw" target="_Duxwk0wVEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DuxwmEwVEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DuxwnEwVEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DuxwmUwVEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DuxwmkwVEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Duxwm0wVEeewALXL7BvPYw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -3943,7 +3976,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjmfAesSEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjgYUesSEealN7CdLT_GPw" x="495" y="-11" height="94"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjgYUesSEealN7CdLT_GPw" x="439" y="-2" height="94"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Qjslq-sSEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QjslrOsSEealN7CdLT_GPw" showTitle="true"/>
@@ -4246,7 +4279,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9OsUEealN7CdLT_GPw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Qbpx9esUEealN7CdLT_GPw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9usUEealN7CdLT_GPw" x="-14" y="-31"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9usUEealN7CdLT_GPw" x="-3" y="-32"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Qbpx9-sUEealN7CdLT_GPw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx-OsUEealN7CdLT_GPw" y="-20"/>
@@ -4278,7 +4311,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__MdIwOsYEealN7CdLT_GPw" type="4001" source="_s9Rl4Or0EeaeHOJw3lCT8A" target="_ryFlIOr0EeaeHOJw3lCT8A">
       <children xmi:type="notation:DecorationNode" xmi:id="__MdIw-sYEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__MdIxOsYEealN7CdLT_GPw" x="21" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__MdIxOsYEealN7CdLT_GPw" x="21" y="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__MdIxesYEealN7CdLT_GPw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="__MdIxusYEealN7CdLT_GPw" x="26" y="-11"/>
@@ -4346,47 +4379,12 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cqu7musbEealN7CdLT_GPw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cqu7m-sbEealN7CdLT_GPw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jHMKYOscEealN7CdLT_GPw" type="4001" source="_QjgYUOsSEealN7CdLT_GPw" target="_W4xb0OsTEealN7CdLT_GPw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKY-scEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKZOscEealN7CdLT_GPw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKZescEealN7CdLT_GPw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKZuscEealN7CdLT_GPw" x="4" y="-59"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKZ-scEealN7CdLT_GPw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKaOscEealN7CdLT_GPw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKaescEealN7CdLT_GPw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKauscEealN7CdLT_GPw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKa-scEealN7CdLT_GPw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKbOscEealN7CdLT_GPw" x="14" y="-19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_jHMKbescEealN7CdLT_GPw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_jHMKbuscEealN7CdLT_GPw" x="-18" y="-19"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_jHMKYescEealN7CdLT_GPw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHMKYuscEealN7CdLT_GPw" points="[0, 0, 116, 123]$[12, -123, 128, 0]$[-116, -123, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHSRAOscEealN7CdLT_GPw" id="(0.5770925110132159,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHSRAescEealN7CdLT_GPw" id="(1.0,0.6682692307692307)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_jHqrh-scEealN7CdLT_GPw" type="StereotypeCommentLink" source="_jHMKYOscEealN7CdLT_GPw" target="_jHqrg-scEealN7CdLT_GPw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_jHqriOscEealN7CdLT_GPw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_jHqrjOscEealN7CdLT_GPw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jHqriescEealN7CdLT_GPw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHqriuscEealN7CdLT_GPw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jHqri-scEealN7CdLT_GPw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lREA8OscEealN7CdLT_GPw" type="4001" source="_QjgYUOsSEealN7CdLT_GPw" target="_W4xb0OsTEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA8-scEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9OscEealN7CdLT_GPw" x="21"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9OscEealN7CdLT_GPw" x="42" y="6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA9escEealN7CdLT_GPw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9uscEealN7CdLT_GPw" x="40" y="9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9uscEealN7CdLT_GPw" x="53" y="12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA9-scEealN7CdLT_GPw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA-OscEealN7CdLT_GPw" y="-20"/>
@@ -4402,9 +4400,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lREA8escEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 73, 81]$[-73, 0, 0, 81]$[-73, -81, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREA_-scEealN7CdLT_GPw" id="(0.0,0.2972972972972973)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREBAOscEealN7CdLT_GPw" id="(0.7948717948717948,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 64, 90]$[-64, 0, 0, 90]$[-64, -90, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREA_-scEealN7CdLT_GPw" id="(0.0,0.2872340425531915)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREBAOscEealN7CdLT_GPw" id="(0.6442307692307693,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lRiiGuscEealN7CdLT_GPw" type="StereotypeCommentLink" source="_lREA8OscEealN7CdLT_GPw" target="_lRiiFuscEealN7CdLT_GPw">
       <styles xmi:type="notation:FontStyle" xmi:id="_lRiiG-scEealN7CdLT_GPw"/>
@@ -4569,8 +4567,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_QX43YfLXEeaAIfPpmDwI5Q"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_KnJbUPIoEea79czpMf3AVQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QX43YvLXEeaAIfPpmDwI5Q" points="[0, 0, 113, -168]$[-113, 168, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgPLXEeaAIfPpmDwI5Q" id="(0.44933920704845814,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgfLXEeaAIfPpmDwI5Q" id="(0.6379821958456974,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgPLXEeaAIfPpmDwI5Q" id="(0.4486301369863014,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgfLXEeaAIfPpmDwI5Q" id="(0.5578635014836796,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QYR49_LXEeaAIfPpmDwI5Q" type="StereotypeCommentLink" source="_QX43YPLXEeaAIfPpmDwI5Q" target="_QYR48_LXEeaAIfPpmDwI5Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_QYR4-PLXEeaAIfPpmDwI5Q"/>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -353,10 +353,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlmzBFEeam35bpdXJzEw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_0HHlnDBFEeam35bpdXJzEw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_GU9nEN6MEeWd9KDn6x5Skg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHluzBFEeam35bpdXJzEw"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_0HHlvDBFEeam35bpdXJzEw" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHl2zBFEeam35bpdXJzEw"/>
@@ -3290,7 +3286,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjgzBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjsTBGEeam35bpdXJzEw" x="-74" y="128" width="435" height="219"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjsTBGEeam35bpdXJzEw" x="-59" y="53" width="435" height="196"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LsrjxjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_LsrjxzBGEeam35bpdXJzEw" type="5029"/>
@@ -3370,7 +3366,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmFTBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmQzBGEeam35bpdXJzEw" x="577" y="219" width="289" height="121"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmQzBGEeam35bpdXJzEw" x="586" y="228" width="289" height="121"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__g_RQzIvEeamvfKYyWmELQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__g_RRDIvEeamvfKYyWmELQ" showTitle="true"/>
@@ -3420,6 +3416,126 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_USf-dRMmEee0L_IMWjydgQ" x="777" y="119"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_rT034EwEEeewALXL7BvPYw" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_rT1e8EwEEeewALXL7BvPYw" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_rT1e8UwEEeewALXL7BvPYw" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rT1e8kwEEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rT1e80wEEeewALXL7BvPYw" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_AR-QUEwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_TsAkwEEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR-QUUwGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AR_ecEwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR_ecUwGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_AR_eckwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR_ec0wGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ASAFgEwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFgUwGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ASAFgkwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFg0wGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ASAFhEwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFhUwGEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ASAskEwGEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAskUwGEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rT1e9EwEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rT1e9UwEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rT1e9kwEEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT1e90wEEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rT1e-EwEEeewALXL7BvPYw" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rT1e-UwEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rT1e-kwEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rT1e-0wEEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT1e_EwEEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_rT1e_UwEEeewALXL7BvPYw" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_rT1e_kwEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_rT1e_0wEEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_rT1fAEwEEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT1fAUwEEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT034UwEEeewALXL7BvPYw" x="15" y="321" height="155"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rT-o4EwEEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rT-o4UwEEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rT-o40wEEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT-o4kwEEeewALXL7BvPYw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FdXMk0wFEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_FdXMlEwFEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FdXMlkwFEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FdXMlUwFEeewALXL7BvPYw" x="180" y="279"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Wnt_wEwFEeewALXL7BvPYw" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Wnum0EwFEeewALXL7BvPYw" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Wnum0UwFEeewALXL7BvPYw" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Wnum0kwFEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Wnum00wFEeewALXL7BvPYw" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_xl5dcEwFEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xl5dcUwFEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_xl6EgEwFEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xl6EgUwFEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Wnum1EwFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Wnum1UwFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Wnum1kwFEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnum10wFEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Wnum2EwFEeewALXL7BvPYw" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Wnum2UwFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Wnum2kwFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Wnum20wFEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnum3EwFEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Wnum3UwFEeewALXL7BvPYw" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Wnum3kwFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Wnum30wFEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Wnum4EwFEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnum4UwFEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnt_wUwFEeewALXL7BvPYw" x="590" y="397" height="93"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Wn2io0wFEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Wn2ipEwFEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wn2ipkwFEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wn2ipUwFEeewALXL7BvPYw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uUeTgEwGEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uUeTgUwGEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUeTg0wGEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUeTgkwGEeewALXL7BvPYw" x="215" y="221"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Hdao8TBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Hdao8jBGEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_Hdao8zBGEeam35bpdXJzEw">
@@ -3451,8 +3567,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Lsre4TBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_TPT-AO_tEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lsre6DBGEeam35bpdXJzEw" points="[47, 100, -36, -74]$[89, 153, 6, -21]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6TBGEeam35bpdXJzEw" id="(1.0,0.0962566844919786)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6jBGEeam35bpdXJzEw" id="(0.0,0.6533333333333333)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6TBGEeam35bpdXJzEw" id="(1.0,0.3826530612244898)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6jBGEeam35bpdXJzEw" id="(0.0,0.41333333333333333)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_LsrfcjBGEeam35bpdXJzEw" type="4001" source="_LsrlYzBGEeam35bpdXJzEw" target="_LsrifDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_LsrfczBGEeam35bpdXJzEw" type="6001">
@@ -3476,8 +3592,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_LsrffzBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LsrfhjBGEeam35bpdXJzEw" points="[-5, -54, 6, 81]$[-11, -135, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfhzBGEeam35bpdXJzEw" id="(0.0,0.5206611570247934)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfiDBGEeam35bpdXJzEw" id="(1.0,0.7123287671232876)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfhzBGEeam35bpdXJzEw" id="(0.0,0.09090909090909091)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfiDBGEeam35bpdXJzEw" id="(1.0,0.9489795918367347)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__hSMQzIvEeamvfKYyWmELQ" type="StereotypeCommentLink" source="_LsrifDBGEeam35bpdXJzEw" target="__hSMPzIvEeamvfKYyWmELQ">
       <styles xmi:type="notation:FontStyle" xmi:id="__hSMRDIvEeamvfKYyWmELQ"/>
@@ -3528,6 +3644,96 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_USf-eRMmEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USf-ehMmEee0L_IMWjydgQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USf-exMmEee0L_IMWjydgQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rT-o5EwEEeewALXL7BvPYw" type="StereotypeCommentLink" source="_rT034EwEEeewALXL7BvPYw" target="_rT-o4EwEEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rT-o5UwEEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rT-o6UwEEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rT-o5kwEEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rT-o50wEEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rT-o6EwEEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4_DRwEwEEeewALXL7BvPYw" type="4001" source="_rT034EwEEeewALXL7BvPYw" target="_LsrlYzBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRw0wEEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRxEwEEeewALXL7BvPYw" x="-8" y="11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRxUwEEeewALXL7BvPYw" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRxkwEEeewALXL7BvPYw" x="-4" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRx0wEEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRyEwEEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRyUwEEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRykwEEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRy0wEEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRzEwEEeewALXL7BvPYw" x="10" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRzUwEEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRzkwEEeewALXL7BvPYw" x="-14" y="16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_4_DRwUwEEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4_DRwkwEEeewALXL7BvPYw" points="[29, -10, -350, 114]$[360, -115, -19, 9]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ACwQEwEEeewALXL7BvPYw" id="(1.0,0.1032258064516129)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ACwQUwEEeewALXL7BvPYw" id="(0.0,0.9008264462809917)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FdXMl0wFEeewALXL7BvPYw" type="StereotypeCommentLink" source="_4_DRwEwEEeewALXL7BvPYw" target="_FdXMk0wFEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FdXMmEwFEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FdXzokwFEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FdXMmUwFEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FdXzoEwFEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FdXzoUwFEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Wn3JsEwFEeewALXL7BvPYw" type="StereotypeCommentLink" source="_Wnt_wEwFEeewALXL7BvPYw" target="_Wn2io0wFEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Wn3JsUwFEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wn3JtUwFEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Wn3JskwFEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wn3Js0wFEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wn3JtEwFEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nLYmYEwFEeewALXL7BvPYw" type="4001" source="_rT034EwEEeewALXL7BvPYw" target="_Wnt_wEwFEeewALXL7BvPYw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmY0wFEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZEwFEeewALXL7BvPYw" x="-4" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZUwFEeewALXL7BvPYw" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZkwFEeewALXL7BvPYw" x="-3" y="-6"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZ0wFEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmaEwFEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmaUwFEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmakwFEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYma0wFEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmbEwFEeewALXL7BvPYw" x="15" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nLYmbUwFEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmbkwFEeewALXL7BvPYw" x="-17" y="16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nLYmYUwFEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nLYmYkwFEeewALXL7BvPYw" points="[15, 0, -301, -9]$[306, 6, -10, -3]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.7161290322580646)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQUwFEeewALXL7BvPYw" id="(0.0,0.3655913978494624)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uUeThEwGEeewALXL7BvPYw" type="StereotypeCommentLink" source="_nLYmYEwFEeewALXL7BvPYw" target="_uUeTgEwGEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uUeThUwGEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uUeTiUwGEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uUeThkwGEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTh0wGEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTiEwGEeewALXL7BvPYw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_l51YUOr0EeaeHOJw3lCT8A" type="PapyrusUMLClassDiagram" name="Resilience" measurementUnit="Pixel">

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -391,7 +391,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHl6TBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="138" y="311" height="134"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="138" y="311" height="149"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtYijBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYizBFEeam35bpdXJzEw" showTitle="true"/>
@@ -945,9 +945,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ysyms_lIEeaQEoLj_Ia_cg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_ysymtPlIEeaQEoLj_Ia_cg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysymtvlIEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysymtvlIEeaQEoLj_Ia_cg" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysymtflIEeaQEoLj_Ia_cg" x="189" y="-337"/>
     </children>
@@ -1496,29 +1494,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rwVK_vlIEeaQEoLj_Ia_cg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rwVK__lIEeaQEoLj_Ia_cg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_yr-uYPlIEeaQEoLj_Ia_cg" type="4007" source="_rwI9oPlIEeaQEoLj_Ia_cg" target="_0G9yhzBFEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_yr-uY_lIEeaQEoLj_Ia_cg" type="6016">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yr-uZPlIEeaQEoLj_Ia_cg" x="-75" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_yr-uZflIEeaQEoLj_Ia_cg" type="6017">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yr-uZvlIEeaQEoLj_Ia_cg" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_yr-uYflIEeaQEoLj_Ia_cg"/>
-      <element xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yr-uYvlIEeaQEoLj_Ia_cg" points="[119, 155, -88, -113]$[207, 268, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yr-uZ_lIEeaQEoLj_Ia_cg" id="(0.35091023226616447,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yr-uaPlIEeaQEoLj_Ia_cg" id="(0.11612903225806452,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ysymt_lIEeaQEoLj_Ia_cg" type="StereotypeCommentLink" source="_yr-uYPlIEeaQEoLj_Ia_cg" target="_ysyms_lIEeaQEoLj_Ia_cg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ysymuPlIEeaQEoLj_Ia_cg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysymvPlIEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ysymuflIEeaQEoLj_Ia_cg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysymuvlIEeaQEoLj_Ia_cg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysymu_lIEeaQEoLj_Ia_cg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BDVm3_4xEea_VPdGG2-szQ" type="StereotypeCommentLink" source="_BDPgIP4xEea_VPdGG2-szQ" target="_BDVm2_4xEea_VPdGG2-szQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_BDVm4P4xEea_VPdGG2-szQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BDVm5P4xEea_VPdGG2-szQ" name="BASE_ELEMENT">
@@ -1694,7 +1669,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1azBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="258" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="258" width="166" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU16TBGEeam35bpdXJzEw" type="2004">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1iHO4BMvEee0L_IMWjydgQ" source="displayNameLabelIcon">
@@ -1723,7 +1698,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1-zBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2ITBGEeam35bpdXJzEw" x="-155" y="-123" width="180" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2ITBGEeam35bpdXJzEw" x="-137" y="-123" width="162" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU2QjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2QzBGEeam35bpdXJzEw" type="5029"/>
@@ -1896,14 +1871,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bn3K3DBGEeam35bpdXJzEw" x="1073" y="369"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_BoKFyjBGEeam35bpdXJzEw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_BoKFyzBGEeam35bpdXJzEw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BoKFzTBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BoKFzDBGEeam35bpdXJzEw" x="850" y="370"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__JVmQzIvEeamvfKYyWmELQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__JVmRDIvEeamvfKYyWmELQ" showTitle="true"/>
@@ -2289,27 +2256,15 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l7R8tchsEeaVlemTikmRHw" x="327" y="-75"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_mwvlE8hsEeaVlemTikmRHw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_mwvlFMhsEeaVlemTikmRHw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mwvlFshsEeaVlemTikmRHw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mwvlFchsEeaVlemTikmRHw" x="327" y="-75"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_zwoew_lHEeaQEoLj_Ia_cg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_zwoexPlHEeaQEoLj_Ia_cg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zwoexvlHEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zwoexvlHEeaQEoLj_Ia_cg" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zwoexflHEeaQEoLj_Ia_cg" x="45" y="-223"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9anQwPlHEeaQEoLj_Ia_cg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9anQwflHEeaQEoLj_Ia_cg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9anQw_lHEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_3AqFEPlHEeaQEoLj_Ia_cg"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9anQw_lHEeaQEoLj_Ia_cg" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9anQwvlHEeaQEoLj_Ia_cg" x="45" y="-223"/>
     </children>
@@ -2363,7 +2318,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyExMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="630" y="-50" width="229" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="631" y="-145" width="229" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UI4IaxMmEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_UI4IbBMmEee0L_IMWjydgQ" showTitle="true"/>
@@ -2423,6 +2378,30 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EYlaRRM4Eee0L_IMWjydgQ" x="213" y="-396"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_w2u2YEq9EeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_w2u2YUq9EeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_w2u2Y0q9EeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_w2u2Ykq9EeexQa2RWFy3AQ" x="688" y="32"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_w3MJYEq9EeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_w3MJYUq9EeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_w3MJY0q9EeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_w3MJYkq9EeexQa2RWFy3AQ" x="973" y="91"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_g66-oEvpEee8IN5myVB_oQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_g66-oUvpEee8IN5myVB_oQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g66-o0vpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g66-okvpEee8IN5myVB_oQ" x="474" y="-45"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_9y8uwzBFEeam35bpdXJzEw">
@@ -2450,7 +2429,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU1UjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -144, 1]$[0, 34, -144, 35]$[144, 34, 0, 35]$[144, -1, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -119, 1]$[0, 34, -119, 35]$[119, 34, 0, 35]$[119, -1, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1VzBGEeam35bpdXJzEw" id="(0.7575757575757576,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1WDBGEeam35bpdXJzEw" id="(0.13548387096774195,1.0)"/>
     </edges>
@@ -2481,10 +2460,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU11TBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU11jBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="4" y="-6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="-13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12DBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-12" y="-5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-25"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12jBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12zBGEeam35bpdXJzEw" y="-20"/>
@@ -2501,8 +2480,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU14jBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU15jBGEeam35bpdXJzEw" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.384180790960452,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.5454545454545454,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.480225988700565,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.536144578313253,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2LjBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2LzBGEeam35bpdXJzEw" type="6001">
@@ -2525,7 +2504,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU2OzBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2PzBGEeam35bpdXJzEw" points="[0, 0, 208, -1]$[0, 83, 208, 82]$[-208, 83, 0, 82]$[-208, 1, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2PzBGEeam35bpdXJzEw" points="[0, 0, 186, -1]$[0, 83, 186, 82]$[-186, 83, 0, 82]$[-186, 1, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QDBGEeam35bpdXJzEw" id="(0.45806451612903226,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QTBGEeam35bpdXJzEw" id="(0.6515151515151515,1.0)"/>
     </edges>
@@ -2550,7 +2529,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU2nDBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2oDBGEeam35bpdXJzEw" points="[0, 0, 48, 0]$[0, 38, 48, 38]$[-48, 38, 0, 38]$[-48, 0, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2oDBGEeam35bpdXJzEw" points="[0, 0, 61, 0]$[0, 38, 61, 38]$[-61, 38, 0, 38]$[-61, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2oTBGEeam35bpdXJzEw" id="(0.422360248447205,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2ojBGEeam35bpdXJzEw" id="(0.055900621118012424,1.0)"/>
     </edges>
@@ -2609,7 +2588,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ETBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3EjBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3EzBGEeam35bpdXJzEw" x="-1" y="10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3EzBGEeam35bpdXJzEw" x="-1" y="13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3FDBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3FTBGEeam35bpdXJzEw" y="-20"/>
@@ -2625,9 +2604,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3HDBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3IDBGEeam35bpdXJzEw" points="[0, 0, 148, 45]$[-13, -45, 135, 0]$[-148, -45, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.5317460317460317,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.5)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3IDBGEeam35bpdXJzEw" points="[0, 0, 113, 60]$[0, -60, 113, 0]$[-113, -60, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.4550898203592814,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.265625)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3IzBGEeam35bpdXJzEw" type="4014" source="_BlU3yjBGEeam35bpdXJzEw" target="_BlU3aTBGEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3JDBGEeam35bpdXJzEw"/>
@@ -2849,16 +2828,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bn3K4TBGEeam35bpdXJzEw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bn3K4jBGEeam35bpdXJzEw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BoKFzjBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU11TBGEeam35bpdXJzEw" target="_BoKFyjBGEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BoKFzzBGEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BoKF0zBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BoKF0DBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BoKF0TBGEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BoKF0jBGEeam35bpdXJzEw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="__JVmRzIvEeamvfKYyWmELQ" type="StereotypeCommentLink" source="_BlU0MDBGEeam35bpdXJzEw" target="__JVmQzIvEeamvfKYyWmELQ">
       <styles xmi:type="notation:FontStyle" xmi:id="__JVmSDIvEeamvfKYyWmELQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="__JVmTDIvEeamvfKYyWmELQ" name="BASE_ELEMENT">
@@ -2984,7 +2953,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9MhsEeaVlemTikmRHw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU9chsEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9shsEeaVlemTikmRHw" x="-71" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9shsEeaVlemTikmRHw" x="-89" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU98hsEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU-MhsEeaVlemTikmRHw" y="-20"/>
@@ -3016,10 +2985,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mwRD8MhsEeaVlemTikmRHw" type="4001" source="_e4LtYMhsEeaVlemTikmRHw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD88hsEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" x="39" y="-47"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD9chsEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9shsEeaVlemTikmRHw" x="-91" y="15"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9shsEeaVlemTikmRHw" x="-99" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD98hsEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD-MhsEeaVlemTikmRHw" y="-20"/>
@@ -3038,62 +3007,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mwRD8shsEeaVlemTikmRHw" points="[130, 45, -33, -12]$[147, 55, -16, -2]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUMhsEeaVlemTikmRHw" id="(0.9475409836065574,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.15819209039548024,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mwvlF8hsEeaVlemTikmRHw" type="StereotypeCommentLink" source="_mwRD8MhsEeaVlemTikmRHw" target="_mwvlE8hsEeaVlemTikmRHw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_mwvlGMhsEeaVlemTikmRHw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mwvlHMhsEeaVlemTikmRHw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mwvlGchsEeaVlemTikmRHw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mwvlGshsEeaVlemTikmRHw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mwvlG8hsEeaVlemTikmRHw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zwiYIPlHEeaQEoLj_Ia_cg" type="4007" source="_BlU16TBGEeam35bpdXJzEw" target="_BlU0MDBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_zwiYI_lHEeaQEoLj_Ia_cg" type="6016">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zwiYJPlHEeaQEoLj_Ia_cg" x="-22" y="3"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zwiYJflHEeaQEoLj_Ia_cg" visible="false" type="6017">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zwiYJvlHEeaQEoLj_Ia_cg" x="33" y="17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_zwiYIflHEeaQEoLj_Ia_cg"/>
-      <element xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zwiYIvlHEeaQEoLj_Ia_cg" points="[22, 61, -33, -87]$[55, 148, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zwiYJ_lHEeaQEoLj_Ia_cg" id="(0.4722222222222222,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zwiYKPlHEeaQEoLj_Ia_cg" id="(0.19375,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zwoex_lHEeaQEoLj_Ia_cg" type="StereotypeCommentLink" source="_zwiYIPlHEeaQEoLj_Ia_cg" target="_zwoew_lHEeaQEoLj_Ia_cg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zwoeyPlHEeaQEoLj_Ia_cg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zwoezPlHEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_KpFD8L2YEeWdore3Cxez9g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zwoeyflHEeaQEoLj_Ia_cg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zwoeyvlHEeaQEoLj_Ia_cg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zwoey_lHEeaQEoLj_Ia_cg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9aU84PlHEeaQEoLj_Ia_cg" type="4007" source="_BlU16TBGEeam35bpdXJzEw" target="_e4LtYMhsEeaVlemTikmRHw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_9aU84_lHEeaQEoLj_Ia_cg" type="6016">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9aU85PlHEeaQEoLj_Ia_cg" x="-53" y="-1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_9aU85flHEeaQEoLj_Ia_cg" visible="false" type="6017">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9aU85vlHEeaQEoLj_Ia_cg" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_9aU84flHEeaQEoLj_Ia_cg"/>
-      <element xmi:type="uml:Usage" href="TapiConnectivity.uml#_3AqFEPlHEeaQEoLj_Ia_cg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9aU84vlHEeaQEoLj_Ia_cg" points="[0, 0, -80, 124]$[0, -124, -80, 0]$[80, -124, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9aU85_lHEeaQEoLj_Ia_cg" id="(0.4888888888888889,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9aU86PlHEeaQEoLj_Ia_cg" id="(0.0,0.5060240963855421)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9anQxPlHEeaQEoLj_Ia_cg" type="StereotypeCommentLink" source="_9aU84PlHEeaQEoLj_Ia_cg" target="_9anQwPlHEeaQEoLj_Ia_cg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_9anQxflHEeaQEoLj_Ia_cg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9anQyflHEeaQEoLj_Ia_cg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiConnectivity.uml#_3AqFEPlHEeaQEoLj_Ia_cg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9anQxvlHEeaQEoLj_Ia_cg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9anQx_lHEeaQEoLj_Ia_cg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9anQyPlHEeaQEoLj_Ia_cg"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lu32EBMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_lu32ExMjEee0L_IMWjydgQ" type="6001">
@@ -3147,10 +3060,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AFw8BMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw8xMjEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="13" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9RMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="22" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="29" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9xMjEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw-BMjEee0L_IMWjydgQ" y="-20"/>
@@ -3172,7 +3085,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Fd7BwBMkEee0L_IMWjydgQ" type="4001" source="_luMgoBMjEee0L_IMWjydgQ" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BwxMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="34"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxRMkEee0L_IMWjydgQ" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="45" y="-18"/>
@@ -3193,7 +3106,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fd7BwhMkEee0L_IMWjydgQ" points="[0, 0, 89, 177]$[-60, -118, 29, 59]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7619047619047619,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9737991266375546,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9694323144104804,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_tVhB4BMkEee0L_IMWjydgQ" type="4001" source="_6_LyABMjEee0L_IMWjydgQ" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB4xMkEee0L_IMWjydgQ" type="6001">
@@ -3216,8 +3129,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_tVhB4RMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 93, -131]$[0, 131, 93, 0]$[-93, 131, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.5191256830601093,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 94, -226]$[0, 226, 94, 0]$[-94, 226, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.5152838427947598,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB8BMkEee0L_IMWjydgQ" id="(1.0,0.13793103448275862)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_UI4IbxMmEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_luMgoBMjEee0L_IMWjydgQ" target="_UI4IaxMmEee0L_IMWjydgQ">
@@ -3279,6 +3192,49 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n4p8MiNtEeenc_m30jt0Ow" points="[56, 58, 4, -81]$[139, 139, 87, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n6kAsCNtEeenc_m30jt0Ow" id="(0.5188284518828452,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n6kAsSNtEeenc_m30jt0Ow" id=""/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_w2vdcEq9EeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_7AFw8BMjEee0L_IMWjydgQ" target="_w2u2YEq9EeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_w2vdcUq9EeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_w2vddUq9EeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_w2vdckq9EeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w2vdc0q9EeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w2vddEq9EeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_w3MJZEq9EeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_Fd7BwBMkEee0L_IMWjydgQ" target="_w3MJYEq9EeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_w3MJZUq9EeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_w3MJaUq9EeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_w3MJZkq9EeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJZ0q9EeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJaEq9EeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_g66-pEvpEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_BlU11TBGEeam35bpdXJzEw" target="_g66-oEvpEee8IN5myVB_oQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_g66-pUvpEee8IN5myVB_oQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g66-qUvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g66-pkvpEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g66-p0vpEee8IN5myVB_oQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g66-qEvpEee8IN5myVB_oQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7o5yQEvrEee8IN5myVB_oQ" type="4005" source="_BlU0MDBGEeam35bpdXJzEw" target="_BlU16TBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_7o5yQ0vrEee8IN5myVB_oQ" type="6012">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7o5yREvrEee8IN5myVB_oQ" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_7o5yRUvrEee8IN5myVB_oQ" type="6013">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7o5yRkvrEee8IN5myVB_oQ" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_7o5yQUvrEee8IN5myVB_oQ"/>
+      <element xmi:type="uml:Realization" href="TapiConnectivity.uml#_7o4kIEvrEee8IN5myVB_oQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7o5yQkvrEee8IN5myVB_oQ" points="[0, 0, 37, 177]$[106, -116, 143, 61]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sEvrEee8IN5myVB_oQ" id="(0.41875,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sUvrEee8IN5myVB_oQ" id="(0.6419753086419753,1.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -3643,7 +3599,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rSCMIer0EeaeHOJw3lCT8A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rR8Fcer0EeaeHOJw3lCT8A" x="5" y="228" height="137"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rR8Fcer0EeaeHOJw3lCT8A" x="5" y="228" height="161"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rSOZa-r0EeaeHOJw3lCT8A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rSOZbOr0EeaeHOJw3lCT8A" showTitle="true"/>
@@ -3797,7 +3753,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjmfAesSEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjgYUesSEealN7CdLT_GPw" x="495" y="-11" height="74"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QjgYUesSEealN7CdLT_GPw" x="495" y="-11" height="94"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Qjslq-sSEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QjslrOsSEealN7CdLT_GPw" showTitle="true"/>
@@ -3999,14 +3955,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__kAwbescEealN7CdLT_GPw" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Oo094-seEealN7CdLT_GPw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Oo095OseEealN7CdLT_GPw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oo095useEealN7CdLT_GPw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Oo095eseEealN7CdLT_GPw" x="953" y="40"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_hU2_M-seEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_hU2_NOseEealN7CdLT_GPw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hU2_NuseEealN7CdLT_GPw" name="BASE_ELEMENT">
@@ -4050,6 +3998,14 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYR49fLXEeaAIfPpmDwI5Q" x="695" y="-111"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_g67ls0vpEee8IN5myVB_oQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_g67ltEvpEee8IN5myVB_oQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g67ltkvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g67ltUvpEee8IN5myVB_oQ" x="943" y="-148"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_l51YUer0EeaeHOJw3lCT8A" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_l51YUur0EeaeHOJw3lCT8A"/>
@@ -4268,7 +4224,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lREA8escEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 73, 76]$[-73, 0, 0, 76]$[-73, -76, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 73, 81]$[-73, 0, 0, 81]$[-73, -81, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREA_-scEealN7CdLT_GPw" id="(0.0,0.2972972972972973)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREBAOscEealN7CdLT_GPw" id="(0.7948717948717948,1.0)"/>
     </edges>
@@ -4316,16 +4272,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OoQWIuseEealN7CdLT_GPw" points="[0, 0, 379, 182]$[0, -182, 379, 0]$[-379, -182, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWL-seEealN7CdLT_GPw" id="(0.45353159851301117,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWMOseEealN7CdLT_GPw" id="(1.0,0.2088607594936709)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Oo095-seEealN7CdLT_GPw" type="StereotypeCommentLink" source="_OoQWIOseEealN7CdLT_GPw" target="_Oo094-seEealN7CdLT_GPw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Oo096OseEealN7CdLT_GPw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Oo097OseEealN7CdLT_GPw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Oo096eseEealN7CdLT_GPw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oo096useEealN7CdLT_GPw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Oo096-seEealN7CdLT_GPw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hUADkOseEealN7CdLT_GPw" type="4001" source="_ryFlIOr0EeaeHOJw3lCT8A" target="__j6psOscEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_hUADk-seEealN7CdLT_GPw" type="6001">
@@ -4457,6 +4403,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QYR4-fLXEeaAIfPpmDwI5Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYR4-vLXEeaAIfPpmDwI5Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYR4-_LXEeaAIfPpmDwI5Q"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_g67lt0vpEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_OoQWIOseEealN7CdLT_GPw" target="_g67ls0vpEee8IN5myVB_oQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_g67luEvpEee8IN5myVB_oQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g67lvEvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g67luUvpEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g67lukvpEee8IN5myVB_oQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g67lu0vpEee8IN5myVB_oQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_W_wkgPItEea79czpMf3AVQ" type="PapyrusUMLClassDiagram" name="DataTypes" measurementUnit="Pixel">

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -33,7 +33,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9yKjBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9yWDBFEeam35bpdXJzEw" x="753" y="337" height="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G9yWDBFEeam35bpdXJzEw" x="711" y="337" height="80"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0G9yhzBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G9yiDBFEeam35bpdXJzEw" type="5029"/>
@@ -137,7 +137,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G903DBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G91CjBFEeam35bpdXJzEw" x="447" y="338" height="97"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G91CjBFEeam35bpdXJzEw" x="432" y="338" height="97"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0G91CzBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G91DDBFEeam35bpdXJzEw" type="5029"/>
@@ -233,7 +233,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G92_jBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G93LDBFEeam35bpdXJzEw" x="-294" y="1" width="303" height="185"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0G93LDBFEeam35bpdXJzEw" x="-270" y="1" width="303" height="185"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHioDBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHioTBFEeam35bpdXJzEw" type="5029"/>
@@ -295,7 +295,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjeTBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjpzBFEeam35bpdXJzEw" x="738" y="61" height="204"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjpzBFEeam35bpdXJzEw" x="696" y="61" height="204"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHjqDBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHjqTBFEeam35bpdXJzEw" type="5029"/>
@@ -333,7 +333,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkATBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkLzBFEeam35bpdXJzEw" x="729" y="-132" width="304" height="95"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHkLzBFEeam35bpdXJzEw" x="687" y="-132" width="304" height="95"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHlMDBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHlMTBFEeam35bpdXJzEw" type="5029"/>
@@ -341,25 +341,33 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlMzBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0HHlNDBFEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_0HHlNTBFEeam35bpdXJzEw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_PYDKgE5qEeeicu4cm-7qRg" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_TsAkwEEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYDKgU5qEeeicu4cm-7qRg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PYDxkE5qEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlWzBFEeam35bpdXJzEw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYDxkU5qEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_0HHlXDBFEeam35bpdXJzEw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlezBFEeam35bpdXJzEw"/>
+        <children xmi:type="notation:Shape" xmi:id="_PYEYoE5qEeeicu4cm-7qRg" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYEYoU5qEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_0HHlfDBFEeam35bpdXJzEw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_PYEYok5qEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlmzBFEeam35bpdXJzEw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYEYo05qEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_0HHlvDBFEeam35bpdXJzEw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_PYE_sE5qEeeicu4cm-7qRg" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYE_sU5qEeeicu4cm-7qRg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_PYE_sk5qEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHl2zBFEeam35bpdXJzEw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYE_s05qEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lzneYP42Eea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_PYE_tE5qEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lzneYf42Eea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_PYE_tU5qEeeicu4cm-7qRg"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0HHl3DBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0HHl3TBFEeam35bpdXJzEw"/>
@@ -379,7 +387,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHl6TBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="138" y="311" height="149"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHmFzBFEeam35bpdXJzEw" x="138" y="304" height="154"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtYijBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYizBFEeam35bpdXJzEw" showTitle="true"/>
@@ -943,41 +951,49 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BDPgJP4xEea_VPdGG2-szQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_BDPgJf4xEea_VPdGG2-szQ" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_2_T1sP4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au4DYE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1sf4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4DYU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1sv4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au4qcE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1s_4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qcU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1tP4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au4qck5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wGVAhMF-EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1tf4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qc05rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1tv4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au4qdE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_xyluAsF-EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1t_4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qdU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1uP4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au5RgE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1uf4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5RgU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1uv4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au5Rgk5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1u_4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5Rg05rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1vP4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au5RhE5rEeeicu4cm-7qRg" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5RhU5rEeeicu4cm-7qRg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_au54kE5rEeeicu4cm-7qRg" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au54kU5rEeeicu4cm-7qRg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_au6foE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_SWwL11EeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1vf4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au6foU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1vv4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au7GsE5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1v_4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au7GsU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2_T1wP4zEea_VPdGG2-szQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_au7Gsk5rEeeicu4cm-7qRg" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2_T1wf4zEea_VPdGG2-szQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_au7Gs05rEeeicu4cm-7qRg"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_BDPgJv4xEea_VPdGG2-szQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_BDPgJ_4xEea_VPdGG2-szQ"/>
@@ -997,7 +1013,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgM_4xEea_VPdGG2-szQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_-fei4P4wEea_VPdGG2-szQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgIf4xEea_VPdGG2-szQ" x="-286" y="195" width="302" height="187"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDPgIf4xEea_VPdGG2-szQ" x="-270" y="195" width="302" height="222"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BDVm2_4xEea_VPdGG2-szQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BDVm3P4xEea_VPdGG2-szQ" showTitle="true"/>
@@ -1014,6 +1030,19 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0LaJf4yEea_VPdGG2-szQ" x="396" y="-69"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Gad5kE5sEeeicu4cm-7qRg" type="2097">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Gad5kk5sEeeicu4cm-7qRg" type="5157"/>
+      <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Gad5kU5sEeeicu4cm-7qRg" x="1259" y="130"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Gaqt405sEeeicu4cm-7qRg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Gaqt5E5sEeeicu4cm-7qRg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Gaqt5k5sEeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Gaqt5U5sEeeicu4cm-7qRg" x="200"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
@@ -1093,7 +1122,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0G9yZjBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nfDxoO_pEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0G9ybTBFEeam35bpdXJzEw" points="[0, 0, -38, -94]$[38, 94, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybjBFEeam35bpdXJzEw" id="(0.9233576642335767,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybjBFEeam35bpdXJzEw" id="(0.8686131386861314,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G9ybzBFEeam35bpdXJzEw" id="(0.10687022900763359,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G9ycDBFEeam35bpdXJzEw" type="4001" source="_0HHioDBFEeam35bpdXJzEw" target="_0G9x2DBFEeam35bpdXJzEw">
@@ -1123,7 +1152,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G90UzBFEeam35bpdXJzEw" type="4001" source="_0G9yhzBFEeam35bpdXJzEw" target="_0G91jDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G90VDBFEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0G90VTBFEeam35bpdXJzEw" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0G90VTBFEeam35bpdXJzEw" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0G90VjBFEeam35bpdXJzEw" type="6002">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-gFXcDI7EeamvfKYyWmELQ" source="PapyrusCSSForceValue">
@@ -1459,7 +1488,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_TzUegP4yEea_VPdGG2-szQ" type="4001" source="_0G9yhzBFEeam35bpdXJzEw" target="_BDPgIP4xEea_VPdGG2-szQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_TzUeg_4yEea_VPdGG2-szQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TzUehP4yEea_VPdGG2-szQ" x="5" y="-15"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TzUehP4yEea_VPdGG2-szQ" x="5" y="-6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_TzUehf4yEea_VPdGG2-szQ" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_TzUehv4yEea_VPdGG2-szQ" x="-3" y="13"/>
@@ -1480,7 +1509,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TzUegv4yEea_VPdGG2-szQ" points="[-13, -1, 206, 16]$[-219, -17, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2z3YP4yEea_VPdGG2-szQ" id="(0.0,0.9178082191780822)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2z3Yf4yEea_VPdGG2-szQ" id="(1.0,0.16042780748663102)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2z3Yf4yEea_VPdGG2-szQ" id="(1.0,0.13063063063063063)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_T0LaJ_4yEea_VPdGG2-szQ" type="StereotypeCommentLink" source="_TzUegP4yEea_VPdGG2-szQ" target="_T0LaI_4yEea_VPdGG2-szQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_T0LaKP4yEea_VPdGG2-szQ"/>
@@ -1491,6 +1520,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0LaKf4yEea_VPdGG2-szQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0LaKv4yEea_VPdGG2-szQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0LaK_4yEea_VPdGG2-szQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Gaqt505sEeeicu4cm-7qRg" type="StereotypeCommentLink" source="_Gad5kE5sEeeicu4cm-7qRg" target="_Gaqt405sEeeicu4cm-7qRg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Gaqt6E5sEeeicu4cm-7qRg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Gaqt7E5sEeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Gaqt6U5sEeeicu4cm-7qRg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Gaqt6k5sEeeicu4cm-7qRg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Gaqt605sEeeicu4cm-7qRg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
@@ -1518,7 +1557,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0QjBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0cDBGEeam35bpdXJzEw" x="-100" y="54" width="160" height="63"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0cDBGEeam35bpdXJzEw" x="-122" y="-3" width="160" height="63"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU0cTBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU0cjBGEeam35bpdXJzEw" type="5029"/>
@@ -1544,7 +1583,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0gzBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0sTBGEeam35bpdXJzEw" x="243" y="55" width="208" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU0sTBGEeam35bpdXJzEw" x="243" y="1" width="208" height="64"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU0sjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU0szBGEeam35bpdXJzEw" type="5029"/>
@@ -1596,7 +1635,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1FjBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1RDBGEeam35bpdXJzEw" x="493" y="282" width="155" height="63"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1RDBGEeam35bpdXJzEw" x="671" y="284" width="136" height="63"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU1WTBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1WjBGEeam35bpdXJzEw" type="5029"/>
@@ -1622,7 +1661,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1azBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="284" width="166" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1mTBGEeam35bpdXJzEw" x="270" y="284" width="143" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU16TBGEeam35bpdXJzEw" type="2004">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1iHO4BMvEee0L_IMWjydgQ" source="displayNameLabelIcon">
@@ -1651,7 +1690,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU1-zBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiConnectivity.uml#_WHPN4FJvEeWcs7ZjyujtOg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2ITBGEeam35bpdXJzEw" x="-137" y="-123" width="162" height="61"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2ITBGEeam35bpdXJzEw" x="-139" y="-110" width="162" height="61"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU2QjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2QzBGEeam35bpdXJzEw" type="5029"/>
@@ -1677,7 +1716,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2VDBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2gjBGEeam35bpdXJzEw" x="159" y="201" width="129" height="49"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2gjBGEeam35bpdXJzEw" x="159" y="171" width="129" height="49"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU2tzBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2uDBGEeam35bpdXJzEw" type="5029"/>
@@ -1703,7 +1742,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU2yTBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU29zBGEeam35bpdXJzEw" x="148" y="437" width="164" height="62"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU29zBGEeam35bpdXJzEw" x="148" y="425" width="164" height="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU3KDBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3KTBGEeam35bpdXJzEw" type="5029"/>
@@ -1729,13 +1768,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3OjBGEeam35bpdXJzEw" y="5"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="488" y="132" width="167" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="647" y="80" width="167" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU3yjBGEeam35bpdXJzEw" type="2011">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3yzBGEeam35bpdXJzEw" type="5037"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3zDBGEeam35bpdXJzEw" type="5159"/>
       <element xmi:type="uml:Constraint" href="TapiConnectivity.uml#_CIxSkLrhEeWYrqoqXLgguw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU33zBGEeam35bpdXJzEw" x="29" y="-34" height="46"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU33zBGEeam35bpdXJzEw" x="35" y="-74" height="46"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlelOjBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BlelOzBGEeam35bpdXJzEw" showTitle="true"/>
@@ -2164,7 +2203,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_e4LtY8hsEeaVlemTikmRHw" type="8510">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_e4LtZMhsEeaVlemTikmRHw" y="5"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_e4LtZchsEeaVlemTikmRHw" type="7017">
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e4LtZchsEeaVlemTikmRHw" visible="false" type="7017">
         <children xmi:type="notation:Shape" xmi:id="_J-wK8shtEeaVlemTikmRHw" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_l5X4NMhsEeaVlemTikmRHw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_J-wK88htEeaVlemTikmRHw"/>
@@ -2191,7 +2230,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4Ltc8hsEeaVlemTikmRHw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4LtYchsEeaVlemTikmRHw" x="13" y="-296" width="305" height="98"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4LtYchsEeaVlemTikmRHw" x="13" y="-246" width="313" height="68"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_e4X6o8hsEeaVlemTikmRHw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_e4X6pMhsEeaVlemTikmRHw" showTitle="true"/>
@@ -2245,7 +2284,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgsxMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="772" y="212" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="931" y="184" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6_LyABMjEee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_6_LyAhMjEee0L_IMWjydgQ" type="5029"/>
@@ -2271,7 +2310,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyExMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="631" y="-145" width="229" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="790" y="-142" width="229" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UI4IaxMmEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_UI4IbBMmEee0L_IMWjydgQ" showTitle="true"/>
@@ -2313,7 +2352,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwMxM2Eee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwIRM2Eee0L_IMWjydgQ" x="507" y="-291"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwIRM2Eee0L_IMWjydgQ" x="505" y="-248" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Gb8EAxM2Eee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Gb8EBBM2Eee0L_IMWjydgQ" showTitle="true"/>
@@ -2347,14 +2386,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_w3MJYkq9EeexQa2RWFy3AQ" x="973" y="91"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_g66-oEvpEee8IN5myVB_oQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_g66-oUvpEee8IN5myVB_oQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g66-o0vpEee8IN5myVB_oQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g66-okvpEee8IN5myVB_oQ" x="474" y="-45"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_Duxwk0wVEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DuxwlEwVEeewALXL7BvPYw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DuxwlkwVEeewALXL7BvPYw" name="BASE_ELEMENT">
@@ -2362,6 +2393,14 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DuxwlUwVEeewALXL7BvPYw" x="213" y="-396"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1-sAA0xwEeeBqfKxLidrUg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1-sABExwEeeBqfKxLidrUg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1-sABkxwEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1-sABUxwEeeBqfKxLidrUg" x="443" y="-99"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
@@ -2374,7 +2413,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1RzBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1SDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1STBGEeam35bpdXJzEw" x="7" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1STBGEeam35bpdXJzEw" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1SjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1SzBGEeam35bpdXJzEw" x="-49" y="62"/>
@@ -2390,16 +2429,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU1UjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -119, 1]$[0, 34, -119, 35]$[119, 34, 0, 35]$[119, -1, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1VzBGEeam35bpdXJzEw" id="(0.7575757575757576,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1WDBGEeam35bpdXJzEw" id="(0.13548387096774195,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -296, -1]$[0, 35, -296, 34]$[296, 35, 0, 34]$[296, 1, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1VzBGEeam35bpdXJzEw" id="(0.8601398601398601,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1WDBGEeam35bpdXJzEw" id="(0.1323529411764706,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU1wTBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1wjBGEeam35bpdXJzEw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1wzBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1xDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xTBGEeam35bpdXJzEw" x="16" y="3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xTBGEeam35bpdXJzEw" x="40" y="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1xjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1xzBGEeam35bpdXJzEw" y="-20"/>
@@ -2408,23 +2447,23 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yTBGEeam35bpdXJzEw" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1yjBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yzBGEeam35bpdXJzEw" x="18" y="-16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1yzBGEeam35bpdXJzEw" x="17" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1zDBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1zTBGEeam35bpdXJzEw" x="-13" y="-16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1zTBGEeam35bpdXJzEw" x="-9" y="21"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU1zjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU10jBGEeam35bpdXJzEw" points="[0, 0, -84, 79]$[84, -79, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU10zBGEeam35bpdXJzEw" id="(0.47096774193548385,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU11DBGEeam35bpdXJzEw" id="(0.46706586826347307,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU10zBGEeam35bpdXJzEw" id="(0.625,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU11DBGEeam35bpdXJzEw" id="(0.6526946107784432,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU11TBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU11jBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="-15" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12DBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-11" y="3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-31" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12jBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12zBGEeam35bpdXJzEw" y="-20"/>
@@ -2441,8 +2480,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU14jBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU15jBGEeam35bpdXJzEw" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.5240384615384616,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.4939759036144578,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.4230769230769231,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.42657342657342656,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2LjBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2LzBGEeam35bpdXJzEw" type="6001">
@@ -2465,9 +2504,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU2OzBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2PzBGEeam35bpdXJzEw" points="[0, 0, 186, -1]$[0, 83, 186, 82]$[-186, 83, 0, 82]$[-186, 1, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2PzBGEeam35bpdXJzEw" points="[0, 0, 370, 1]$[0, 74, 370, 75]$[-370, 74, 0, 75]$[-370, -1, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QDBGEeam35bpdXJzEw" id="(0.45806451612903226,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QTBGEeam35bpdXJzEw" id="(0.6515151515151515,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QTBGEeam35bpdXJzEw" id="(0.6506024096385542,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2jzBGEeam35bpdXJzEw" type="4001" source="_BlU1WTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2kDBGEeam35bpdXJzEw" type="6001">
@@ -2491,8 +2530,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU2nDBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2oDBGEeam35bpdXJzEw" points="[0, 0, 61, 0]$[0, 38, 61, 38]$[-61, 38, 0, 38]$[-61, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2oTBGEeam35bpdXJzEw" id="(0.422360248447205,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2ojBGEeam35bpdXJzEw" id="(0.055900621118012424,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2oTBGEeam35bpdXJzEw" id="(0.4755244755244755,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2ojBGEeam35bpdXJzEw" id="(0.04895104895104895,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2ozBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU2tzBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2pDBGEeam35bpdXJzEw" type="6001">
@@ -2515,9 +2554,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU2sDBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_MM4s4EHBEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2tDBGEeam35bpdXJzEw" points="[0, 0, 294, -130]$[0, 130, 294, 0]$[-294, 130, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2tTBGEeam35bpdXJzEw" id="(0.7290322580645161,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2tjBGEeam35bpdXJzEw" id="(1.0,0.6129032258064516)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2tDBGEeam35bpdXJzEw" points="[0, -1, 445, -106]$[0, 105, 445, 0]$[-445, 105, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2tTBGEeam35bpdXJzEw" id="(0.6348039215686274,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2tjBGEeam35bpdXJzEw" id="(1.0,0.43548387096774194)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2-DBGEeam35bpdXJzEw" type="4001" source="_BlU0MDBGEeam35bpdXJzEw" target="_BlU0sjBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2-TBGEeam35bpdXJzEw" type="6001">
@@ -2536,20 +2575,20 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3AjBGEeam35bpdXJzEw" x="7" y="-22"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3AzBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3BDBGEeam35bpdXJzEw" x="18" y="-24"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3BDBGEeam35bpdXJzEw" x="-12" y="-18"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3BTBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3DDBGEeam35bpdXJzEw" points="[4, 52, 0, -98]$[7, 130, 3, -20]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DTBGEeam35bpdXJzEw" id="(0.525,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DjBGEeam35bpdXJzEw" id="(0.45977011494252873,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DTBGEeam35bpdXJzEw" id="(0.625,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DjBGEeam35bpdXJzEw" id="(0.42528735632183906,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3DzBGEeam35bpdXJzEw" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3EDBGEeam35bpdXJzEw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ETBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3EjBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3EzBGEeam35bpdXJzEw" x="-1" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3EzBGEeam35bpdXJzEw" x="32" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3FDBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3FTBGEeam35bpdXJzEw" y="-20"/>
@@ -2565,9 +2604,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3HDBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3IDBGEeam35bpdXJzEw" points="[0, 0, 113, 60]$[0, -60, 113, 0]$[-113, -60, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.4550898203592814,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.265625)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3IDBGEeam35bpdXJzEw" points="[0, 0, 232, 50]$[0, -50, 232, 0]$[-232, -50, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.2155688622754491,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.453125)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3IzBGEeam35bpdXJzEw" type="4014" source="_BlU3yjBGEeam35bpdXJzEw" target="_ijqBwEwPEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3JDBGEeam35bpdXJzEw"/>
@@ -2581,7 +2620,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3azBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="17" y="-14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="38" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bzBGEeam35bpdXJzEw" y="-20"/>
@@ -2590,15 +2629,15 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3cTBGEeam35bpdXJzEw" x="7" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3cjBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3czBGEeam35bpdXJzEw" x="19" y="-19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3czBGEeam35bpdXJzEw" x="15" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3dDBGEeam35bpdXJzEw" type="6034">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3dTBGEeam35bpdXJzEw" x="-11" y="21"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3djBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3ejBGEeam35bpdXJzEw" points="[0, 0, 57, 62]$[-57, 0, 0, 62]$[-57, -62, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ezBGEeam35bpdXJzEw" id="(0.0,0.45161290322580644)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3ejBGEeam35bpdXJzEw" points="[0, 0, 57, 83]$[-57, 0, 0, 83]$[-57, -83, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ezBGEeam35bpdXJzEw" id="(0.0,0.3064516129032258)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3fDBGEeam35bpdXJzEw" id="(0.4186046511627907,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3fTBGEeam35bpdXJzEw" type="4001" source="_BlU0sjBGEeam35bpdXJzEw" target="_BlU2tzBGEeam35bpdXJzEw">
@@ -2622,8 +2661,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3ijBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3jjBGEeam35bpdXJzEw" points="[0, 0, -159, -109]$[0, 109, -159, 0]$[159, 109, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3jzBGEeam35bpdXJzEw" id="(0.4885057471264368,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3jjBGEeam35bpdXJzEw" points="[0, -1, -160, -98]$[0, 97, -160, 0]$[160, 97, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3jzBGEeam35bpdXJzEw" id="(0.4827586206896552,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3kDBGEeam35bpdXJzEw" id="(0.0,0.43548387096774194)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3nTBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU2QjBGEeam35bpdXJzEw">
@@ -2640,10 +2679,10 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3pTBGEeam35bpdXJzEw" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3pjBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3pzBGEeam35bpdXJzEw" x="14" y="-18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3pzBGEeam35bpdXJzEw" x="12" y="15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3qDBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3qTBGEeam35bpdXJzEw" x="-7" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3qTBGEeam35bpdXJzEw" x="-10" y="14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3qjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
@@ -2676,7 +2715,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3wzBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3xzBGEeam35bpdXJzEw" points="[82, 16, -195, -41]$[277, 57, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3yDBGEeam35bpdXJzEw" id="(1.0,0.38095238095238093)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3yDBGEeam35bpdXJzEw" id="(1.0,0.42857142857142855)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3yTBGEeam35bpdXJzEw" id="(0.0,0.359375)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlelPjBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU3tDBGEeam35bpdXJzEw" target="_BlelOjBGEeam35bpdXJzEw">
@@ -2911,10 +2950,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_l6tU8MhsEeaVlemTikmRHw" type="4001" source="_e4LtYMhsEeaVlemTikmRHw" target="_BlU0MDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU88hsEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9MhsEeaVlemTikmRHw" x="-73" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9MhsEeaVlemTikmRHw" x="-39" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU9chsEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9shsEeaVlemTikmRHw" x="-89" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU9shsEeaVlemTikmRHw" x="-57" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_l6tU98hsEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_l6tU-MhsEeaVlemTikmRHw" y="-20"/>
@@ -2931,8 +2970,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_l6tU8chsEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l6tU8shsEeaVlemTikmRHw" points="[0, 0, 50, -221]$[-50, 221, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8MhsEeaVlemTikmRHw" id="(0.04918032786885246,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8chsEeaVlemTikmRHw" id="(0.8,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8MhsEeaVlemTikmRHw" id="(0.04792332268370607,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l8O-8chsEeaVlemTikmRHw" id="(0.9375,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_l7R8t8hsEeaVlemTikmRHw" type="StereotypeCommentLink" source="_l6tU8MhsEeaVlemTikmRHw" target="_l7R8s8hsEeaVlemTikmRHw">
       <styles xmi:type="notation:FontStyle" xmi:id="_l7R8uMhsEeaVlemTikmRHw"/>
@@ -2946,10 +2985,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mwRD8MhsEeaVlemTikmRHw" type="4001" source="_e4LtYMhsEeaVlemTikmRHw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD88hsEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" x="-79" y="4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9MhsEeaVlemTikmRHw" x="-33" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD9chsEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9shsEeaVlemTikmRHw" x="-99" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD9shsEeaVlemTikmRHw" x="-52" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_mwRD98hsEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_mwRD-MhsEeaVlemTikmRHw" y="-20"/>
@@ -2966,8 +3005,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_mwRD8chsEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mwRD8shsEeaVlemTikmRHw" points="[130, 45, -33, -12]$[147, 55, -16, -2]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUMhsEeaVlemTikmRHw" id="(0.9475409836065574,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.28846153846153844,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUMhsEeaVlemTikmRHw" id="(0.9456869009584664,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.3173076923076923,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lu32EBMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_lu32ExMjEee0L_IMWjydgQ" type="6001">
@@ -2990,7 +3029,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lu32ERMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -145, -37]$[145, 0, 0, -37]$[145, 37, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -145, -61]$[145, 0, 0, -61]$[145, 61, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32HxMjEee0L_IMWjydgQ" id="(1.0,0.7413793103448276)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.26666666666666666,0.0)"/>
     </edges>
@@ -3015,16 +3054,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_piyMkRMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -176, 40]$[176, 0, 0, 40]$[176, -40, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -176, 70]$[176, 0, 0, 70]$[176, -70, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMnxMjEee0L_IMWjydgQ" id="(1.0,0.4603174603174603)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.49523809523809526,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AFw8BMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw8xMjEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="13" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="23"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9RMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="29" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="38" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9xMjEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw-BMjEee0L_IMWjydgQ" y="-20"/>
@@ -3042,14 +3081,14 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7AFw8hMjEee0L_IMWjydgQ" points="[0, 0, 508, 132]$[-508, -132, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFw_xMjEee0L_IMWjydgQ" id="(0.9401197604790419,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFxABMjEee0L_IMWjydgQ" id="(0.06550218340611354,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFxABMjEee0L_IMWjydgQ" id="(0.0611353711790393,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Fd7BwBMkEee0L_IMWjydgQ" type="4001" source="_luMgoBMjEee0L_IMWjydgQ" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BwxMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="34"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="60" y="-5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxRMkEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="45" y="-18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="74" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxxMkEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7ByBMkEee0L_IMWjydgQ" y="-20"/>
@@ -3090,7 +3129,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_tVhB4RMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 94, -226]$[0, 226, 94, 0]$[-94, 226, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 94, -171]$[0, 171, 94, 0]$[-94, 171, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.5152838427947598,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB8BMkEee0L_IMWjydgQ" id="(1.0,0.13793103448275862)"/>
     </edges>
@@ -3134,8 +3173,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_EYfToRM4Eee0L_IMWjydgQ"/>
       <element xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EYfTohM4Eee0L_IMWjydgQ" points="[305, 3, -189, -2]$[494, 5, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYfTpxM4Eee0L_IMWjydgQ" id="(1.0,0.47959183673469385)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYfTqBM4Eee0L_IMWjydgQ" id="(0.0,0.42)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYfTpxM4Eee0L_IMWjydgQ" id="(1.0,0.4411764705882353)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EYfTqBM4Eee0L_IMWjydgQ" id="(0.0,0.4383561643835616)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EYlaRxM4Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_EYfToBM4Eee0L_IMWjydgQ" target="_EYlaQxM4Eee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_EYlaSBM4Eee0L_IMWjydgQ"/>
@@ -3174,16 +3213,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJZ0q9EeexQa2RWFy3AQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJaEq9EeexQa2RWFy3AQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_g66-pEvpEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_BlU11TBGEeam35bpdXJzEw" target="_g66-oEvpEee8IN5myVB_oQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_g66-pUvpEee8IN5myVB_oQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g66-qUvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g66-pkvpEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g66-p0vpEee8IN5myVB_oQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g66-qEvpEee8IN5myVB_oQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7o5yQEvrEee8IN5myVB_oQ" type="4005" source="_BlU0MDBGEeam35bpdXJzEw" target="_BlU16TBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_7o5yQ0vrEee8IN5myVB_oQ" type="6012">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7o5yREvrEee8IN5myVB_oQ" y="40"/>
@@ -3194,15 +3223,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_7o5yQUvrEee8IN5myVB_oQ"/>
       <element xmi:type="uml:Realization" href="TapiConnectivity.uml#_7o4kIEvrEee8IN5myVB_oQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7o5yQkvrEee8IN5myVB_oQ" points="[0, 0, 37, 177]$[106, -116, 143, 61]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sEvrEee8IN5myVB_oQ" id="(0.41875,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sUvrEee8IN5myVB_oQ" id="(0.6419753086419753,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sEvrEee8IN5myVB_oQ" id="(0.5125,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7qV8sUvrEee8IN5myVB_oQ" id="(0.5864197530864198,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VZoF4EwOEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_VZoF40wOEeewALXL7BvPYw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5EwOEeewALXL7BvPYw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_VZoF5UwOEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-101" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-186" y="-98"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_VZoF50wOEeewALXL7BvPYw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6EwOEeewALXL7BvPYw" y="-20"/>
@@ -3218,16 +3247,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VZoF4UwOEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_U4H7UEwOEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -353, -128]$[0, 128, -353, 0]$[353, 128, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -512, -141]$[0, 141, -512, 0]$[512, 141, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbFecEwOEeewALXL7BvPYw" id="(0.8461538461538461,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbGFgEwOEeewALXL7BvPYw" id="(0.0,0.5932203389830508)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbGFgEwOEeewALXL7BvPYw" id="(0.0,0.3728813559322034)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ijqBwEwPEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_ijqBw0wPEeewALXL7BvPYw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxEwPEeewALXL7BvPYw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ijqBxUwPEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxkwPEeewALXL7BvPYw" x="-44" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxkwPEeewALXL7BvPYw" x="-44" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ijqBx0wPEeewALXL7BvPYw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqByEwPEeewALXL7BvPYw" y="-20"/>
@@ -3243,7 +3272,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ijqBwUwPEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ihpPkEwPEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ijqBwkwPEeewALXL7BvPYw" points="[0, 0, 88, 0]$[0, -91, 88, -91]$[-88, -91, 0, -91]$[-88, 0, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ijqBwkwPEeewALXL7BvPYw" points="[0, 0, 88, 0]$[0, -71, 88, -71]$[-88, -71, 0, -71]$[-88, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ilYgEEwPEeewALXL7BvPYw" id="(0.8365384615384616,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ilYgEUwPEeewALXL7BvPYw" id="(0.41346153846153844,0.0)"/>
     </edges>
@@ -3256,6 +3285,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DuxwmUwVEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DuxwmkwVEeewALXL7BvPYw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Duxwm0wVEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1-sAB0xwEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_BlU11TBGEeam35bpdXJzEw" target="_1-sAA0xwEeeBqfKxLidrUg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1-sACExwEeeBqfKxLidrUg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1-sADExwEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1-sACUxwEeeBqfKxLidrUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1-sACkxwEeeBqfKxLidrUg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1-sAC0xwEeeBqfKxLidrUg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -3822,7 +3861,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rSCMIer0EeaeHOJw3lCT8A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MBqV4OrzEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rR8Fcer0EeaeHOJw3lCT8A" x="5" y="228" height="161"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rR8Fcer0EeaeHOJw3lCT8A" x="5" y="219" height="161"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rSOZa-r0EeaeHOJw3lCT8A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rSOZbOr0EeaeHOJw3lCT8A" showTitle="true"/>
@@ -4046,7 +4085,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W43igesTEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W4xb0esTEealN7CdLT_GPw" x="174" y="-273" width="312" height="208"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W4xb0esTEealN7CdLT_GPw" x="174" y="-231" width="312" height="189"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W5Dvy-sTEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_W5DvzOsTEealN7CdLT_GPw" showTitle="true"/>
@@ -4055,14 +4094,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5DvzesTEealN7CdLT_GPw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Qcgtk-sUEealN7CdLT_GPw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QcgtlOsUEealN7CdLT_GPw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcgtlusUEealN7CdLT_GPw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_QZXS8OsUEealN7CdLT_GPw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QcgtlesUEealN7CdLT_GPw" x="357" y="-208"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__NH3I-sYEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__NH3JOsYEealN7CdLT_GPw" showTitle="true"/>
@@ -4210,13 +4241,21 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QYR49fLXEeaAIfPpmDwI5Q" x="695" y="-111"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_g67ls0vpEee8IN5myVB_oQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_g67ltEvpEee8IN5myVB_oQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g67ltkvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_1-tOI0xwEeeBqfKxLidrUg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1-tOJExwEeeBqfKxLidrUg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1-tOJkxwEeeBqfKxLidrUg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g67ltUvpEee8IN5myVB_oQ" x="943" y="-148"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1-tOJUxwEeeBqfKxLidrUg" x="943" y="-148"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_t3jSgE5tEeeicu4cm-7qRg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_t3jSgU5tEeeicu4cm-7qRg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t3jSg05tEeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_QZXS8OsUEealN7CdLT_GPw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t3jSgk5tEeeicu4cm-7qRg" x="374" y="-331"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_l51YUer0EeaeHOJw3lCT8A" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_l51YUur0EeaeHOJw3lCT8A"/>
@@ -4276,10 +4315,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Qbpx8OsUEealN7CdLT_GPw" type="4001" source="_W4xb0OsTEealN7CdLT_GPw" target="_s9Rl4Or0EeaeHOJw3lCT8A">
       <children xmi:type="notation:DecorationNode" xmi:id="_Qbpx8-sUEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9OsUEealN7CdLT_GPw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9OsUEealN7CdLT_GPw" x="-9" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Qbpx9esUEealN7CdLT_GPw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9usUEealN7CdLT_GPw" x="-3" y="-32"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx9usUEealN7CdLT_GPw" x="-25"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Qbpx9-sUEealN7CdLT_GPw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Qbpx-OsUEealN7CdLT_GPw" y="-20"/>
@@ -4298,16 +4337,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qbpx8usUEealN7CdLT_GPw" points="[0, 0, 77, -124]$[-77, 124, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qdp9EOsUEealN7CdLT_GPw" id="(0.125,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qdp9EesUEealN7CdLT_GPw" id="(0.6690647482014388,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Qcgtl-sUEealN7CdLT_GPw" type="StereotypeCommentLink" source="_Qbpx8OsUEealN7CdLT_GPw" target="_Qcgtk-sUEealN7CdLT_GPw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QcgtmOsUEealN7CdLT_GPw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QcgtnOsUEealN7CdLT_GPw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_QZXS8OsUEealN7CdLT_GPw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QcgtmesUEealN7CdLT_GPw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QcgtmusUEealN7CdLT_GPw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qcgtm-sUEealN7CdLT_GPw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__MdIwOsYEealN7CdLT_GPw" type="4001" source="_s9Rl4Or0EeaeHOJw3lCT8A" target="_ryFlIOr0EeaeHOJw3lCT8A">
       <children xmi:type="notation:DecorationNode" xmi:id="__MdIw-sYEealN7CdLT_GPw" type="6001">
@@ -4330,9 +4359,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__MdIwesYEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#__LyaYOsYEealN7CdLT_GPw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MdIwusYEealN7CdLT_GPw" points="[0, 0, -197, -64]$[0, 64, -197, 0]$[197, 64, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MdIwusYEealN7CdLT_GPw" points="[0, 0, -197, -45]$[0, 45, -197, 0]$[197, 45, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywOsYEealN7CdLT_GPw" id="(0.5683453237410072,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywesYEealN7CdLT_GPw" id="(0.0,0.2804878048780488)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywesYEealN7CdLT_GPw" id="(0.0,0.16463414634146342)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__NH3J-sYEealN7CdLT_GPw" type="StereotypeCommentLink" source="__MdIwOsYEealN7CdLT_GPw" target="__NH3I-sYEealN7CdLT_GPw">
       <styles xmi:type="notation:FontStyle" xmi:id="__NH3KOsYEealN7CdLT_GPw"/>
@@ -4346,7 +4375,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_CqKT0OsbEealN7CdLT_GPw" type="4001" source="_s9Rl4Or0EeaeHOJw3lCT8A" target="_rR8FcOr0EeaeHOJw3lCT8A">
       <children xmi:type="notation:DecorationNode" xmi:id="_CqKT0-sbEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_CqKT1OsbEealN7CdLT_GPw" x="10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CqKT1OsbEealN7CdLT_GPw"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_CqKT1esbEealN7CdLT_GPw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_CqKT1usbEealN7CdLT_GPw" x="-8" y="2"/>
@@ -4381,10 +4410,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lREA8OscEealN7CdLT_GPw" type="4001" source="_QjgYUOsSEealN7CdLT_GPw" target="_W4xb0OsTEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA8-scEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9OscEealN7CdLT_GPw" x="42" y="6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9OscEealN7CdLT_GPw" x="28" y="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA9escEealN7CdLT_GPw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9uscEealN7CdLT_GPw" x="53" y="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA9uscEealN7CdLT_GPw" x="41" y="14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lREA9-scEealN7CdLT_GPw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_lREA-OscEealN7CdLT_GPw" y="-20"/>
@@ -4400,7 +4429,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lREA8escEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 64, 90]$[-64, 0, 0, 90]$[-64, -90, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 64, 67]$[-64, 0, 0, 67]$[-64, -67, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREA_-scEealN7CdLT_GPw" id="(0.0,0.2872340425531915)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREBAOscEealN7CdLT_GPw" id="(0.6442307692307693,1.0)"/>
     </edges>
@@ -4426,7 +4455,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_OoQWIOseEealN7CdLT_GPw" type="4001" source="__j6psOscEealN7CdLT_GPw" target="_W4xb0OsTEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_OoQWI-seEealN7CdLT_GPw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OoQWJOseEealN7CdLT_GPw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OoQWJOseEealN7CdLT_GPw" x="81" y="-11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OoQWJeseEealN7CdLT_GPw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_OoQWJuseEealN7CdLT_GPw" x="78" y="9"/>
@@ -4445,9 +4474,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_OoQWIeseEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OoQWIuseEealN7CdLT_GPw" points="[0, 0, 379, 182]$[0, -182, 379, 0]$[-379, -182, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OoQWIuseEealN7CdLT_GPw" points="[0, 0, 379, 144]$[0, -144, 379, 0]$[-379, -144, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWL-seEealN7CdLT_GPw" id="(0.45353159851301117,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWMOseEealN7CdLT_GPw" id="(1.0,0.2088607594936709)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWMOseEealN7CdLT_GPw" id="(1.0,0.20634920634920634)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hUADkOseEealN7CdLT_GPw" type="4001" source="_ryFlIOr0EeaeHOJw3lCT8A" target="__j6psOscEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_hUADk-seEealN7CdLT_GPw" type="6001">
@@ -4580,15 +4609,25 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYR4-vLXEeaAIfPpmDwI5Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QYR4-_LXEeaAIfPpmDwI5Q"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_g67lt0vpEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_OoQWIOseEealN7CdLT_GPw" target="_g67ls0vpEee8IN5myVB_oQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_g67luEvpEee8IN5myVB_oQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g67lvEvpEee8IN5myVB_oQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_1-tOJ0xwEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_OoQWIOseEealN7CdLT_GPw" target="_1-tOI0xwEeeBqfKxLidrUg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1-tOKExwEeeBqfKxLidrUg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1-tOLExwEeeBqfKxLidrUg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g67luUvpEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g67lukvpEee8IN5myVB_oQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g67lu0vpEee8IN5myVB_oQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1-tOKUxwEeeBqfKxLidrUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1-tOKkxwEeeBqfKxLidrUg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1-tOK0xwEeeBqfKxLidrUg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_t3jShE5tEeeicu4cm-7qRg" type="StereotypeCommentLink" source="_Qbpx8OsUEealN7CdLT_GPw" target="_t3jSgE5tEeeicu4cm-7qRg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_t3jShU5tEeeicu4cm-7qRg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t3jSiU5tEeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_QZXS8OsUEealN7CdLT_GPw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_t3jShk5tEeeicu4cm-7qRg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t3jSh05tEeeicu4cm-7qRg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t3jSiE5tEeeicu4cm-7qRg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_W_wkgPItEea79czpMf3AVQ" type="PapyrusUMLClassDiagram" name="DataTypes" measurementUnit="Pixel">

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -81,10 +81,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_MDItIxMiEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_MDItJBMiEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_MDItJRMiEee0L_IMWjydgQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G9zbDBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G9zbTBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_0G9zbjBFEeam35bpdXJzEw"/>
@@ -280,10 +276,6 @@
         <children xmi:type="notation:Shape" xmi:id="_S8ZrAhMiEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_S8ZrAxMiEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_S8ZrBBMiEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_S8ZrBRMiEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0HHjbDBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0HHjbTBFEeam35bpdXJzEw"/>
@@ -3264,10 +3256,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQCcFtEeaALJQAf08uAg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQCsFtEeaALJQAf08uAg" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_6a7R8KU7EeWkWNPM1BHzGA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQC8FtEeaALJQAf08uAg"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="__HmQDMFtEeaALJQAf08uAg" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQDcFtEeaALJQAf08uAg"/>
@@ -3283,10 +3271,6 @@
         <children xmi:type="notation:Shape" xmi:id="_RCqFshMjEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_RCqFsxMjEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_RCqFtBMjEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RCqFtRMjEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LsrjdjBGEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LsrjdzBGEeam35bpdXJzEw"/>
@@ -3805,10 +3789,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ZbNksxMmEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZbNktBMmEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZbNktRMmEee0L_IMWjydgQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_W43idOsTEealN7CdLT_GPw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_W43idesTEealN7CdLT_GPw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_W43idusTEealN7CdLT_GPw"/>
@@ -3903,10 +3883,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_dZjpmRMmEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_dZjpmhMmEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_6a7R8KU7EeWkWNPM1BHzGA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_dZjpmxMmEee0L_IMWjydgQ"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_dZjpnBMmEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_dZjpnRMmEee0L_IMWjydgQ"/>
@@ -3922,10 +3898,6 @@
         <children xmi:type="notation:Shape" xmi:id="_dZjpohMmEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_dZjpoxMmEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_dZjppBMmEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_dZjppRMmEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__j6ptuscEealN7CdLT_GPw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__j6pt-scEealN7CdLT_GPw"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -231,6 +231,18 @@
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Realization" xmi:id="_7o4kIEvrEee8IN5myVB_oQ" client="_kuDzQEHaEeWqPKyD1j6LMg" supplier="_WHPN4FJvEeWcs7ZjyujtOg"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nJo58EwFEeewALXL7BvPYw" name="CSEPHasCapacityPac" memberEnd="_nJqIEUwFEeewALXL7BvPYw _nJqvIUwFEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nJphAEwFEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nJqIEEwFEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nJqvIUwFEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_nJo58EwFEeewALXL7BvPYw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_3_TE8EwEEeewALXL7BvPYw" name="SEPIncludesLP" memberEnd="_3_TsAkwEEeewALXL7BvPYw _3_U6IEwEEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3_TsAEwEEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3_TsAUwEEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_3_U6IEwEEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_3_TE8EwEEeewALXL7BvPYw"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
@@ -494,16 +506,16 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <generalization xmi:type="uml:Generalization" xmi:id="_Wx2QAN8rEeWT9tG0gGLRFw">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_TsAkwEEeewALXL7BvPYw" name="_layerProtocol" aggregation="composite" association="_3_TE8EwEEeewALXL7BvPYw">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AzVGYEwFEeewALXL7BvPYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AzW7kEwFEeewALXL7BvPYw" value="*"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceInterfacePoint" isReadOnly="true" association="_YyfoEGkJEeWZEqTYAF8eqA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTJ2h5EeWZEqTYAF8eqA" name="role" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTKGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTJ2h5EeWZEqTYAF8eqA">
-            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
-          </ownedComment>
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MIWTKWh5EeWZEqTYAF8eqA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MIWTKmh5EeWZEqTYAF8eqA" value="1"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nJqIEUwFEeewALXL7BvPYw" name="_capacity" aggregation="composite" association="_nJo58EwFEeewALXL7BvPYw">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTK2h5EeWZEqTYAF8eqA" name="direction" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTLGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTK2h5EeWZEqTYAF8eqA">
@@ -513,10 +525,13 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MIWTLWh5EeWZEqTYAF8eqA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MIWTLmh5EeWZEqTYAF8eqA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GU9nEN6MEeWd9KDn6x5Skg" name="layerProtocolName" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GU9nEd6MEeWd9KDn6x5Skg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GU9nEt6MEeWd9KDn6x5Skg" value="1"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTJ2h5EeWZEqTYAF8eqA" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTKGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTJ2h5EeWZEqTYAF8eqA">
+            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MIWTKWh5EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MIWTKmh5EeWZEqTYAF8eqA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route" isLeaf="true">
@@ -831,7 +846,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_hv9NttnYEeWIOYiRCk5bbQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_V2I0IdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_V2I0INnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_caIFkdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_caIFkNnlEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_GU9nE96MEeWd9KDn6x5Skg" base_StructuralFeature="_GU9nEN6MEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpO_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxo-_pEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpu_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxpe_pEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_WFu44-_qEeWLlrwIF3w0vA" base_StructuralFeature="_WFu44u_qEeWLlrwIF3w0vA"/>
@@ -990,7 +1004,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPFxhrEeewCs0lkpWskw" base_Property="_YyoyAmkJEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGBhrEeewCs0lkpWskw" base_Property="_MIWTJ2h5EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGRhrEeewCs0lkpWskw" base_Property="_MIWTK2h5EeWZEqTYAF8eqA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGhhrEeewCs0lkpWskw" base_Property="_GU9nEN6MEeWd9KDn6x5Skg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPGxhrEeewCs0lkpWskw" base_Property="_p40DAEUeEeWEwNCluy4jrw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPHBhrEeewCs0lkpWskw" base_Property="_l5X4NMhsEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPHRhrEeewCs0lkpWskw" base_Property="_mvBt1MhsEeaVlemTikmRHw"/>
@@ -1016,11 +1029,15 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMRhrEeewCs0lkpWskw" base_Property="_Ca3vhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMhhrEeewCs0lkpWskw" base_Property="_MjEHhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMxhrEeewCs0lkpWskw" base_Property="_3_SWwL11EeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_LuawxiBcEeeWCKlkirNtnw">
-    <base_Property xmi:type="uml:Property" href="TapiOam.uml#_LuawxSBcEeeWCKlkirNtnw"/>
-  </OpenInterfaceModel_Profile:OpenInterfaceModelAttribute>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Lug3YCBcEeeWCKlkirNtnw">
-    <base_StructuralFeature xmi:type="uml:Property" href="TapiOam.uml#_LuawxSBcEeeWCKlkirNtnw"/>
-  </OpenModel_Profile:OpenModelAttribute>
   <OpenModel_Profile:StrictComposite xmi:id="_g6zC0EvpEee8IN5myVB_oQ" base_Association="_ijcPoGkHEeWZEqTYAF8eqA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3_TsA0wEEeewALXL7BvPYw" base_Property="_3_TsAkwEEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3_UTEEwEEeewALXL7BvPYw" base_StructuralFeature="_3_TsAkwEEeewALXL7BvPYw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_FdQe4EwFEeewALXL7BvPYw" base_Association="_3_TE8EwEEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqIEkwFEeewALXL7BvPYw" base_Property="_nJqIEUwFEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nJqvIEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqIEUwFEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3_U6IUwEEeewALXL7BvPYw" base_Property="_3_U6IEwEEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_49ZE4EwEEeewALXL7BvPYw" base_StructuralFeature="_3_U6IEwEEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqvIkwFEeewALXL7BvPYw" base_Property="_nJqvIUwFEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nJrWMEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqvIUwFEeewALXL7BvPYw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_uUXl0EwGEeewALXL7BvPYw" base_Association="_nJo58EwFEeewALXL7BvPYw"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -50,11 +50,11 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_nfDxpe_pEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_niJd8GkKEeWZEqTYAF8eqA" name="ConnectionIsContainedByNode" memberEnd="_niJd82kKEeWZEqTYAF8eqA _niJd9WkKEeWZEqTYAF8eqA">
+      <packagedElement xmi:type="uml:Association" xmi:id="_niJd8GkKEeWZEqTYAF8eqA" name="ConnectionIsBoundedByNode" memberEnd="_niJd82kKEeWZEqTYAF8eqA _niJd9WkKEeWZEqTYAF8eqA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_niJd8WkKEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_niJd8mkKEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_niJd82kKEeWZEqTYAF8eqA" name="_conectionRefList" type="_IZ3vcEHbEeWqPKyD1j6LMg" aggregation="shared" association="_niJd8GkKEeWZEqTYAF8eqA">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_niJd82kKEeWZEqTYAF8eqA" name="_conectionRefList" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_niJd8GkKEeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0hPKkGkKEeWZEqTYAF8eqA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0hPKkWkKEeWZEqTYAF8eqA" value="*"/>
         </ownedEnd>
@@ -75,7 +75,7 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B3JysEHCEeWqPKyD1j6LMg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B3KZwEHCEeWqPKyD1j6LMg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_B3KZwUHCEeWqPKyD1j6LMg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" aggregation="shared" association="_B3JLoEHCEeWqPKyD1j6LMg">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_B3KZwUHCEeWqPKyD1j6LMg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_B3JLoEHCEeWqPKyD1j6LMg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_T8JpMEHCEeWqPKyD1j6LMg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_T8LeYEHCEeWqPKyD1j6LMg" value="*"/>
         </ownedEnd>
@@ -243,17 +243,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_3_U6IEwEEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_3_TE8EwEEeewALXL7BvPYw"/>
       </packagedElement>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
-      <packagedElement xmi:type="uml:Association" xmi:id="_U4H7UEwOEeewALXL7BvPYw" name="ConnectionSupportsLink" memberEnd="_U4LlsUwOEeewALXL7BvPYw _U4Mz0EwOEeewALXL7BvPYw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_U4K-oEwOEeewALXL7BvPYw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_U4LlsEwOEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_U4Mz0EwOEeewALXL7BvPYw" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_U4H7UEwOEeewALXL7BvPYw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mUsf4EwOEeewALXL7BvPYw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mUu8IEwOEeewALXL7BvPYw" value="1"/>
-        </ownedEnd>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_ihpPkEwPEeewALXL7BvPYw" name="ConnectionHasLowerLevelConnections" memberEnd="_ihp2oUwPEeewALXL7BvPYw _ihqdsUwPEeewALXL7BvPYw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ihpPkUwPEeewALXL7BvPYw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ihp2oEwPEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
@@ -263,7 +252,29 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6fX0AEwPEeewALXL7BvPYw" value="1"/>
         </ownedEnd>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_U4H7UEwOEeewALXL7BvPYw" name="ConnectionSupportsLink" memberEnd="_U4LlsUwOEeewALXL7BvPYw _U4Mz0EwOEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_U4K-oEwOEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_U4LlsEwOEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_U4Mz0EwOEeewALXL7BvPYw" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_U4H7UEwOEeewALXL7BvPYw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mUsf4EwOEeewALXL7BvPYw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mUu8IEwOEeewALXL7BvPYw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_5TB-sE5qEeeicu4cm-7qRg" name="ConstrHasExcludeNode" memberEnd="_5TDM0U5qEeeicu4cm-7qRg _5TDz4k5qEeeicu4cm-7qRg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5TClwE5qEeeicu4cm-7qRg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5TDM0E5qEeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_5TDz4k5qEeeicu4cm-7qRg" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_5TB-sE5qEeeicu4cm-7qRg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_tATBwE5qEeeicu4cm-7qRg" name="ConstrHasIncludeNode" memberEnd="_tAVeAE5qEeeicu4cm-7qRg _tAkHgE5qEeeicu4cm-7qRg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tAUP4E5qEeeicu4cm-7qRg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tAU28E5qEeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_tAkHgE5qEeeicu4cm-7qRg" name="topologyconstraint" type="_-fei4P4wEea_VPdGG2-szQ" association="_tATBwE5qEeeicu4cm-7qRg"/>
+      </packagedElement>
     </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -742,6 +753,9 @@ All administrative controls of any aspect of protection are rejected.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e8ofMsF_EeaALJQAf08uAg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Ca3vhP4zEea_VPdGG2-szQ" name="_includeLink" isReadOnly="true" association="_Ca3vgP4zEea_VPdGG2-szQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xdX0kE5rEeeicu4cm-7qRg" annotatedElement="_Ca3vhP4zEea_VPdGG2-szQ">
+            <body>This is a loose constraint - that is it is unordered and could be a partial list </body>
+          </ownedComment>
           <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_I_odAP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_I_prIP4zEea_VPdGG2-szQ" value="*"/>
@@ -750,6 +764,19 @@ All administrative controls of any aspect of protection are rejected.</body>
           <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OG3ckP4zEea_VPdGG2-szQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OG3ckv4zEea_VPdGG2-szQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tAVeAE5qEeeicu4cm-7qRg" name="_includeNode" isReadOnly="true" association="_tATBwE5qEeeicu4cm-7qRg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zUMzUE5rEeeicu4cm-7qRg" annotatedElement="_tAVeAE5qEeeicu4cm-7qRg">
+            <body>This is a loose constraint - that is it is unordered and could be a partial list</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OubwE5qEeeicu4cm-7qRg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OxfEE5qEeeicu4cm-7qRg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5TDM0U5qEeeicu4cm-7qRg" name="_exludeNode" isReadOnly="true" association="_5TB-sE5qEeeicu4cm-7qRg">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-ZosIE5qEeeicu4cm-7qRg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-ZqhUE5qEeeicu4cm-7qRg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="preferredTransportLayer" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_f3CoEMF2EeaALJQAf08uAg" annotatedElement="_3_SWwL11EeWdore3Cxez9g">
@@ -1066,7 +1093,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMRhrEeewCs0lkpWskw" base_Property="_Ca3vhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMhhrEeewCs0lkpWskw" base_Property="_MjEHhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMxhrEeewCs0lkpWskw" base_Property="_3_SWwL11EeWdore3Cxez9g"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_g6zC0EvpEee8IN5myVB_oQ" base_Association="_ijcPoGkHEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3_TsA0wEEeewALXL7BvPYw" base_Property="_3_TsAkwEEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3_UTEEwEEeewALXL7BvPYw" base_StructuralFeature="_3_TsAkwEEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_FdQe4EwFEeewALXL7BvPYw" base_Association="_3_TE8EwEEeewALXL7BvPYw"/>
@@ -1087,4 +1113,14 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_VXlegEwOEeewALXL7BvPYw" base_StructuralFeature="_U4Mz0EwOEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_COm-UEwVEeewALXL7BvPYw" base_Association="_l5X4MMhsEeaVlemTikmRHw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_Durp8EwVEeewALXL7BvPYw" base_Association="_mvBt0MhsEeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_1-krQExwEeeBqfKxLidrUg" base_Association="_ijcPoGkHEeWZEqTYAF8eqA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAVeAU5qEeeicu4cm-7qRg" base_Property="_tAVeAE5qEeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tAWFEE5qEeeicu4cm-7qRg" base_StructuralFeature="_tAVeAE5qEeeicu4cm-7qRg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5TDz4E5qEeeicu4cm-7qRg" base_Property="_5TDM0U5qEeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5TDz4U5qEeeicu4cm-7qRg" base_StructuralFeature="_5TDM0U5qEeeicu4cm-7qRg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAkHgU5qEeeicu4cm-7qRg" base_Property="_tAkHgE5qEeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tS-GIE5qEeeicu4cm-7qRg" base_StructuralFeature="_tAkHgE5qEeeicu4cm-7qRg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5TEa8E5qEeeicu4cm-7qRg" base_Property="_5TDz4k5qEeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5TEa8U5qEeeicu4cm-7qRg" base_StructuralFeature="_5TDz4k5qEeeicu4cm-7qRg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_t3b9wE5tEeeicu4cm-7qRg" base_Association="_QZXS8OsUEealN7CdLT_GPw"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -107,7 +107,7 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ja2G0WkJEeWZEqTYAF8eqA" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_p4w_sEUeEeWEwNCluy4jrw" name="RouteIsDescribedByLowerConnections" memberEnd="_p4y04EUeEeWEwNCluy4jrw _p40DAEUeEeWEwNCluy4jrw">
+      <packagedElement xmi:type="uml:Association" xmi:id="_p4w_sEUeEeWEwNCluy4jrw" name="RouteIsDescribedByCEPs" memberEnd="_p4y04EUeEeWEwNCluy4jrw _p40DAEUeEeWEwNCluy4jrw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p4yN0EUeEeWEwNCluy4jrw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p4yN0UUeEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
         </eAnnotations>
@@ -244,7 +244,26 @@
         <ownedEnd xmi:type="uml:Property" xmi:id="_3_U6IEwEEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_3_TE8EwEEeewALXL7BvPYw"/>
       </packagedElement>
     </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_U4H7UEwOEeewALXL7BvPYw" name="ConnectionSupportsLink" memberEnd="_U4LlsUwOEeewALXL7BvPYw _U4Mz0EwOEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_U4K-oEwOEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_U4LlsEwOEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_U4Mz0EwOEeewALXL7BvPYw" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_U4H7UEwOEeewALXL7BvPYw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mUsf4EwOEeewALXL7BvPYw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mUu8IEwOEeewALXL7BvPYw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ihpPkEwPEeewALXL7BvPYw" name="ConnectionHasLowerLevelConnections" memberEnd="_ihp2oUwPEeewALXL7BvPYw _ihqdsUwPEeewALXL7BvPYw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ihpPkUwPEeewALXL7BvPYw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ihp2oEwPEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ihqdsUwPEeewALXL7BvPYw" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ihpPkEwPEeewALXL7BvPYw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6fVXwEwPEeewALXL7BvPYw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6fX0AEwPEeewALXL7BvPYw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -344,14 +363,32 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FLa7AMFrEeaALJQAf08uAg" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FLa7AsFrEeaALJQAf08uAg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" isReadOnly="true" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_obsPoEUcEeWEwNCluy4jrw" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ihp2oUwPEeewALXL7BvPYw" name="_lowerConnection" type="_IZ3vcEHbEeWqPKyD1j6LMg" aggregation="shared" association="_ihpPkEwPEeewALXL7BvPYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lf8XQEwQEeewALXL7BvPYw" annotatedElement="_ihp2oUwPEeewALXL7BvPYw">
+            <body>An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).&#xD;
+Aggregation is used as for the Node/Topology  to allow changes in hierarchy. &#xD;
+Connection aggregation reflects Node/Topology aggregation. &#xD;
+The FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5kzpMEwPEeewALXL7BvPYw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5k1eYEwPEeewALXL7BvPYw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_niJd9WkKEeWZEqTYAF8eqA" name="_node" isReadOnly="true" association="_niJd8GkKEeWZEqTYAF8eqA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_U4LlsUwOEeewALXL7BvPYw" name="_supportedLink" association="_U4H7UEwOEeewALXL7BvPYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_M35f8EwPEeewALXL7BvPYw" annotatedElement="_U4LlsUwOEeewALXL7BvPYw">
+            <body>An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer.</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lVIgUEwOEeewALXL7BvPYw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lVLjoEwOEeewALXL7BvPYw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_niJd9WkKEeWZEqTYAF8eqA" name="_containerNode" isReadOnly="true" association="_niJd8GkKEeWZEqTYAF8eqA">
           <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Aoh_oN5TEeWHTPgMsm3CIw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Aokb4N5TEeWHTPgMsm3CIw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" isReadOnly="true" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_obsPoEUcEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_QZdZkusUEealN7CdLT_GPw" name="_switchControl" type="_nuZ_MOryEeaeHOJw3lCT8A" isReadOnly="true" aggregation="composite" association="_QZXS8OsUEealN7CdLT_GPw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_b1f_EOsUEealN7CdLT_GPw"/>
@@ -543,7 +580,7 @@ Note that depending on the service supported by an FC, an the FC can have multip
         <generalization xmi:type="uml:Generalization" xmi:id="_HOnysN8rEeWT9tG0gGLRFw">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_p40DAEUeEeWEwNCluy4jrw" name="_lowerConnection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="shared" association="_p4w_sEUeEeWEwNCluy4jrw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p40DAEUeEeWEwNCluy4jrw" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" aggregation="shared" association="_p4w_sEUeEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tAZCgEUfEeWEwNCluy4jrw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tAd7AEUfEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
@@ -725,8 +762,8 @@ All administrative controls of any aspect of protection are rejected.</body>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="__4jwIC5zEea0_JngOlSKcA" name="Rules">
-      <ownedRule xmi:type="uml:Constraint" xmi:id="_CIxSkLrhEeWYrqoqXLgguw" name="XOR: ConnectionContainment" constrainedElement="_4ErWsEUcEeWEwNCluy4jrw _p4w_sEUeEeWEwNCluy4jrw">
-        <specification xmi:type="uml:LiteralString" xmi:id="_nOJNQLriEeWYrqoqXLgguw" name="XOR: ConnectionContainment" value="ServiceComponent ⊕ RouteComponent"/>
+      <ownedRule xmi:type="uml:Constraint" xmi:id="_CIxSkLrhEeWYrqoqXLgguw" name="XOR: ConnectionContainment" constrainedElement="_4ErWsEUcEeWEwNCluy4jrw _ihpPkEwPEeewALXL7BvPYw">
+        <specification xmi:type="uml:LiteralString" xmi:id="_nOJNQLriEeWYrqoqXLgguw" name="XOR: ConnectionContainment" value="ServiceComponent ⊕ ConnectionComponent"/>
       </ownedRule>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_W1hQkC5zEea0_JngOlSKcA" name="TypeDefinitions">
@@ -1040,4 +1077,14 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqvIkwFEeewALXL7BvPYw" base_Property="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nJrWMEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_uUXl0EwGEeewALXL7BvPYw" base_Association="_nJo58EwFEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_U4LlskwOEeewALXL7BvPYw" base_Property="_U4LlsUwOEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_U4MMwEwOEeewALXL7BvPYw" base_StructuralFeature="_U4LlsUwOEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ihp2okwPEeewALXL7BvPYw" base_Property="_ihp2oUwPEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ihqdsEwPEeewALXL7BvPYw" base_StructuralFeature="_ihp2oUwPEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ihqdskwPEeewALXL7BvPYw" base_Property="_ihqdsUwPEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ihqds0wPEeewALXL7BvPYw" base_StructuralFeature="_ihqdsUwPEeewALXL7BvPYw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_U4Mz0UwOEeewALXL7BvPYw" base_Property="_U4Mz0EwOEeewALXL7BvPYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VXlegEwOEeewALXL7BvPYw" base_StructuralFeature="_U4Mz0EwOEeewALXL7BvPYw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_COm-UEwVEeewALXL7BvPYw" base_Association="_l5X4MMhsEeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Durp8EwVEeewALXL7BvPYw" base_Association="_mvBt0MhsEeaVlemTikmRHw"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -50,7 +50,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_nfDxpe_pEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_KpFD8L2YEeWdore3Cxez9g" name="CreatesUpdatesDeletesConnectivityService" client="_TQ0awC5zEea0_JngOlSKcA" supplier="_kuDzQEHaEeWqPKyD1j6LMg"/>
       <packagedElement xmi:type="uml:Association" xmi:id="_niJd8GkKEeWZEqTYAF8eqA" name="ConnectionIsContainedByNode" memberEnd="_niJd82kKEeWZEqTYAF8eqA _niJd9WkKEeWZEqTYAF8eqA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_niJd8WkKEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_niJd8mkKEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
@@ -207,7 +206,6 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e_SZIPIoEea79czpMf3AVQ" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_3AqFEPlHEeaQEoLj_Ia_cg" name="OperatesOn" client="_WHPN4FJvEeWcs7ZjyujtOg" supplier="_e4FmwMhsEeaVlemTikmRHw"/>
       <packagedElement xmi:type="uml:Association" xmi:id="_Tx9zoP4yEea_VPdGG2-szQ" name="ConnServiceHasTopologyConstraints" memberEnd="_TyD6Qv4yEea_VPdGG2-szQ _TyD6Rf4yEea_VPdGG2-szQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TyD6QP4yEea_VPdGG2-szQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TyD6Qf4yEea_VPdGG2-szQ" key="nature" value="UML_Nature"/>
@@ -232,6 +230,7 @@
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_7o4kIEvrEee8IN5myVB_oQ" client="_kuDzQEHaEeWqPKyD1j6LMg" supplier="_WHPN4FJvEeWcs7ZjyujtOg"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
@@ -455,7 +454,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         <generalization xmi:type="uml:Generalization" xmi:id="_ntHGoO_nEeWLlrwIF3w0vA">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_4EtL4EUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_4ErWsEUcEeWEwNCluy4jrw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4EtL4EUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="shared" association="_4ErWsEUcEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YteN0EUdEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YtgqEEUdEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
@@ -532,7 +531,7 @@ Note that depending on the service supported by an FC, an the FC can have multip
         <generalization xmi:type="uml:Generalization" xmi:id="_HOnysN8rEeWT9tG0gGLRFw">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_p40DAEUeEeWEwNCluy4jrw" name="_lowerConnection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_p4w_sEUeEeWEwNCluy4jrw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p40DAEUeEeWEwNCluy4jrw" name="_lowerConnection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="shared" association="_p4w_sEUeEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tAZCgEUfEeWEwNCluy4jrw" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tAd7AEUfEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
@@ -614,7 +613,7 @@ This ability allows multiple alternate routes to be present that otherwise would
         <ownedComment xmi:type="uml:Comment" xmi:id="_MBqV4erzEeaeHOJw3lCT8A" annotatedElement="_MBqV4OrzEeaeHOJw3lCT8A">
           <body>A list of control parameters to apply to a switch.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_MBqV6erzEeaeHOJw3lCT8A" name="protType" visibility="public" type="_9bzYYOr1EeaeHOJw3lCT8A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MBqV6erzEeaeHOJw3lCT8A" name="switchType" visibility="public" type="_9bzYYOr1EeaeHOJw3lCT8A">
           <ownedComment xmi:type="uml:Comment" xmi:id="_MBqV6urzEeaeHOJw3lCT8A" annotatedElement="_MBqV6erzEeaeHOJw3lCT8A">
             <body>Indicates the protection scheme that is used for the ProtectionGroup.</body>
           </ownedComment>
@@ -642,9 +641,21 @@ This ability allows multiple alternate routes to be present that otherwise would
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MBqV7urzEeaeHOJw3lCT8A"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_kKvJ4PKiEeaAIfPpmDwI5Q" name="isLockOut">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Mn3b0EDKEeezirADScVY4Q" annotatedElement="_kKvJ4PKiEeaAIfPpmDwI5Q">
+            <body>The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.&#xD;
+This overrides all other protection control states including forced.&#xD;
+If the item is locked out then it cannot be used under any circumstances.&#xD;
+Note: Only relevant when part of a protection scheme.</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_yfVXQEDKEeezirADScVY4Q"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_zpUU8O4GEeaRONVEJOGI1g" name="isFrozen">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_bVyo0EDKEeezirADScVY4Q" annotatedElement="_zpUU8O4GEeaRONVEJOGI1g">
+            <body>Temporarily prevents any switch action to be taken and, as such, freezes the current state. &#xD;
+Until the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.&#xD;
+All administrative controls of any aspect of protection are rejected.</body>
+          </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
           <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_nN9yEO4HEeaRONVEJOGI1g"/>
         </ownedAttribute>
@@ -755,7 +766,7 @@ Note: Only relevant when part of a protection scheme.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_I_ObcOr6EeaeHOJw3lCT8A" name="SIGNAL_DEGRADE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KaoCcOr6EeaeHOJw3lCT8A" name="SIGNAL_FAIL"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_9bzYYOr1EeaeHOJw3lCT8A" name="ProtectionType" isLeaf="true">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_9bzYYOr1EeaeHOJw3lCT8A" name="SwitchType" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_EBLacP49Eea_VPdGG2-szQ" name="LINEAR_1_PLUS_1"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_e-RTAP49Eea_VPdGG2-szQ" name="LINEAR_1_FOR_1"/>
       </packagedElement>
@@ -918,7 +929,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:PassedByReference xmi:id="_96rvQBMiEee0L_IMWjydgQ" base_Property="_4EtL4EUcEeWEwNCluy4jrw"/>
   <OpenModel_Profile:PassedByReference xmi:id="_CBU0gBMjEee0L_IMWjydgQ" base_Property="_p40DAEUeEeWEwNCluy4jrw"/>
   <OpenModel_Profile:Specify xmi:id="_L-XKwBM2Eee0L_IMWjydgQ" base_Abstraction="_Ju5pkBM2Eee0L_IMWjydgQ" target="/TapiCommon:Context:_context"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_uaxzQBNEEeeQQtMBY9ly8w" base_Association="_ijcPoGkHEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xxt8BhrEeewCs0lkpWskw" base_Property="_TPT-Be_tEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xzjIBhrEeewCs0lkpWskw" base_Property="_ZiZgIEUcEeWEwNCluy4jrw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xzjIRhrEeewCs0lkpWskw" base_Property="_B00SgO_sEeWLlrwIF3w0vA"/>
@@ -1017,5 +1027,5 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Lug3YCBcEeeWCKlkirNtnw">
     <base_StructuralFeature xmi:type="uml:Property" href="TapiOam.uml#_LuawxSBcEeeWCKlkirNtnw"/>
   </OpenModel_Profile:OpenModelAttribute>
-  <OpenModel_Profile:StrictComposite xmi:id="_7P0a4CBcEeeWCKlkirNtnw" base_Association="_mvBt0MhsEeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_g6zC0EvpEee8IN5myVB_oQ" base_Association="_ijcPoGkHEeWZEqTYAF8eqA"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -384,9 +384,6 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_6a7R8KU7EeWkWNPM1BHzGA" name="terminationDirection" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_sIutK2h-EeWZEqTYAF8eqA" name="connectionPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_sIutLGh-EeWZEqTYAF8eqA" annotatedElement="_sIutK2h-EeWZEqTYAF8eqA">
             <body>The orientation of defined flow at the EndPoint.</body>
@@ -814,7 +811,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cfZ_dIbpEeWLkaOCu--9xg" base_StructuralFeature="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cfjJYYbpEeWLkaOCu--9xg" base_StructuralFeature="_cfjJYIbpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_T9ChoaU5EeWkWNPM1BHzGA" base_Parameter="_T9ChoKU5EeWkWNPM1BHzGA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_6a7R8aU7EeWkWNPM1BHzGA" base_StructuralFeature="_6a7R8KU7EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_7BwFUbvMEeWYrqoqXLgguw" base_Parameter="_7BwFULvMEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lY2XUbvZEeWYrqoqXLgguw" base_StructuralFeature="_lY2XULvZEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3_SWwb11EeWdore3Cxez9g" base_StructuralFeature="_3_SWwL11EeWdore3Cxez9g"/>
@@ -974,7 +970,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yA-gBhrEeewCs0lkpWskw" base_Property="_B3Ln4EHCEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkBhrEeewCs0lkpWskw" base_Property="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkRhrEeewCs0lkpWskw" base_Property="_TPT-A-_tEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkhhrEeewCs0lkpWskw" base_Property="_6a7R8KU7EeWkWNPM1BHzGA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkxhrEeewCs0lkpWskw" base_Property="_sIutK2h-EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBllBhrEeewCs0lkpWskw" base_Property="_sIutJ2h-EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBllRhrEeewCs0lkpWskw" base_Property="_lY2XULvZEeWYrqoqXLgguw"/>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -263,7 +263,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1qqMI-wNEealldJ4rm6P_g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1qqMEewNEealldJ4rm6P_g" x="-365" y="-447" width="131" height="68"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1qqMEewNEealldJ4rm6P_g" x="-365" y="-457" width="131" height="68"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1qwSy-wNEealldJ4rm6P_g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_1qwSzOwNEealldJ4rm6P_g" showTitle="true"/>
@@ -540,7 +540,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkTs-6lEeaHHP1Zcp2a0A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-409" y="185" width="134" height="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-410" y="210" width="134" height="60"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_emqaW-6lEeaHHP1Zcp2a0A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_emqaXO6lEeaHHP1Zcp2a0A" showTitle="true"/>
@@ -654,7 +654,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f3yaExM7Eee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f3yaARM7Eee0L_IMWjydgQ" x="-82" y="-437" height="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f3yaARM7Eee0L_IMWjydgQ" x="-82" y="-447" height="60"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_f3-nQxM7Eee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_f3-nRBM7Eee0L_IMWjydgQ" showTitle="true"/>
@@ -822,7 +822,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_eAxoEEeeV4o0osG5stg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_d8RoEEeeV4o0osG5stg" x="315" y="-441" height="64"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_d8RoEEeeV4o0osG5stg" x="315" y="-451" height="64"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_f2LrPhoEEeeV4o0osG5stg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_f2LrPxoEEeeV4o0osG5stg" showTitle="true"/>
@@ -848,11 +848,29 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7P8WsiBcEeeWCKlkirNtnw" x="454" y="-297"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_KWG5wCNsEeenc_m30jt0Ow" type="2011">
-      <children xmi:type="notation:DecorationNode" xmi:id="_KWNAYCNsEeenc_m30jt0Ow" type="5037"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_KWNAYSNsEeenc_m30jt0Ow" type="5159"/>
-      <element xmi:type="uml:Constraint" href="TapiOam.uml#_9B-xQCNrEeenc_m30jt0Ow"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KWG5wSNsEeenc_m30jt0Ow" x="51" y="-221" height="44"/>
+    <children xmi:type="notation:Shape" xmi:id="__RBOYExtEeeBqfKxLidrUg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__RBOYUxtEeeBqfKxLidrUg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RBOY0xtEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__RBOYkxtEeeBqfKxLidrUg" x="449" y="-420"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__RKYUExtEeeBqfKxLidrUg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="__RKYUUxtEeeBqfKxLidrUg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RKYU0xtEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__RKYUkxtEeeBqfKxLidrUg" x="167" y="-158"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_WvGdQE8-Eeeicu4cm-7qRg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_WvGdQU8-Eeeicu4cm-7qRg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WvGdQ08-Eeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvGdQk8-Eeeicu4cm-7qRg" x="-46" y="-270"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z8zk8evSEealldJ4rm6P_g" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z8zk8uvSEealldJ4rm6P_g"/>
@@ -1001,10 +1019,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MvU3AOwNEealldJ4rm6P_g" type="4001" source="_ZUO-gOwMEealldJ4rm6P_g" target="_1qqMEOwNEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_Mva9oOwNEealldJ4rm6P_g" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9oewNEealldJ4rm6P_g" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9oewNEealldJ4rm6P_g" x="60" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Mva9ouwNEealldJ4rm6P_g" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9o-wNEealldJ4rm6P_g" x="55" y="-3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9o-wNEealldJ4rm6P_g" x="78" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Mva9pOwNEealldJ4rm6P_g" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9pewNEealldJ4rm6P_g" y="-20"/>
@@ -1057,7 +1075,7 @@
       <element xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O1ddEuwNEealldJ4rm6P_g" points="[40, 0, -86, -4]$[125, 3, -1, -1]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1ddH-wNEealldJ4rm6P_g" id="(0.7954545454545454,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1ddIOwNEealldJ4rm6P_g" id="(0.1956521739130435,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1ddIOwNEealldJ4rm6P_g" id="(0.20526315789473684,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_O1jjt-wNEealldJ4rm6P_g" type="StereotypeCommentLink" source="_O1ddEOwNEealldJ4rm6P_g" target="_O1jjs-wNEealldJ4rm6P_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_O1jjuOwNEealldJ4rm6P_g"/>
@@ -1111,10 +1129,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qYmAIOxIEeaTUPmcu3rLwA" type="4001" source="_1qqMEOwNEealldJ4rm6P_g" target="_NkS1sOxFEeaTUPmcu3rLwA">
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAI-xIEeaTUPmcu3rLwA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJOxIEeaTUPmcu3rLwA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJOxIEeaTUPmcu3rLwA" x="7" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAJexIEeaTUPmcu3rLwA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJuxIEeaTUPmcu3rLwA" x="-4" y="-10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJuxIEeaTUPmcu3rLwA" x="-10" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAJ-xIEeaTUPmcu3rLwA" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAKOxIEeaTUPmcu3rLwA" y="-20"/>
@@ -1131,8 +1149,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_qYmAIexIEeaTUPmcu3rLwA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qYmAIuxIEeaTUPmcu3rLwA" points="[0, -1, -3, -66]$[1, 41, -2, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIOxIEeaTUPmcu3rLwA" id="(0.8748091603053435,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIexIEeaTUPmcu3rLwA" id="(0.48105263157894734,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIOxIEeaTUPmcu3rLwA" id="(0.8702290076335878,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIexIEeaTUPmcu3rLwA" id="(0.4789473684210526,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qZW1J-xIEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_qYmAIOxIEeaTUPmcu3rLwA" target="_qZW1I-xIEeaTUPmcu3rLwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_qZW1KOxIEeaTUPmcu3rLwA"/>
@@ -1217,9 +1235,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_9cCoo-xYEeaTUPmcu3rLwA"/>
       <element xmi:type="uml:Dependency" href="TapiOam.uml#_9cCooOxYEeaTUPmcu3rLwA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9cCopOxYEeaTUPmcu3rLwA" points="[0, 0, -81, 96]$[0, -96, -81, 0]$[80, -96, -1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoOxYEeaTUPmcu3rLwA" id="(0.4870967741935484,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoexYEeaTUPmcu3rLwA" id="(0.0,0.7029411764705882)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9cCopOxYEeaTUPmcu3rLwA" points="[0, 0, -81, 106]$[0, -106, -81, 0]$[81, -106, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoOxYEeaTUPmcu3rLwA" id="(0.4838709677419355,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoexYEeaTUPmcu3rLwA" id="(0.0,0.6911764705882353)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9c_q5-xYEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_9cCoouxYEeaTUPmcu3rLwA" target="_9c_q4-xYEeaTUPmcu3rLwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_9c_q6OxYEeaTUPmcu3rLwA"/>
@@ -1257,10 +1275,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_g5zzgO6jEeaHHP1Zcp2a0A" type="4001" source="_emkToO6lEeaHHP1Zcp2a0A" target="_fc1w8OwLEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_g5zzg-6jEeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhO6jEeaHHP1Zcp2a0A" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhO6jEeaHHP1Zcp2a0A" x="-9" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_g5zzhe6jEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhu6jEeaHHP1Zcp2a0A" x="2" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhu6jEeaHHP1Zcp2a0A" x="11" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_g5zzh-6jEeaHHP1Zcp2a0A" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zziO6jEeaHHP1Zcp2a0A" y="-20"/>
@@ -1292,10 +1310,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hm478O6jEeaHHP1Zcp2a0A" type="4001" source="_emkToO6lEeaHHP1Zcp2a0A" target="_dcMSYOwMEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_CkO6jEeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cke6jEeaHHP1Zcp2a0A" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cke6jEeaHHP1Zcp2a0A" x="-5" y="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_Cku6jEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Ck-6jEeaHHP1Zcp2a0A" x="-1" y="9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Ck-6jEeaHHP1Zcp2a0A" x="14" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_ClO6jEeaHHP1Zcp2a0A" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cle6jEeaHHP1Zcp2a0A" y="-20"/>
@@ -1312,7 +1330,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_hm478e6jEeaHHP1Zcp2a0A"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hm478u6jEeaHHP1Zcp2a0A" points="[2, -1, -262, 83]$[266, -85, 2, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.835820895522388,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.8432835820895522,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_se6jEeaHHP1Zcp2a0A" id="(0.35964912280701755,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hoYJt-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A" target="_hoYJs-6jEeaHHP1Zcp2a0A">
@@ -1516,7 +1534,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Z1Zb8RNKEeeQQtMBY9ly8w"/>
       <element xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[0, 0, -667, 56]$[667, 0, 0, 56]$[667, -56, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[0, 0, -668, 81]$[668, 0, 0, 81]$[668, -81, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8BNKEeeQQtMBY9ly8w" id="(1.0,0.45)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8RNKEeeQQtMBY9ly8w" id="(0.45132743362831856,1.0)"/>
     </edges>
@@ -1679,8 +1697,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_uhjcgRP7EeepnPPr_BcZKg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_uW9WEBP7EeepnPPr_BcZKg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uhjcghP7EeepnPPr_BcZKg" points="[0, -1, -135, -85]$[0, 84, -135, 0]$[134, 84, -1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkBP7EeepnPPr_BcZKg" id="(0.5864661654135338,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uhjcghP7EeepnPPr_BcZKg" points="[0, 0, -124, -84]$[0, 84, -124, 0]$[124, 84, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkBP7EeepnPPr_BcZKg" id="(0.6691729323308271,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkRP7EeepnPPr_BcZKg" id="(0.0,0.5357142857142857)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_f2LrQhoEEeeV4o0osG5stg" type="StereotypeCommentLink" source="_f1_d8BoEEeeV4o0osG5stg" target="_f2LrPhoEEeeV4o0osG5stg">
@@ -1718,10 +1736,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zcI-IBoEEeeV4o0osG5stg" type="4001" source="_PBp_YBO0EeeuwKj8ylAa1g" target="_f1_d8BoEEeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_zcI-IxoEEeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JBoEEeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JBoEEeeV4o0osG5stg" x="-7" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_zcI-JRoEEeeV4o0osG5stg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JhoEEeeV4o0osG5stg" x="4" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JhoEEeeV4o0osG5stg" x="8" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_zcI-JxoEEeeV4o0osG5stg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-KBoEEeeV4o0osG5stg" y="-20"/>
@@ -1743,7 +1761,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_OM4K0BoHEeeV4o0osG5stg" type="4001" source="_94EI8BP6EeepnPPr_BcZKg" target="_f3yaABM7Eee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K0xoHEeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1BoHEeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1BoHEeeV4o0osG5stg" x="102" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K1RoHEeeV4o0osG5stg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1hoHEeeV4o0osG5stg" x="120" y="-4"/>
@@ -1763,8 +1781,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_OM4K0RoHEeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OM4K0hoHEeeV4o0osG5stg" points="[0, 0, 121, 473]$[-102, -398, 19, 75]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K3xoHEeeV4o0osG5stg" id="(0.4045112781954887,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K4BoHEeeV4o0osG5stg" id="(0.5743016759776536,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K3xoHEeeV4o0osG5stg" id="(0.39849624060150374,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K4BoHEeeV4o0osG5stg" id="(0.5698324022346368,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BYrsACBcEeeWCKlkirNtnw" type="4001" source="_7WyOUO6zEeaHHP1Zcp2a0A" target="_f1_d8BoEEeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_BYrsAyBcEeeWCKlkirNtnw" type="6001">
@@ -1791,31 +1809,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BYrsDyBcEeeWCKlkirNtnw" id="(0.7692307692307693,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BYrsECBcEeeWCKlkirNtnw" id="(0.8384615384615385,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_LvB0wCBcEeeWCKlkirNtnw" type="4001" source="_NkS1sOxFEeaTUPmcu3rLwA" target="_7WyOUO6zEeaHHP1Zcp2a0A">
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0wyBcEeeWCKlkirNtnw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0xCBcEeeWCKlkirNtnw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0xSBcEeeWCKlkirNtnw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0xiBcEeeWCKlkirNtnw" x="-108" y="-119"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0xyBcEeeWCKlkirNtnw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0yCBcEeeWCKlkirNtnw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0ySBcEeeWCKlkirNtnw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0yiBcEeeWCKlkirNtnw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0yyBcEeeWCKlkirNtnw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0zCBcEeeWCKlkirNtnw" x="10" y="11"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LvB0zSBcEeeWCKlkirNtnw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LvB0ziBcEeeWCKlkirNtnw" x="-12" y="12"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_LvB0wSBcEeeWCKlkirNtnw"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_LuUqICBcEeeWCKlkirNtnw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LvB0wiBcEeeWCKlkirNtnw" points="[-1, 0, -486, -104]$[145, 0, -340, -104]$[145, 104, -340, 0]$[484, 104, -1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LwX4kCBcEeeWCKlkirNtnw" id="(1.0,0.7241379310344828)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LwX4kSBcEeeWCKlkirNtnw" id="(0.0,0.39344262295081966)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7P8WtCBcEeeWCKlkirNtnw" type="StereotypeCommentLink" source="_BYrsACBcEeeWCKlkirNtnw" target="_7P8WsCBcEeeWCKlkirNtnw">
       <styles xmi:type="notation:FontStyle" xmi:id="_7P8WtSBcEeeWCKlkirNtnw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7P8WuSBcEeeWCKlkirNtnw" name="BASE_ELEMENT">
@@ -1826,19 +1819,60 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7P8WtyBcEeeWCKlkirNtnw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7P8WuCBcEeeWCKlkirNtnw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cv2RMCNsEeenc_m30jt0Ow" type="4014" source="_KWG5wCNsEeenc_m30jt0Ow" target="_LvB0wCBcEeeWCKlkirNtnw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cv2RMSNsEeenc_m30jt0Ow"/>
+    <edges xmi:type="notation:Connector" xmi:id="__RBOZExtEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_zcI-IBoEEeeV4o0osG5stg" target="__RBOYExtEeeBqfKxLidrUg">
+      <styles xmi:type="notation:FontStyle" xmi:id="__RBOZUxtEeeBqfKxLidrUg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RBOaUxtEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cv2RMiNsEeenc_m30jt0Ow" points="[15, 11, 531, 109]$[40, 32, 556, 130]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cyShMCNsEeenc_m30jt0Ow" id="(0.8778242677824267,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cyShMSNsEeenc_m30jt0Ow" id="(0.7517006802721088,0.7945945945945946)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__RBOZkxtEeeBqfKxLidrUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RBOZ0xtEeeBqfKxLidrUg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RBOaExtEeeBqfKxLidrUg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eGlIsCNuEeenc_m30jt0Ow" type="4014" source="_KWG5wCNsEeenc_m30jt0Ow" target="_PFUXYBO0EeeuwKj8ylAa1g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_eGlIsSNuEeenc_m30jt0Ow"/>
+    <edges xmi:type="notation:Connector" xmi:id="__RKYVExtEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_OM4K0BoHEeeV4o0osG5stg" target="__RKYUExtEeeBqfKxLidrUg">
+      <styles xmi:type="notation:FontStyle" xmi:id="__RKYVUxtEeeBqfKxLidrUg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RKYWUxtEeeBqfKxLidrUg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eGlIsiNuEeenc_m30jt0Ow" points="[12, -4, -68, 71]$[80, -37, 0, 38]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eIZGkCNuEeenc_m30jt0Ow" id="(1.0016736401673643,0.4409090909090904)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eIZGkSNuEeenc_m30jt0Ow" id=""/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__RKYVkxtEeeBqfKxLidrUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RKYV0xtEeeBqfKxLidrUg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RKYWExtEeeBqfKxLidrUg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0qX7AE86Eeeicu4cm-7qRg" type="4001" source="_W5IZsBP7EeepnPPr_BcZKg" target="_Sv-f8OwPEealldJ4rm6P_g">
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qX7A086Eeeicu4cm-7qRg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEE86Eeeicu4cm-7qRg" x="-151" y="-149"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qYiEU86Eeeicu4cm-7qRg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEk86Eeeicu4cm-7qRg" x="-156" y="-166"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qYiE086Eeeicu4cm-7qRg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiFE86Eeeicu4cm-7qRg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qYiFU86Eeeicu4cm-7qRg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiFk86Eeeicu4cm-7qRg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qYiF086Eeeicu4cm-7qRg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiGE86Eeeicu4cm-7qRg" x="9" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_0qYiGU86Eeeicu4cm-7qRg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiGk86Eeeicu4cm-7qRg" x="-10" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_0qX7AU86Eeeicu4cm-7qRg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0qX7Ak86Eeeicu4cm-7qRg" points="[0, 0, -549, -244]$[0, 244, -549, 0]$[549, 244, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AME86Eeeicu4cm-7qRg" id="(0.2857142857142857,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AMU86Eeeicu4cm-7qRg" id="(0.0,0.6666666666666666)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WvGdRE8-Eeeicu4cm-7qRg" type="StereotypeCommentLink" source="_0qX7AE86Eeeicu4cm-7qRg" target="_WvGdQE8-Eeeicu4cm-7qRg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_WvGdRU8-Eeeicu4cm-7qRg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WvGdSU8-Eeeicu4cm-7qRg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvGdRk8-Eeeicu4cm-7qRg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvGdR08-Eeeicu4cm-7qRg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvGdSE8-Eeeicu4cm-7qRg"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -540,7 +540,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkTs-6lEeaHHP1Zcp2a0A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-409" y="185" width="113" height="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-409" y="185" width="134" height="60"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_emqaW-6lEeaHHP1Zcp2a0A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_emqaXO6lEeaHHP1Zcp2a0A" showTitle="true"/>
@@ -1277,8 +1277,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_g5zzge6jEeaHHP1Zcp2a0A"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g5zzgu6jEeaHHP1Zcp2a0A" points="[-12, -26, 31, 71]$[-43, -98, 0, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svcO6jEeaHHP1Zcp2a0A" id="(0.1752212389380531,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svce6jEeaHHP1Zcp2a0A" id="(0.6277777777777778,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svcO6jEeaHHP1Zcp2a0A" id="(0.1417910447761194,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svce6jEeaHHP1Zcp2a0A" id="(0.6203703703703703,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_g7J3V-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_g5zzgO6jEeaHHP1Zcp2a0A" target="_g7J3U-6jEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_g7J3WO6jEeaHHP1Zcp2a0A"/>
@@ -1312,8 +1312,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_hm478e6jEeaHHP1Zcp2a0A"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hm478u6jEeaHHP1Zcp2a0A" points="[2, -1, -262, 83]$[266, -85, 2, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.8407079646017699,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_se6jEeaHHP1Zcp2a0A" id="(0.21052631578947367,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.835820895522388,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_se6jEeaHHP1Zcp2a0A" id="(0.35964912280701755,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hoYJt-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A" target="_hoYJs-6jEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_hoYJuO6jEeaHHP1Zcp2a0A"/>
@@ -1516,7 +1516,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Z1Zb8RNKEeeQQtMBY9ly8w"/>
       <element xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[-1, 0, -689, 56]$[688, 0, 0, 56]$[688, -56, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[0, 0, -667, 56]$[667, 0, 0, 56]$[667, -56, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8BNKEeeQQtMBY9ly8w" id="(1.0,0.45)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8RNKEeeQQtMBY9ly8w" id="(0.45132743362831856,1.0)"/>
     </edges>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -6,31 +6,31 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_UgUN4PLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-eSFcMbMEeaVKq30FmMykA" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" association="_-eN0AMbMEeaVKq30FmMykA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-eSFcMbMEeaVKq30FmMykA" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" isReadOnly="true" association="_-eN0AMbMEeaVKq30FmMykA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YfX9EPLxEeaAIfPpmDwI5Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YfaZUPLxEeaAIfPpmDwI5Q" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_LgK8AufKEea2-taDQDzvGg" name="_mepBidirectional" type="_82r5QLzJEeSmrtWG5D-wKA" aggregation="composite" association="_LgIfwOfKEea2-taDQDzvGg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LgK8AufKEea2-taDQDzvGg" name="_mepBidirectional" type="_82r5QLzJEeSmrtWG5D-wKA" isReadOnly="true" aggregation="composite" association="_LgIfwOfKEea2-taDQDzvGg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UkgqUOfKEea2-taDQDzvGg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Uk2BgOfKEea2-taDQDzvGg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_iGTYMOfGEea2-taDQDzvGg" name="_mepSink" type="_nPXJwLxAEeSpn78DYJKtkA" aggregation="composite" association="_iGK1UOfGEea2-taDQDzvGg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iGTYMOfGEea2-taDQDzvGg" name="_mepSink" type="_nPXJwLxAEeSpn78DYJKtkA" isReadOnly="true" aggregation="composite" association="_iGK1UOfGEea2-taDQDzvGg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rpLnMOfHEea2-taDQDzvGg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rptysOfHEea2-taDQDzvGg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_RlhMILxDEeSpn78DYJKtkA" name="_mepSource" type="_BaBVQLxAEeSpn78DYJKtkA" aggregation="composite" association="_RlnSwLxDEeSpn78DYJKtkA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RlhMILxDEeSpn78DYJKtkA" name="_mepSource" type="_BaBVQLxAEeSpn78DYJKtkA" isReadOnly="true" aggregation="composite" association="_RlnSwLxDEeSpn78DYJKtkA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RlhMIbxDEeSpn78DYJKtkA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RlhMIrxDEeSpn78DYJKtkA" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AY3XUMOiEeaFfJxGCRaf4A" name="_onDemandMeasurementJob" type="_wSTOUMOfEeaFfJxGCRaf4A" aggregation="composite" association="_AYu0cMOiEeaFfJxGCRaf4A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AY3XUMOiEeaFfJxGCRaf4A" name="_onDemandMeasurementJob" type="_wSTOUMOfEeaFfJxGCRaf4A" isReadOnly="true" aggregation="composite" association="_AYu0cMOiEeaFfJxGCRaf4A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PyaUMMOiEeaFfJxGCRaf4A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PylTUMOiEeaFfJxGCRaf4A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Fk6lcMOiEeaFfJxGCRaf4A" name="_proActiveMeasurementJob" type="_z9S5YMOfEeaFfJxGCRaf4A" aggregation="composite" association="_Fk5XUMOiEeaFfJxGCRaf4A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Fk6lcMOiEeaFfJxGCRaf4A" name="_proActiveMeasurementJob" type="_z9S5YMOfEeaFfJxGCRaf4A" isReadOnly="true" aggregation="composite" association="_Fk5XUMOiEeaFfJxGCRaf4A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RFcpYMOiEeaFfJxGCRaf4A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RFgTwMOiEeaFfJxGCRaf4A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_dXwzgLw1EeSpn78DYJKtkA" name="megIdentifier" visibility="public">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dXwzgLw1EeSpn78DYJKtkA" name="megIdentifier" visibility="public" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dvy5ALw1EeSpn78DYJKtkA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dvzgELw1EeSpn78DYJKtkA" value="1"/>
@@ -71,11 +71,11 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_FSc8kPLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_khqLYMbMEeaVKq30FmMykA" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" aggregation="composite" association="_kho9QMbMEeaVKq30FmMykA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_khqLYMbMEeaVKq30FmMykA" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" isReadOnly="true" aggregation="composite" association="_kho9QMbMEeaVKq30FmMykA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nJMOUMbMEeaVKq30FmMykA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nJPRoMbMEeaVKq30FmMykA" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_mJof4PLsEeaAIfPpmDwI5Q" name="megLevel">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_mJof4PLsEeaAIfPpmDwI5Q" name="megLevel" isReadOnly="true">
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
         </ownedAttribute>
       </packagedElement>
@@ -83,11 +83,11 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_cBgHYPLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-ePpMMbMEeaVKq30FmMykA" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" association="_-eN0AMbMEeaVKq30FmMykA">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-ePpMMbMEeaVKq30FmMykA" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" isReadOnly="true" association="_-eN0AMbMEeaVKq30FmMykA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BaSjkMbNEeaVKq30FmMykA"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BacUkMbNEeaVKq30FmMykA" value="2"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ystxUNzEEeaMV83ubDcSig" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" association="_ysrVENzEEeaMV83ubDcSig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ystxUNzEEeaMV83ubDcSig" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" isReadOnly="true" association="_ysrVENzEEeaMV83ubDcSig">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nFpC4PLxEeaAIfPpmDwI5Q"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nFvJgPLxEeaAIfPpmDwI5Q" value="*"/>
         </ownedAttribute>
@@ -96,7 +96,7 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_bPpzsPLuEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_yssjMNzEEeaMV83ubDcSig" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" association="_ysrVENzEEeaMV83ubDcSig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yssjMNzEEeaMV83ubDcSig" name="_me" type="_iE9fcMbMEeaVKq30FmMykA" isReadOnly="true" association="_ysrVENzEEeaMV83ubDcSig">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_beW-4NzFEeaMV83ubDcSig"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bejMINzFEeaMV83ubDcSig" value="*"/>
         </ownedAttribute>
@@ -105,18 +105,13 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_6pojwPLtEeaAIfPpmDwI5Q">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__n5DwNzDEeaMV83ubDcSig" name="_meg" type="_zR-agMbLEeaVKq30FmMykA" isReadOnly="true" aggregation="composite" association="__nuEoNzDEeaMV83ubDcSig">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__n5DwNzDEeaMV83ubDcSig" name="_meg" type="_zR-agMbLEeaVKq30FmMykA" isReadOnly="true" aggregation="shared" association="__nuEoNzDEeaMV83ubDcSig">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DlTUgNzEEeaMV83ubDcSig"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DlVJsNzEEeaMV83ubDcSig" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_bsmIshP7EeepnPPr_BcZKg" name="_endPoint" type="_W48McBP7EeepnPPr_BcZKg" aggregation="composite" association="_bsgCEBP7EeepnPPr_BcZKg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kXCJQBP7EeepnPPr_BcZKg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_LuawwiBcEeeWCKlkirNtnw" name="_connection" isReadOnly="true" aggregation="composite" association="_LuUqICBcEeeWCKlkirNtnw">
-          <type xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WuCqkCBdEeeWCKlkirNtnw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WuCqkSBdEeeWCKlkirNtnw" value="*"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1qX4MOwNEealldJ4rm6P_g" name="OamContext">
@@ -130,11 +125,11 @@
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_emeNAO6lEeaHHP1Zcp2a0A" name="MepMipReference">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hl75tO6jEeaHHP1Zcp2a0A" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" aggregation="composite" association="_hl75sO6jEeaHHP1Zcp2a0A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hl75tO6jEeaHHP1Zcp2a0A" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" isReadOnly="true" aggregation="composite" association="_hl75sO6jEeaHHP1Zcp2a0A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_psLBAO6jEeaHHP1Zcp2a0A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_psRHoO6jEeaHHP1Zcp2a0A" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_g43YUO6jEeaHHP1Zcp2a0A" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" aggregation="composite" association="_g408EO6jEeaHHP1Zcp2a0A">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_g43YUO6jEeaHHP1Zcp2a0A" name="_mep" type="_CE0kkLwmEeSpn78DYJKtkA" isReadOnly="true" aggregation="composite" association="_g408EO6jEeaHHP1Zcp2a0A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mQC4YO6jEeaHHP1Zcp2a0A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mQI_Ae6jEeaHHP1Zcp2a0A" value="*"/>
         </ownedAttribute>
@@ -143,17 +138,19 @@
         <generalization xmi:type="uml:Generalization" xmi:id="_M_LcEBocEeeV4o0osG5stg">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0YC04k86Eeeicu4cm-7qRg" name="_layerProtocol" aggregation="composite" association="_0WKlkE86Eeeicu4cm-7qRg">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OnEtkE87Eeeicu4cm-7qRg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OnF7sE87Eeeicu4cm-7qRg" value="*"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_uW9WExP7EeepnPPr_BcZKg" name="_serviceInterfacePoint" isReadOnly="true" association="_uW9WEBP7EeepnPPr_BcZKg">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_SPp3MBocEeeV4o0osG5stg" name="role" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hJpKQBocEeeV4o0osG5stg" name="direction" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_k_ASQBocEeeV4o0osG5stg" name="layerProtocolName" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_SPp3MBocEeeV4o0osG5stg" name="role" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
@@ -285,14 +282,11 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_z6cMwRP7EeepnPPr_BcZKg" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_LuUqICBcEeeWCKlkirNtnw" name="OamServiceHasConnections" memberEnd="_LuawwiBcEeeWCKlkirNtnw _LuawxSBcEeeWCKlkirNtnw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LuawwCBcEeeWCKlkirNtnw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LuawwSBcEeeWCKlkirNtnw" key="nature" value="UML_Nature"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_0WKlkE86Eeeicu4cm-7qRg" name="OSEPIncludesLP" memberEnd="_0YC04k86Eeeicu4cm-7qRg _0YDb8k86Eeeicu4cm-7qRg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0YC04E86Eeeicu4cm-7qRg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0YC04U86Eeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_LuawxSBcEeeWCKlkirNtnw" name="oamservice" type="_NgYmEOxFEeaTUPmcu3rLwA" association="_LuUqICBcEeeWCKlkirNtnw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZhaKECBdEeeWCKlkirNtnw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZhaKESBdEeeWCKlkirNtnw" value="1"/>
-        </ownedEnd>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_0YDb8k86Eeeicu4cm-7qRg" name="oamserviceendpoint" type="_W48McBP7EeepnPPr_BcZKg" association="_0WKlkE86Eeeicu4cm-7qRg"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_-MPC0OvREealldJ4rm6P_g" name="Imports">
@@ -304,13 +298,7 @@
       </packageImport>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_XQfKcOvSEealldJ4rm6P_g" name="Diagrams"/>
-    <packagedElement xmi:type="uml:Package" xmi:id="_7xKpoCNrEeenc_m30jt0Ow" name="Rules">
-      <ownedRule xmi:type="uml:Constraint" xmi:id="_9B-xQCNrEeenc_m30jt0Ow" name="AND-OR: ConnectionContainment">
-        <constrainedElement xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-        <constrainedElement xmi:type="uml:Association" href="#_LuUqICBcEeeWCKlkirNtnw"/>
-        <specification xmi:type="uml:LiteralString" xmi:id="_9B-xQSNrEeenc_m30jt0Ow" name="AND-OR: ConnectionContainment" value="ServiceComponent ∨ RouteComponent"/>
-      </ownedRule>
-    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_7xKpoCNrEeenc_m30jt0Ow" name="Rules"/>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_x2I28BMwEee0L_IMWjydgQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_x2I28RMwEee0L_IMWjydgQ" source="http://www.eclipse.org/uml2/2.0.0/UML">
         <references xmi:type="ecore:EPackage" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_aG-rgAPxEeewDI5jM-81FA"/>
@@ -427,9 +415,13 @@
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SPp3MhocEeeV4o0osG5stg" base_Property="_SPp3MBocEeeV4o0osG5stg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_hJpKQRocEeeV4o0osG5stg" base_StructuralFeature="_hJpKQBocEeeV4o0osG5stg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_hJpKQhocEeeV4o0osG5stg" base_Property="_hJpKQBocEeeV4o0osG5stg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_k_ASQRocEeeV4o0osG5stg" base_StructuralFeature="_k_ASQBocEeeV4o0osG5stg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_k_ASQhocEeeV4o0osG5stg" base_Property="_k_ASQBocEeeV4o0osG5stg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_LuawwyBcEeeWCKlkirNtnw" base_Property="_LuawwiBcEeeWCKlkirNtnw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_LuawxCBcEeeWCKlkirNtnw" base_StructuralFeature="_LuawwiBcEeeWCKlkirNtnw"/>
-  <OpenModel_Profile:PassedByReference xmi:id="_OX0w0CNuEeenc_m30jt0Ow" base_Property="_LuawwiBcEeeWCKlkirNtnw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Hi0EoEyeEeeBqfKxLidrUg" base_Association="_qXvEgOxIEeaTUPmcu3rLwA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_K2_yMEyeEeeBqfKxLidrUg" base_Association="_1i2mEMbNEeaVKq30FmMykA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_ReJsYEyeEeeBqfKxLidrUg" base_Association="_hl75sO6jEeaHHP1Zcp2a0A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_U-UAcEyeEeeBqfKxLidrUg" base_Association="_g408EO6jEeaHHP1Zcp2a0A"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0YDb8E86Eeeicu4cm-7qRg" base_Property="_0YC04k86Eeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_0YDb8U86Eeeicu4cm-7qRg" base_StructuralFeature="_0YC04k86Eeeicu4cm-7qRg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_0YEDAE86Eeeicu4cm-7qRg" base_Property="_0YDb8k86Eeeicu4cm-7qRg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_0pme8E86Eeeicu4cm-7qRg" base_StructuralFeature="_0YDb8k86Eeeicu4cm-7qRg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Wu8FME8-Eeeicu4cm-7qRg" base_Association="_0WKlkE86Eeeicu4cm-7qRg"/>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -129,7 +129,7 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_61UlQMbNEeaVKq30FmMykA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_emeNAO6lEeaHHP1Zcp2a0A" name="OamLpSpec">
+      <packagedElement xmi:type="uml:Class" xmi:id="_emeNAO6lEeaHHP1Zcp2a0A" name="MepMipReference">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hl75tO6jEeaHHP1Zcp2a0A" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" aggregation="composite" association="_hl75sO6jEeaHHP1Zcp2a0A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_psLBAO6jEeaHHP1Zcp2a0A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_psRHoO6jEeaHHP1Zcp2a0A" value="*"/>
@@ -267,7 +267,7 @@
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Zz0HkBNKEeeQQtMBY9ly8w" name="LpSpecAugmentsLp" client="_emeNAO6lEeaHHP1Zcp2a0A">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Zz0HkBNKEeeQQtMBY9ly8w" name="MepMipRefAugmentsLp" client="_emeNAO6lEeaHHP1Zcp2a0A">
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_bsgCEBP7EeepnPPr_BcZKg" name="OamServiceHasSEPs" memberEnd="_bsmIshP7EeepnPPr_BcZKg _bssPUBP7EeepnPPr_BcZKg">

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -490,10 +490,6 @@
           <element xmi:type="uml:Property" href="TapiTopology.uml#_STzYA-_tEeWLlrwIF3w0vA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_icw848FlEeaALJQAf08uAg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icw85MFlEeaALJQAf08uAg" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_093zYKU7EeWkWNPM1BHzGA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icw85cFlEeaALJQAf08uAg"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_icw85sFlEeaALJQAf08uAg" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdVA2h_EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_icw858FlEeaALJQAf08uAg"/>
@@ -509,10 +505,6 @@
         <children xmi:type="notation:Shape" xmi:id="_gxs0ohMnEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_gxs0oxMnEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_gxs0pBMnEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gxs0pRMnEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NPs5_zBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NPs6ADBDEea4fKwSGMr6CA"/>
@@ -895,10 +887,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_8eoZQxMoEee0L_IMWjydgQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_8eoZRBMoEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8eoZRRMoEee0L_IMWjydgQ"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvSYRTBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvSYRjBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_WvSYRzBDEea4fKwSGMr6CA"/>
@@ -1002,10 +990,6 @@
         <children xmi:type="notation:Shape" xmi:id="_7wZaQhMoEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_7wZaQxMoEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_7wZaRBMoEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7wZaRRMoEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvSaXDBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvSaXTBDEea4fKwSGMr6CA"/>
@@ -1157,10 +1141,6 @@
         <children xmi:type="notation:Shape" xmi:id="_6-0zYRMoEee0L_IMWjydgQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_6-0zYhMoEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_6-0zYxMoEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_6-0zZBMoEee0L_IMWjydgQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvbkHTBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvbkHjBDEea4fKwSGMr6CA"/>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -124,7 +124,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49DjBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49ITBDEea4fKwSGMr6CA" x="174" y="30" width="302" height="191"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49ITBDEea4fKwSGMr6CA" x="174" y="30" width="302" height="175"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bz49IjBDEea4fKwSGMr6CA" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_Bz49IzBDEea4fKwSGMr6CA" type="5035"/>
@@ -2598,17 +2598,13 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3RaD0Em0EeaKuvClDq6rqA"/>
       </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_3RaDxEm0EeaKuvClDq6rqA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3RaDxkm0EeaKuvClDq6rqA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiTopology.uml#_3Qgr4Em0EeaKuvClDq6rqA"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3RaDxkm0EeaKuvClDq6rqA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3RaDxUm0EeaKuvClDq6rqA" x="58" y="16"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dUvQ80m1EeaKuvClDq6rqA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_dUvQ9Em1EeaKuvClDq6rqA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dUvQ9km1EeaKuvClDq6rqA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiTopology.uml#_dT_qEEm1EeaKuvClDq6rqA"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dUvQ9km1EeaKuvClDq6rqA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dUvQ9Um1EeaKuvClDq6rqA" x="57" y="16"/>
     </children>
@@ -2690,14 +2686,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sp0h1chmEeaVlemTikmRHw" x="133" y="-245"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_3WkWk8hmEeaVlemTikmRHw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_3WkWlMhmEeaVlemTikmRHw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WkWlshmEeaVlemTikmRHw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3WkWlchmEeaVlemTikmRHw" x="121" y="-269"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_p9gpoBM3Eee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_p9gpohM3Eee0L_IMWjydgQ" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_p9gpoxM3Eee0L_IMWjydgQ" type="8510">
@@ -2740,6 +2728,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v5TSpRM3Eee0L_IMWjydgQ" x="59" y="-326"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_BMhFkEpcEeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BMhFkUpcEeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BMhsoEpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BMhFkkpcEeexQa2RWFy3AQ" x="59" y="-326"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_d6faUTBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_d6faUjBDEea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_d6faUzBDEea4fKwSGMr6CA">
@@ -2776,7 +2772,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9BgJjBDEea4fKwSGMr6CA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9BgJzBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9BgKDBDEea4fKwSGMr6CA" x="-39" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9BgKDBDEea4fKwSGMr6CA" x="-9" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9BgKTBDEea4fKwSGMr6CA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9BgKjBDEea4fKwSGMr6CA" x="-24" y="-13"/>
@@ -2823,7 +2819,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_i9LRlzBDEea4fKwSGMr6CA" type="4001" source="_i9BgRjBDEea4fKwSGMr6CA" target="_i9LSWTBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LRmDBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LRmTBDEea4fKwSGMr6CA" x="18" y="-18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LRmTBDEea4fKwSGMr6CA" x="-47" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LRmjBDEea4fKwSGMr6CA" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LRmzBDEea4fKwSGMr6CA" x="-61" y="-2"/>
@@ -2843,15 +2839,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_i9LRpDBDEea4fKwSGMr6CA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9LRqDBDEea4fKwSGMr6CA" points="[0, 0, 0, -240]$[0, 240, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LRqTBDEea4fKwSGMr6CA" id="(0.25668449197860965,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LRqjBDEea4fKwSGMr6CA" id="(0.4303030303030303,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LRqTBDEea4fKwSGMr6CA" id="(0.26737967914438504,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LRqjBDEea4fKwSGMr6CA" id="(0.43636363636363634,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_i9LSOTBDEea4fKwSGMr6CA" type="4001" source="_i9BgRjBDEea4fKwSGMr6CA" target="_i9LRtzBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSOjBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSOzBDEea4fKwSGMr6CA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSOzBDEea4fKwSGMr6CA" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSPDBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSPTBDEea4fKwSGMr6CA" x="-6" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSPTBDEea4fKwSGMr6CA" x="-16" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSPjBDEea4fKwSGMr6CA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSPzBDEea4fKwSGMr6CA" x="-16" y="-16"/>
@@ -2876,7 +2872,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSnjBDEea4fKwSGMr6CA" x="-2" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSnzBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSoDBDEea4fKwSGMr6CA" x="29" y="5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSoDBDEea4fKwSGMr6CA" x="22" y="6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSoTBDEea4fKwSGMr6CA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSojBDEea4fKwSGMr6CA" x="-26" y="8"/>
@@ -3051,64 +3047,9 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v5_WCkTtEead1bezhJG4aw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v5_WC0TtEead1bezhJG4aw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3Qqc4Em0EeaKuvClDq6rqA" type="4007" source="_i9BgkzBDEea4fKwSGMr6CA" target="_q5U4gETtEead1bezhJG4aw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B2qLMEm1EeaKuvClDq6rqA" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B2qLMUm1EeaKuvClDq6rqA" key="displayNameLabelIcon_value" value="true"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_3Qzm0Em0EeaKuvClDq6rqA" type="6016">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FGinkEm1EeaKuvClDq6rqA" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FGinkUm1EeaKuvClDq6rqA" key="visible" value="true"/>
-        </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Qzm0Um0EeaKuvClDq6rqA" x="-8" y="5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_3Qzm0km0EeaKuvClDq6rqA" visible="false" type="6017">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FGrxgEm1EeaKuvClDq6rqA" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FGrxgUm1EeaKuvClDq6rqA" key="visible" value="true"/>
-        </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Qzm00m0EeaKuvClDq6rqA" x="-20" y="186"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_3Qqc4Um0EeaKuvClDq6rqA"/>
-      <element xmi:type="uml:Usage" href="TapiTopology.uml#_3Qgr4Em0EeaKuvClDq6rqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Qqc4km0EeaKuvClDq6rqA" points="[0, -7, -4, 70]$[4, -68, 0, 9]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3SclkEm0EeaKuvClDq6rqA" id="(0.4748603351955307,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3SclkUm0EeaKuvClDq6rqA" id="(0.4971751412429379,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3RaDx0m0EeaKuvClDq6rqA" type="StereotypeCommentLink" source="_3Qqc4Em0EeaKuvClDq6rqA" target="_3RaDw0m0EeaKuvClDq6rqA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3RaDyEm0EeaKuvClDq6rqA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3RaDzEm0EeaKuvClDq6rqA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiTopology.uml#_3Qgr4Em0EeaKuvClDq6rqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3RaDyUm0EeaKuvClDq6rqA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3RaDykm0EeaKuvClDq6rqA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3RaDy0m0EeaKuvClDq6rqA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dUI0AEm1EeaKuvClDq6rqA" type="4007" source="_i9BgkzBDEea4fKwSGMr6CA" target="_i9BgRjBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dUI0A0m1EeaKuvClDq6rqA" type="6016">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dUI0BEm1EeaKuvClDq6rqA" x="-43" y="-9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dUI0BUm1EeaKuvClDq6rqA" type="6017">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dUI0Bkm1EeaKuvClDq6rqA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_dUI0AUm1EeaKuvClDq6rqA"/>
-      <element xmi:type="uml:Usage" href="TapiTopology.uml#_dT_qEEm1EeaKuvClDq6rqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dUI0Akm1EeaKuvClDq6rqA" points="[0, 0, -198, 68]$[198, 0, 0, 68]$[198, -68, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dV68sEm1EeaKuvClDq6rqA" id="(1.0,0.25862068965517243)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dV68sUm1EeaKuvClDq6rqA" id="(0.10160427807486631,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dUvQ90m1EeaKuvClDq6rqA" type="StereotypeCommentLink" source="_dUI0AEm1EeaKuvClDq6rqA" target="_dUvQ80m1EeaKuvClDq6rqA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dUvQ-Em1EeaKuvClDq6rqA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dUvQ_Em1EeaKuvClDq6rqA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Usage" href="TapiTopology.uml#_dT_qEEm1EeaKuvClDq6rqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dUvQ-Um1EeaKuvClDq6rqA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dUvQ-km1EeaKuvClDq6rqA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dUvQ-0m1EeaKuvClDq6rqA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xrS7gE0EEeabHNlo0UKXdA" type="4001" source="_i9LREDBDEea4fKwSGMr6CA" target="_i9LRtzBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_xrS7g00EEeabHNlo0UKXdA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xrS7hE0EEeabHNlo0UKXdA" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xrS7hE0EEeabHNlo0UKXdA" x="9" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_xrS7hU0EEeabHNlo0UKXdA" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_xrS7hk0EEeabHNlo0UKXdA" x="26" y="3"/>
@@ -3185,10 +3126,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_So9mMMhmEeaVlemTikmRHw" type="4001" source="_PTdqAshmEeaVlemTikmRHw" target="_q5U4gETtEead1bezhJG4aw">
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mM8hmEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNMhmEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNMhmEeaVlemTikmRHw" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mNchmEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNshmEeaVlemTikmRHw" x="-6" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNshmEeaVlemTikmRHw" x="-18" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mN8hmEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mOMhmEeaVlemTikmRHw" y="-20"/>
@@ -3220,10 +3161,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3Vf_kMhmEeaVlemTikmRHw" type="4001" source="_PTdqAshmEeaVlemTikmRHw" target="_i9BgRjBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_k8hmEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lMhmEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lMhmEeaVlemTikmRHw" x="-21" y="-36"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_lchmEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lshmEeaVlemTikmRHw" x="-23" y="-75"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lshmEeaVlemTikmRHw" x="-22" y="-51"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_l8hmEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_mMhmEeaVlemTikmRHw" y="-20"/>
@@ -3242,16 +3183,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Vf_kshmEeaVlemTikmRHw" points="[0, 0, -229, -104]$[0, 104, -229, 0]$[149, 104, -80, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkMhmEeaVlemTikmRHw" id="(0.6730769230769231,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkchmEeaVlemTikmRHw" id="(0.42780748663101603,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3WkWl8hmEeaVlemTikmRHw" type="StereotypeCommentLink" source="_3Vf_kMhmEeaVlemTikmRHw" target="_3WkWk8hmEeaVlemTikmRHw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3WkWmMhmEeaVlemTikmRHw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3WqdMMhmEeaVlemTikmRHw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3WkWmchmEeaVlemTikmRHw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WkWmshmEeaVlemTikmRHw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3WkWm8hmEeaVlemTikmRHw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_p9y9gBM3Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_p9gpoBM3Eee0L_IMWjydgQ" target="_p9s27hM3Eee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_p9y9gRM3Eee0L_IMWjydgQ"/>
@@ -3285,6 +3216,54 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v5TSqRM3Eee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v5TSqhM3Eee0L_IMWjydgQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v5TSqxM3Eee0L_IMWjydgQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uMDXQEpZEeexQa2RWFy3AQ" type="4001" source="_i9LREDBDEea4fKwSGMr6CA" target="_i9LREDBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMFzgEpZEeexQa2RWFy3AQ" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGakEpZEeexQa2RWFy3AQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMGakUpZEeexQa2RWFy3AQ" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGakkpZEeexQa2RWFy3AQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMGak0pZEeexQa2RWFy3AQ" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGalEpZEeexQa2RWFy3AQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMGalUpZEeexQa2RWFy3AQ" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGalkpZEeexQa2RWFy3AQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMHBoEpZEeexQa2RWFy3AQ" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMHBoUpZEeexQa2RWFy3AQ" x="15" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uMHBokpZEeexQa2RWFy3AQ" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMHBo0pZEeexQa2RWFy3AQ" x="-13" y="-12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_uMDXQUpZEeexQa2RWFy3AQ"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_G1pfMNnfEeWIOYiRCk5bbQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMDXQkpZEeexQa2RWFy3AQ" points="[0, 0, 115, 0]$[0, 49, 115, 49]$[-115, 49, 0, 49]$[-115, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMI20EpZEeexQa2RWFy3AQ" id="(0.922077922077922,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMI20UpZEeexQa2RWFy3AQ" id="(0.17532467532467533,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BMhsoUpcEeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_3Vf_kMhmEeaVlemTikmRHw" target="_BMhFkEpcEeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BMhsokpcEeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BMiTskpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BMhso0pcEeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BMiTsEpcEeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BMiTsUpcEeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nnfc8EvsEee8IN5myVB_oQ" type="4005" source="_q5U4gETtEead1bezhJG4aw" target="_i9BgkzBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nngEAEvsEee8IN5myVB_oQ" type="6012">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nngEAUvsEee8IN5myVB_oQ" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nngEAkvsEee8IN5myVB_oQ" type="6013">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nngEA0vsEee8IN5myVB_oQ" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nnfc8UvsEee8IN5myVB_oQ"/>
+      <element xmi:type="uml:Realization" href="TapiTopology.uml#_nneO0EvsEee8IN5myVB_oQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nnfc8kvsEee8IN5myVB_oQ" points="[34, 58, 31, -50]$[3, 108, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_noneUEvsEee8IN5myVB_oQ" id="(0.4576271186440678,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_noneUUvsEee8IN5myVB_oQ" id="(0.41899441340782123,0.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_vy9qUBk7EeeV4o0osG5stg" type="PapyrusUMLClassDiagram" name="NodeConstraints" measurementUnit="Pixel">
@@ -3500,7 +3479,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9W6Xkxk7EeeV4o0osG5stg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_9W0Q4Bk7EeeV4o0osG5stg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9W6XgRk7EeeV4o0osG5stg" x="759" y="118" height="192"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9W6XgRk7EeeV4o0osG5stg" x="790" y="117" height="192"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9XAeLhk7EeeV4o0osG5stg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9XAeLxk7EeeV4o0osG5stg" showTitle="true"/>
@@ -3554,7 +3533,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JC2aQxk8EeeV4o0osG5stg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_JCwTkBk8EeeV4o0osG5stg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JC2aMRk8EeeV4o0osG5stg" x="478" y="417" height="125"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JC2aMRk8EeeV4o0osG5stg" x="488" y="417" height="125"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JDCnfhk8EeeV4o0osG5stg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_JDCnfxk8EeeV4o0osG5stg" showTitle="true"/>
@@ -3632,6 +3611,30 @@
       <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_5Mca0Bk-EeeV4o0osG5stg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5Mca0hk-EeeV4o0osG5stg" x="198" y="428"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_UexZY0pcEeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UexZZEpcEeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UexZZkpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UexZZUpcEeexQa2RWFy3AQ" x="284" y="99"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mIg3Q0pcEeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mIg3REpcEeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mIg3RkpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_u4xdgBk8EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mIg3RUpcEeexQa2RWFy3AQ" x="290" y="-131"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_t2TCUEpcEeexQa2RWFy3AQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_t2TCUUpcEeexQa2RWFy3AQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t2TCU0pcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_Qw4ncBk9EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t2TCUkpcEeexQa2RWFy3AQ" x="547" y="18"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vy9qURk7EeeV4o0osG5stg" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vy9qUhk7EeeV4o0osG5stg"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_vy9qUxk7EeeV4o0osG5stg">
@@ -3690,7 +3693,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qaIvABk8EeeV4o0osG5stg" type="4001" source="_1uyIgBk7EeeV4o0osG5stg" target="_4nWREBk7EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_qaIvAxk8EeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qaIvBBk8EeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qaIvBBk8EeeV4o0osG5stg" x="16" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qaIvBRk8EeeV4o0osG5stg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_qaIvBhk8EeeV4o0osG5stg" x="30" y="8"/>
@@ -3715,7 +3718,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_u6_rEBk8EeeV4o0osG5stg" type="4001" source="_4nWREBk7EeeV4o0osG5stg" target="_xHZGoBk7EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_u6_rExk8EeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_u6_rFBk8EeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_u6_rFBk8EeeV4o0osG5stg" x="-53" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_u6_rFRk8EeeV4o0osG5stg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_u6_rFhk8EeeV4o0osG5stg" x="-48" y="-13"/>
@@ -3765,7 +3768,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QxRB8Bk9EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_9W6XgBk7EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_QxRB8xk9EeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QxRB9Bk9EeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QxRB9Bk9EeeV4o0osG5stg" x="-2" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QxRB9Rk9EeeV4o0osG5stg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_QxRB9hk9EeeV4o0osG5stg" y="-11"/>
@@ -3809,8 +3812,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_bjfOYRk9EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_bjGM0Bk9EeeV4o0osG5stg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bjfOYhk9EeeV4o0osG5stg" points="[0, 0, 230, 0]$[0, -47, 230, -47]$[-230, -47, 0, -47]$[-230, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bkOOMBk9EeeV4o0osG5stg" id="(0.1601423487544484,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bjfOYhk9EeeV4o0osG5stg" points="[0, 0, 261, -1]$[0, -47, 261, -48]$[-261, -47, 0, -48]$[-261, 1, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bkOOMBk9EeeV4o0osG5stg" id="(0.15719063545150502,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bkOOMRk9EeeV4o0osG5stg" id="(0.8513011152416357,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ljTtgBk9EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_JC2aMBk8EeeV4o0osG5stg">
@@ -3836,7 +3839,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_li1MYBk9EeeV4o0osG5stg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ljTtghk9EeeV4o0osG5stg" points="[0, 0, -200, -87]$[200, 87, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Bk9EeeV4o0osG5stg" id="(0.7174721189591078,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Rk9EeeV4o0osG5stg" id="(0.14385150812064965,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Rk9EeeV4o0osG5stg" id="(0.12064965197215777,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VckeABk-EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_1uyIgBk7EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_VckeAxk-EeeV4o0osG5stg" type="6001">
@@ -3911,7 +3914,37 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_zPz88BlBEeeV4o0osG5stg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zQMXchlBEeeV4o0osG5stg" points="[0, 0, 327, -214]$[-327, 214, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRWOABlBEeeV4o0osG5stg" id="(0.25418060200668896,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRWOARlBEeeV4o0osG5stg" id="(0.8283062645011601,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRWOARlBEeeV4o0osG5stg" id="(0.877030162412993,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UexZZ0pcEeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_qaIvABk8EeeV4o0osG5stg" target="_UexZY0pcEeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UexZaEpcEeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UeyAckpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UexZaUpcEeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeyAcEpcEeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UeyAcUpcEeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mIg3R0pcEeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_u6_rEBk8EeeV4o0osG5stg" target="_mIg3Q0pcEeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mIg3SEpcEeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mIg3TEpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_u4xdgBk8EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mIg3SUpcEeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIg3SkpcEeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIg3S0pcEeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_t2TCVEpcEeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_QxRB8Bk9EeeV4o0osG5stg" target="_t2TCUEpcEeexQa2RWFy3AQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_t2TCVUpcEeexQa2RWFy3AQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t2TCWUpcEeexQa2RWFy3AQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_Qw4ncBk9EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_t2TCVkpcEeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t2TCV0pcEeexQa2RWFy3AQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t2TCWEpcEeexQa2RWFy3AQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -34,7 +34,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BzvyfTBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq69v-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BzvykDBDEea4fKwSGMr6CA" x="494" y="267" height="96"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BzvykDBDEea4fKwSGMr6CA" x="258" y="14" height="96"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bz48ADBDEea4fKwSGMr6CA" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_Bz48ATBDEea4fKwSGMr6CA" type="5035"/>
@@ -69,62 +69,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz48bTBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz48gDBDEea4fKwSGMr6CA" x="225" y="266" width="196" height="98"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bz48gTBDEea4fKwSGMr6CA" type="2010">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Bz48gjBDEea4fKwSGMr6CA" type="5035"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Bz48gzBDEea4fKwSGMr6CA" type="8502">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz48hDBDEea4fKwSGMr6CA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Bz48hTBDEea4fKwSGMr6CA" type="7020">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cQFZMEm5EeaKuvClDq6rqA" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cQFZMUm5EeaKuvClDq6rqA" key="showTitle" value="true"/>
-        </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_Bz48hjBDEea4fKwSGMr6CA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_rNbewr1-EeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz48pTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0YR40D6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_zB_30D6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0YR40T6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp0D6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_FKRr0D6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp0T6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp0j6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_VJ4jID6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp0z6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp1D6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_aMoEQD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp1T6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp1j6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_g9oeAD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp1z6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp2D6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_or7mcD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp2T6jEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0Ybp2j6jEeai_egNtQKqQA" type="3018">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_u_PXkD6jEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0Ybp2z6jEeai_egNtQKqQA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Bz49BjBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Bz49BzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bz49CDBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49CTBDEea4fKwSGMr6CA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Bz49CjBDEea4fKwSGMr6CA" visible="false" type="7021">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Bz49CzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Bz49DDBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bz49DTBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49DjBDEea4fKwSGMr6CA"/>
-      </children>
-      <element xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49ITBDEea4fKwSGMr6CA" x="174" y="30" width="302" height="175"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz48gDBDEea4fKwSGMr6CA" x="20" y="16" width="196" height="98"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bz49IjBDEea4fKwSGMr6CA" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_Bz49IzBDEea4fKwSGMr6CA" type="5035"/>
@@ -167,61 +112,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49bzBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49gjBDEea4fKwSGMr6CA" x="499" y="127" height="128"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Bz49gzBDEea4fKwSGMr6CA" type="2006">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Bz49hDBDEea4fKwSGMr6CA" type="5023"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Bz49hTBDEea4fKwSGMr6CA" type="8508">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49hjBDEea4fKwSGMr6CA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Bz49hzBDEea4fKwSGMr6CA" type="7015">
-        <children xmi:type="notation:Shape" xmi:id="_Bz49iDBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_HBQVkL2AEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49iTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49ijBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1YyV8L1yEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49izBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49jDBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_z7f4kL1yEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49jTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49jjBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_7cCR0L1yEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49jzBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49kDBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_gyYdML1zEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49kTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49kjBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_Ye91gL1zEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49kzBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49lDBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_bhtNwL1zEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49lTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49ljBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_x85d4L1yEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49lzBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49mDBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_oRItwL1zEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49mTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bz49mjBDEea4fKwSGMr6CA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_mXlyML1zEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bz49mzBDEea4fKwSGMr6CA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Bz49nDBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Bz49nTBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Bz49njBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49nzBDEea4fKwSGMr6CA"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_smkSYL1yEeWdore3Cxez9g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49sjBDEea4fKwSGMr6CA" x="22" y="32" height="201"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz49gjBDEea4fKwSGMr6CA" x="282" y="138" height="128"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bz49szBDEea4fKwSGMr6CA" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_Bz49tDBDEea4fKwSGMr6CA" type="5035"/>
@@ -252,7 +143,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz4-ADBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqz9v-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz4-EzBDEea4fKwSGMr6CA" x="512" y="32" height="81"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bz4-EzBDEea4fKwSGMr6CA" x="29" y="143" height="81"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EsxwjDBKEeaSroGqGbZ6jg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_EsxwjTBKEeaSroGqGbZ6jg" showTitle="true"/>
@@ -302,40 +193,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EtXmbjBKEeaSroGqGbZ6jg" x="392" y="181"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_eP2ekD6iEeai_egNtQKqQA" type="2006">
-      <children xmi:type="notation:DecorationNode" xmi:id="_eP2ekj6iEeai_egNtQKqQA" type="5023"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_eQAPkD6iEeai_egNtQKqQA" type="8508">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_eQAPkT6iEeai_egNtQKqQA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_eQAPkj6iEeai_egNtQKqQA" type="7015">
-        <children xmi:type="notation:Shape" xmi:id="_fbvC4D6iEeai_egNtQKqQA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_Lrs40D6gEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fbvC4T6iEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fbvC4j6iEeai_egNtQKqQA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_PYdMgD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fbvC4z6iEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fbvC5D6iEeai_egNtQKqQA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_R0GvkD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fbvC5T6iEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fbvC5j6iEeai_egNtQKqQA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_VNVVMD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fbvC5z6iEeai_egNtQKqQA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fbvC6D6iEeai_egNtQKqQA" type="3017">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_YMrbMD6iEeai_egNtQKqQA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fbvC6T6iEeai_egNtQKqQA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_eQAPkz6iEeai_egNtQKqQA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_eQAPlD6iEeai_egNtQKqQA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_eQAPlT6iEeai_egNtQKqQA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eQAPlj6iEeai_egNtQKqQA"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_EuZIcD6gEeai_egNtQKqQA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eP2ekT6iEeai_egNtQKqQA" x="30" y="247"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_eQTKgD6iEeai_egNtQKqQA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_eQTKgT6iEeai_egNtQKqQA" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eQTKgz6iEeai_egNtQKqQA" name="BASE_ELEMENT">
@@ -343,6 +200,74 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eQTKgj6iEeai_egNtQKqQA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dqCTUEwCEeewALXL7BvPYw" type="2006">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dqDhcEwCEeewALXL7BvPYw" type="5023"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dqEIgEwCEeewALXL7BvPYw" type="8508">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dqEIgUwCEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dqEIgkwCEeewALXL7BvPYw" type="7015">
+        <children xmi:type="notation:Shape" xmi:id="_eiN4gEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_z1arwBk-EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiN4gUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eiOfkEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_1t3bIBk-EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiOfkUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eiOfkkwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_2a3rEBk-EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiOfk0wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eiPGoEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_JFlRYBl5EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiPGoUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eiPGokwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_3SEY0Bk-EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiPGo0wCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eiPGpEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_nR7FcBl_EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eiPtsEwCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dqEIg0wCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dqEIhEwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dqEIhUwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqEIhkwCEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_u1jfgBk-EeeV4o0osG5stg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqCTUUwCEeewALXL7BvPYw" x="63" y="250"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gUZAwEwCEeewALXL7BvPYw" type="2006">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gUZAwkwCEeewALXL7BvPYw" type="5023"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gUZAw0wCEeewALXL7BvPYw" type="8508">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gUZAxEwCEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gUZAxUwCEeewALXL7BvPYw" type="7015">
+        <children xmi:type="notation:Shape" xmi:id="_hHTrcEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_EihiQBk_EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hHTrcUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_hHUSgEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_GcYm4Bk_EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hHUSgUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_hHU5kEwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_CKy14Bk_EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hHU5kUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_hHU5kkwCEeewALXL7BvPYw" type="3017">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiTopology.uml#_ymf6YBlmEeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_hHU5k0wCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gUZAxkwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gUZAx0wCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gUZAyEwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gUZAyUwCEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="TapiTopology.uml#_5Mca0Bk-EeeV4o0osG5stg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gUZAwUwCEeewALXL7BvPYw" x="223" y="283"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_717IwTBCEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_717IwjBCEea4fKwSGMr6CA"/>
@@ -370,16 +295,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Es66ejBKEeaSroGqGbZ6jg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Es66ezBKEeaSroGqGbZ6jg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Es66-TBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_Bz48gTBDEea4fKwSGMr6CA" target="_Es669TBKEeaSroGqGbZ6jg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Es66-jBKEeaSroGqGbZ6jg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Es66_jBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Es66-zBKEeaSroGqGbZ6jg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Es66_DBKEeaSroGqGbZ6jg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Es66_TBKEeaSroGqGbZ6jg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EtEr-DBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_Bz49IjBDEea4fKwSGMr6CA" target="_EtEr9DBKEeaSroGqGbZ6jg">
       <styles xmi:type="notation:FontStyle" xmi:id="_EtEr-TBKEeaSroGqGbZ6jg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtEr_TBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
@@ -390,16 +305,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtEr-zBKEeaSroGqGbZ6jg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtEr_DBKEeaSroGqGbZ6jg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EtN1rDBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_Bz49gzBDEea4fKwSGMr6CA" target="_EtN1qDBKEeaSroGqGbZ6jg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_EtN1rTBKEeaSroGqGbZ6jg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtN1sTBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Enumeration" href="TapiTopology.uml#_smkSYL1yEeWdore3Cxez9g"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EtN1rjBKEeaSroGqGbZ6jg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtN1rzBKEeaSroGqGbZ6jg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtN1sDBKEeaSroGqGbZ6jg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EtXmcDBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_Bz49szBDEea4fKwSGMr6CA" target="_EtXmbDBKEeaSroGqGbZ6jg">
       <styles xmi:type="notation:FontStyle" xmi:id="_EtXmcTBKEeaSroGqGbZ6jg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EtXmdTBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
@@ -409,16 +314,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EtXmcjBKEeaSroGqGbZ6jg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtXmczBKEeaSroGqGbZ6jg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EtXmdDBKEeaSroGqGbZ6jg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eQTKhD6iEeai_egNtQKqQA" type="StereotypeCommentLink" source="_eP2ekD6iEeai_egNtQKqQA" target="_eQTKgD6iEeai_egNtQKqQA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_eQTKhT6iEeai_egNtQKqQA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eQTKiT6iEeai_egNtQKqQA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Enumeration" href="TapiTopology.uml#_EuZIcD6gEeai_egNtQKqQA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eQTKhj6iEeai_egNtQKqQA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eQTKhz6iEeai_egNtQKqQA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eQTKiD6iEeai_egNtQKqQA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_JS4dIDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="EdgePointDetails" measurementUnit="Pixel">
@@ -905,7 +800,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvSYUjBDEea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvSYgDBDEea4fKwSGMr6CA" x="515" y="-26" height="134"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvSYgDBDEea4fKwSGMr6CA" x="515" y="-26" height="123"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_WvSYxjBDEea4fKwSGMr6CA" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_WvSYxzBDEea4fKwSGMr6CA" type="5029"/>
@@ -1162,51 +1057,6 @@
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvbkWDBDEea4fKwSGMr6CA" x="-333" y="106" height="286"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_WvbkhDBDEea4fKwSGMr6CA" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvbkhTBDEea4fKwSGMr6CA" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvbkhjBDEea4fKwSGMr6CA" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvbkhzBDEea4fKwSGMr6CA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WvbkiDBDEea4fKwSGMr6CA" type="7017">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_l6BZ0Em3EeaKuvClDq6rqA" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_l6BZ0Um3EeaKuvClDq6rqA" key="showTitle" value="true"/>
-        </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_WvbkiTBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvbkqDBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvbkqTBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvbkyDBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvbkyTBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_KjZXPdyKEeWXdJnxZxtFYA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Wvbk6DBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Wvbk6TBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_KjZXQdyKEeWXdJnxZxtFYA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvblCDBDEea4fKwSGMr6CA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WvblCTBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WvblCjBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WvblCzBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvblDDBDEea4fKwSGMr6CA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WvblDTBDEea4fKwSGMr6CA" visible="false" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WvblDjBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WvblDzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WvblEDBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvblETBDEea4fKwSGMr6CA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_WvblEjBDEea4fKwSGMr6CA" visible="false" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_WvblEzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_WvblFDBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_WvblFTBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvblFjBDEea4fKwSGMr6CA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiTopology.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvblRDBDEea4fKwSGMr6CA" x="110" y="-38" width="279" height="116"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_WvblRTBDEea4fKwSGMr6CA" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_WvblRjBDEea4fKwSGMr6CA" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_WvblRzBDEea4fKwSGMr6CA" type="8510">
@@ -1423,14 +1273,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WxhMgjBDEea4fKwSGMr6CA" x="243" y="385"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_Wy2pQDBDEea4fKwSGMr6CA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Wy2pQTBDEea4fKwSGMr6CA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wy2pQzBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wy2pQjBDEea4fKwSGMr6CA" x="-218" y="95"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_Wy2pXjBDEea4fKwSGMr6CA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Wy2pXzBDEea4fKwSGMr6CA" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wy2pYTBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
@@ -1494,14 +1336,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WzAaYDBDEea4fKwSGMr6CA" x="-218" y="95"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_WzcfKjBDEea4fKwSGMr6CA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_WzcfKzBDEea4fKwSGMr6CA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WzcfLTBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WzcfLDBDEea4fKwSGMr6CA" x="213" y="-43"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W0MGCjBDEea4fKwSGMr6CA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_W0MGCzBDEea4fKwSGMr6CA" showTitle="true"/>
@@ -1615,37 +1449,70 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qXQM6EYDEeaB8vMnkFQLXQ" x="-217" y="410"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_r05PgEwCEeewALXL7BvPYw" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_r052kEwCEeewALXL7BvPYw" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r052kUwCEeewALXL7BvPYw" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r052kkwCEeewALXL7BvPYw" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r052k0wCEeewALXL7BvPYw" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_tJDmEEwCEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tJDmEUwCEeewALXL7BvPYw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_tJDmEkwCEeewALXL7BvPYw" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_tJDmE0wCEeewALXL7BvPYw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r052lEwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r052lUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r052lkwCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r052l0wCEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r052mEwCEeewALXL7BvPYw" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r052mUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r052mkwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r052m0wCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r052nEwCEeewALXL7BvPYw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_r06doEwCEeewALXL7BvPYw" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_r06doUwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_r06dokwCEeewALXL7BvPYw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_r06do0wCEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r06dpEwCEeewALXL7BvPYw"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r05PgUwCEeewALXL7BvPYw" x="135" y="-4" height="88"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_r1JHI0wCEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r1JHJEwCEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r1JHJkwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r1JHJUwCEeewALXL7BvPYw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_r3xkYEwCEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_r3xkYUwCEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r3xkY0wCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r3xkYkwCEeewALXL7BvPYw" x="419" y="-87"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uoq-s0wCEeewALXL7BvPYw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_uoq-tEwCEeewALXL7BvPYw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uoq-tkwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uoq-tUwCEeewALXL7BvPYw" x="335" y="-104"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_SFF5oTBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_SFF5ojBDEea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_SFF5ozBDEea4fKwSGMr6CA">
       <owner xmi:type="uml:Package" href="TapiTopology.uml#_SXc0sC5xEea0_JngOlSKcA"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiTopology.uml#_SXc0sC5xEea0_JngOlSKcA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_WvSYgTBDEea4fKwSGMr6CA" type="4001" source="_WvbikTBDEea4fKwSGMr6CA" target="_WvbkhDBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYgjBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYgzBDEea4fKwSGMr6CA" x="16" y="7"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYhDBDEea4fKwSGMr6CA" visible="false" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYhTBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYhjBDEea4fKwSGMr6CA" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYhzBDEea4fKwSGMr6CA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYiDBDEea4fKwSGMr6CA" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYiTBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYijBDEea4fKwSGMr6CA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYizBDEea4fKwSGMr6CA" x="20" y="-15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvSYjDBDEea4fKwSGMr6CA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYjTBDEea4fKwSGMr6CA" x="-4" y="-16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_WvSYjjBDEea4fKwSGMr6CA"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvSYlTBDEea4fKwSGMr6CA" points="[0, 0, -155, 88]$[155, -88, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvSYljBDEea4fKwSGMr6CA" id="(1.0,0.13986013986013987)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvSYlzBDEea4fKwSGMr6CA" id="(0.0,0.6982758620689655)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WvSYmDBDEea4fKwSGMr6CA" type="4001" source="_WvbikTBDEea4fKwSGMr6CA" target="_Wvbh0DBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_WvSYmTBDEea4fKwSGMr6CA" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSYmjBDEea4fKwSGMr6CA" x="-1" y="4"/>
@@ -1770,31 +1637,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvlUkDBDEea4fKwSGMr6CA" points="[259, 28, -170, -20]$[429, 48, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlUkTBDEea4fKwSGMr6CA" id="(1.0,0.4117647058823529)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlUkjBDEea4fKwSGMr6CA" id="(0.0,0.14285714285714285)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_WvlU9DBDEea4fKwSGMr6CA" type="4001" source="_WvbkhDBDEea4fKwSGMr6CA" target="_WvSZKTBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU9TBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlU9jBDEea4fKwSGMr6CA" x="-32" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU9zBDEea4fKwSGMr6CA" visible="false" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlU-DBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU-TBDEea4fKwSGMr6CA" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlU-jBDEea4fKwSGMr6CA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU-zBDEea4fKwSGMr6CA" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlU_DBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU_TBDEea4fKwSGMr6CA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlU_jBDEea4fKwSGMr6CA" x="1" y="-16"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlU_zBDEea4fKwSGMr6CA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlVADBDEea4fKwSGMr6CA" x="-15" y="-12"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_WvlVATBDEea4fKwSGMr6CA"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvlVCDBDEea4fKwSGMr6CA" points="[257, 117, -175, -80]$[432, 197, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlVCTBDEea4fKwSGMr6CA" id="(1.0,0.7586206896551724)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlVCjBDEea4fKwSGMr6CA" id="(0.0,0.036734693877551024)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WvlVCzBDEea4fKwSGMr6CA" type="4001" source="_WvbikTBDEea4fKwSGMr6CA" target="_WvlUkzBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_WvlVDDBDEea4fKwSGMr6CA" type="6001">
@@ -2071,16 +1913,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WxhMhzBDEea4fKwSGMr6CA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WxhMiDBDEea4fKwSGMr6CA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Wy2pRDBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvSYgTBDEea4fKwSGMr6CA" target="_Wy2pQDBDEea4fKwSGMr6CA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Wy2pRTBDEea4fKwSGMr6CA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wy2pSTBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Wy2pRjBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wy2pRzBDEea4fKwSGMr6CA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Wy2pSDBDEea4fKwSGMr6CA"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Wy2pYjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvlWMzBDEea4fKwSGMr6CA" target="_Wy2pXjBDEea4fKwSGMr6CA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Wy2pYzBDEea4fKwSGMr6CA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wy2pZzBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
@@ -2150,16 +1982,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WzAaRjBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WzAaRzBDEea4fKwSGMr6CA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WzAaSDBDEea4fKwSGMr6CA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_WzcfLjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvlU9DBDEea4fKwSGMr6CA" target="_WzcfKjBDEea4fKwSGMr6CA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_WzcfLzBDEea4fKwSGMr6CA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WzcfMzBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WzcfMDBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WzcfMTBDEea4fKwSGMr6CA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WzcfMjBDEea4fKwSGMr6CA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_W0MGDjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvlVIjBDEea4fKwSGMr6CA" target="_W0MGCjBDEea4fKwSGMr6CA">
       <styles xmi:type="notation:FontStyle" xmi:id="_W0MGDzBDEea4fKwSGMr6CA"/>
@@ -2241,16 +2063,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ej_oPzBKEeaSroGqGbZ6jg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ej_oQDBKEeaSroGqGbZ6jg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ElL6-TBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_WvbkhDBDEea4fKwSGMr6CA" target="_ElL69TBKEeaSroGqGbZ6jg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ElL6-jBKEeaSroGqGbZ6jg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ElL6_jBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ElL6-zBKEeaSroGqGbZ6jg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ElL6_DBKEeaSroGqGbZ6jg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ElL6_TBKEeaSroGqGbZ6jg"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Ele16TBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_WvblRTBDEea4fKwSGMr6CA" target="_Ele15TBKEeaSroGqGbZ6jg">
       <styles xmi:type="notation:FontStyle" xmi:id="_Ele16jBKEeaSroGqGbZ6jg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ele17jBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
@@ -2300,6 +2112,86 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qXQM7EYDEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qXQM7UYDEeaB8vMnkFQLXQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qXQM7kYDEeaB8vMnkFQLXQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r1JHJ0wCEeewALXL7BvPYw" type="StereotypeCommentLink" source="_r05PgEwCEeewALXL7BvPYw" target="_r1JHI0wCEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r1JHKEwCEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r1JHLEwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r1JHKUwCEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r1JHKkwCEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r1JHK0wCEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r27P0EwCEeewALXL7BvPYw" type="4001" source="_r05PgEwCEeewALXL7BvPYw" target="_WvSZKTBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P00wCEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r27P1EwCEeewALXL7BvPYw" x="-27" y="-5"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P1UwCEeewALXL7BvPYw" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r27P1kwCEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P10wCEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r27P2EwCEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P2UwCEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r27P2kwCEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P20wCEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r27P3EwCEeewALXL7BvPYw" x="3" y="-12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_r27P3UwCEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_r2724EwCEeewALXL7BvPYw" x="-8" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_r27P0UwCEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r27P0kwCEeewALXL7BvPYw" points="[0, 0, -522, -180]$[522, 180, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r2724UwCEeewALXL7BvPYw" id="(1.0,0.7045454545454546)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r2724kwCEeewALXL7BvPYw" id="(0.0,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_r3xkZEwCEeewALXL7BvPYw" type="StereotypeCommentLink" source="_r27P0EwCEeewALXL7BvPYw" target="_r3xkYEwCEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_r3xkZUwCEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_r3xkaUwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_r3xkZkwCEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r3xkZ0wCEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_r3xkaEwCEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_un6JsEwCEeewALXL7BvPYw" type="4001" source="_r05PgEwCEeewALXL7BvPYw" target="_WvbikTBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6Js0wCEeewALXL7BvPYw" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6JtEwCEeewALXL7BvPYw" x="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6JtUwCEeewALXL7BvPYw" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6JtkwCEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6Jt0wCEeewALXL7BvPYw" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6JuEwCEeewALXL7BvPYw" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6JuUwCEeewALXL7BvPYw" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6JukwCEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6Ju0wCEeewALXL7BvPYw" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6wwEwCEeewALXL7BvPYw" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_un6wwUwCEeewALXL7BvPYw" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_un6wwkwCEeewALXL7BvPYw" x="-18" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_un6JsUwCEeewALXL7BvPYw"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_un6JskwCEeewALXL7BvPYw" points="[0, 0, 185, -140]$[-185, 140, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_un6ww0wCEeewALXL7BvPYw" id="(0.0,0.4090909090909091)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_un6wxEwCEeewALXL7BvPYw" id="(1.0,0.1048951048951049)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uoq-t0wCEeewALXL7BvPYw" type="StereotypeCommentLink" source="_un6JsEwCEeewALXL7BvPYw" target="_uoq-s0wCEeewALXL7BvPYw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uoq-uEwCEeewALXL7BvPYw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_uoq-vEwCEeewALXL7BvPYw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uoq-uUwCEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uoq-ukwCEeewALXL7BvPYw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uoq-u0wCEeewALXL7BvPYw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_d6faUDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceSkeleton" measurementUnit="Pixel">
@@ -3750,7 +3642,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_8zK70Rk8EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_8y7EMBk8EeeV4o0osG5stg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8zK70hk8EeeV4o0osG5stg" points="[0, 0, 129, 0]$[0, -51, 129, -51]$[-129, -51, 0, -51]$[-129, 0, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8zK70hk8EeeV4o0osG5stg" points="[0, 0, 121, 0]$[0, -51, 121, -51]$[-121, -51, 0, -51]$[-121, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80XOoBk8EeeV4o0osG5stg" id="(0.6932773109243697,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_80XOoRk8EeeV4o0osG5stg" id="(0.21428571428571427,0.0)"/>
     </edges>
@@ -3800,13 +3692,13 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_bjfOYRk9EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_bjGM0Bk9EeeV4o0osG5stg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bjfOYhk9EeeV4o0osG5stg" points="[0, 0, 261, -1]$[0, -47, 261, -48]$[-261, -47, 0, -48]$[-261, 1, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bjfOYhk9EeeV4o0osG5stg" points="[0, 0, 275, -1]$[0, -47, 275, -48]$[-275, -47, 0, -48]$[-275, 1, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bkOOMBk9EeeV4o0osG5stg" id="(0.15719063545150502,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bkOOMRk9EeeV4o0osG5stg" id="(0.8513011152416357,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ljTtgBk9EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_JC2aMBk8EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_ljTtgxk9EeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthBk9EeeV4o0osG5stg" x="9" y="-8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthBk9EeeV4o0osG5stg" x="2" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ljTthRk9EeeV4o0osG5stg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthhk9EeeV4o0osG5stg" x="-10" y="-3"/>
@@ -3826,7 +3718,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_ljTtgRk9EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_li1MYBk9EeeV4o0osG5stg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ljTtghk9EeeV4o0osG5stg" points="[0, 0, -200, -87]$[200, 87, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Bk9EeeV4o0osG5stg" id="(0.7174721189591078,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Bk9EeeV4o0osG5stg" id="(0.7628458498023716,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lj-b4Rk9EeeV4o0osG5stg" id="(0.12064965197215777,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VckeABk-EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_1uyIgBk7EeeV4o0osG5stg">

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -2507,7 +2507,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_PTdqBchmEeaVlemTikmRHw" type="8510">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_PTdqBshmEeaVlemTikmRHw" y="5"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_PTdqB8hmEeaVlemTikmRHw" type="7017">
+      <children xmi:type="notation:BasicCompartment" xmi:id="_PTdqB8hmEeaVlemTikmRHw" visible="false" type="7017">
         <children xmi:type="notation:Shape" xmi:id="__9VYEshmEeaVlemTikmRHw" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_SoY-dMhmEeaVlemTikmRHw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="__9VYE8hmEeaVlemTikmRHw"/>
@@ -2534,7 +2534,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PTdqFchmEeaVlemTikmRHw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PTdqA8hmEeaVlemTikmRHw" x="-141" y="-226" height="96"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PTdqA8hmEeaVlemTikmRHw" x="-81" y="-214" width="164" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_PTjwu8hmEeaVlemTikmRHw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_PTjwvMhmEeaVlemTikmRHw" showTitle="true"/>
@@ -2582,7 +2582,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpsxM3Eee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpoRM3Eee0L_IMWjydgQ" x="412" y="-221" height="82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpoRM3Eee0L_IMWjydgQ" x="412" y="-206" height="71"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_p9s27hM3Eee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_p9s27xM3Eee0L_IMWjydgQ" showTitle="true"/>
@@ -2998,10 +2998,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_So9mMMhmEeaVlemTikmRHw" type="4001" source="_PTdqAshmEeaVlemTikmRHw" target="_q5U4gETtEead1bezhJG4aw">
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mM8hmEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNMhmEeaVlemTikmRHw" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNMhmEeaVlemTikmRHw" x="-10" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mNchmEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNshmEeaVlemTikmRHw" x="-18" y="-7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mNshmEeaVlemTikmRHw" x="-28" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_So9mN8hmEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_So9mOMhmEeaVlemTikmRHw" y="-20"/>
@@ -3018,8 +3018,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_So9mMchmEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_SoY-cMhmEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_So9mMshmEeaVlemTikmRHw" points="[-7, 17, 13, -38]$[3, 42, 23, -13]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SrJ-kMhmEeaVlemTikmRHw" id="(0.25961538461538464,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SrJ-kchmEeaVlemTikmRHw" id="(0.4689265536723164,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SrJ-kMhmEeaVlemTikmRHw" id="(0.22560975609756098,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SrJ-kchmEeaVlemTikmRHw" id="(0.559322033898305,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Sp0h18hmEeaVlemTikmRHw" type="StereotypeCommentLink" source="_So9mMMhmEeaVlemTikmRHw" target="_Sp0h08hmEeaVlemTikmRHw">
       <styles xmi:type="notation:FontStyle" xmi:id="_Sp0h2MhmEeaVlemTikmRHw"/>
@@ -3033,10 +3033,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3Vf_kMhmEeaVlemTikmRHw" type="4001" source="_PTdqAshmEeaVlemTikmRHw" target="_i9BgRjBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_k8hmEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lMhmEeaVlemTikmRHw" x="-21" y="-36"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lMhmEeaVlemTikmRHw" x="-16" y="-25"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_lchmEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lshmEeaVlemTikmRHw" x="-22" y="-51"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_lshmEeaVlemTikmRHw" x="-22" y="-42"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3Vf_l8hmEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3Vf_mMhmEeaVlemTikmRHw" y="-20"/>
@@ -3052,9 +3052,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_3Vf_kchmEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Vf_kshmEeaVlemTikmRHw" points="[0, 0, -229, -104]$[0, 104, -229, 0]$[149, 104, -80, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkMhmEeaVlemTikmRHw" id="(0.6730769230769231,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkchmEeaVlemTikmRHw" id="(0.42780748663101603,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Vf_kshmEeaVlemTikmRHw" points="[0, -1, -150, -120]$[0, 119, -150, 0]$[149, 118, -1, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkMhmEeaVlemTikmRHw" id="(0.9085365853658537,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3XVLkchmEeaVlemTikmRHw" id="(0.0,0.0546448087431694)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_p9y9gBM3Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_p9gpoBM3Eee0L_IMWjydgQ" target="_p9s27hM3Eee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_p9y9gRM3Eee0L_IMWjydgQ"/>
@@ -3071,13 +3071,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_tkf-dBM3Eee0L_IMWjydgQ" x="1" y="-14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_tkf-dRM3Eee0L_IMWjydgQ" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tkf-dhM3Eee0L_IMWjydgQ" x="-5" y="11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tkf-dhM3Eee0L_IMWjydgQ" x="-6" y="12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_tkf-cRM3Eee0L_IMWjydgQ"/>
       <element xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tkf-chM3Eee0L_IMWjydgQ" points="[17, -1, -251, 3]$[258, -7, -10, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlRagBM3Eee0L_IMWjydgQ" id="(1.0,0.40625)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlRagRM3Eee0L_IMWjydgQ" id="(0.0,0.3780487804878049)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlRagBM3Eee0L_IMWjydgQ" id="(1.0,0.4351851851851852)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tlRagRM3Eee0L_IMWjydgQ" id="(0.0,0.30985915492957744)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_v5TSpxM3Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_tkf-cBM3Eee0L_IMWjydgQ" target="_v5TSoxM3Eee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_v5TSqBM3Eee0L_IMWjydgQ"/>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -3316,10 +3316,6 @@
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_M44cgxl8EeeV4o0osG5stg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_M44chBl8EeeV4o0osG5stg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_M44chRl8EeeV4o0osG5stg"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_xHfNRBk7EeeV4o0osG5stg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_xHfNRRk7EeeV4o0osG5stg"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_xHfNRhk7EeeV4o0osG5stg"/>
@@ -3338,7 +3334,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xHfNURk7EeeV4o0osG5stg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xDuuoBk7EeeV4o0osG5stg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xHZGoRk7EeeV4o0osG5stg" x="347" y="118" height="224"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xHZGoRk7EeeV4o0osG5stg" x="347" y="118" height="206"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xHraixk7EeeV4o0osG5stg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_xHrajBk7EeeV4o0osG5stg" showTitle="true"/>
@@ -3456,10 +3452,6 @@
         <children xmi:type="notation:Shape" xmi:id="_Bzz6qhl-EeeV4o0osG5stg" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Bzz6qxl-EeeV4o0osG5stg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Bzz6rBl-EeeV4o0osG5stg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Bzz6rRl-EeeV4o0osG5stg"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_9W6Xhhk7EeeV4o0osG5stg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_9W6Xhxk7EeeV4o0osG5stg"/>
@@ -3635,6 +3627,22 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t2TCUkpcEeexQa2RWFy3AQ" x="547" y="18"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_MzFpg0vwEee8IN5myVB_oQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MzFphEvwEee8IN5myVB_oQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MzFphkvwEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_li1MYBk9EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MzFphUvwEee8IN5myVB_oQ" x="547" y="18"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OUFiM0vwEee8IN5myVB_oQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OUFiNEvwEee8IN5myVB_oQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OUFiNkvwEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_zPz88BlBEeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OUFiNUvwEee8IN5myVB_oQ" x="990" y="17"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vy9qURk7EeeV4o0osG5stg" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vy9qUhk7EeeV4o0osG5stg"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_vy9qUxk7EeeV4o0osG5stg">
@@ -3788,8 +3796,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_QxRB8Rk9EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_Qw4ncBk9EeeV4o0osG5stg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QxRB8hk9EeeV4o0osG5stg" points="[19, -1, -115, 2]$[114, 0, -20, 3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qya4gBk9EeeV4o0osG5stg" id="(1.0,0.41964285714285715)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qya4gRk9EeeV4o0osG5stg" id="(0.0,0.4895833333333333)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qya4gBk9EeeV4o0osG5stg" id="(1.0,0.470873786407767)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qya4gRk9EeeV4o0osG5stg" id="(0.0,0.5104166666666666)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_bjfOYBk9EeeV4o0osG5stg" type="4001" source="_9W6XgBk7EeeV4o0osG5stg" target="_xHZGoBk7EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_bjfOYxk9EeeV4o0osG5stg" type="6001">
@@ -3818,10 +3826,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ljTtgBk9EeeV4o0osG5stg" type="4001" source="_xHZGoBk7EeeV4o0osG5stg" target="_JC2aMBk8EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_ljTtgxk9EeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthBk9EeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthBk9EeeV4o0osG5stg" x="9" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ljTthRk9EeeV4o0osG5stg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthhk9EeeV4o0osG5stg" x="2" y="-3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTthhk9EeeV4o0osG5stg" x="-10" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ljTthxk9EeeV4o0osG5stg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ljTtiBk9EeeV4o0osG5stg" y="-20"/>
@@ -3863,7 +3871,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_VckeARk-EeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_VbhVIBk-EeeV4o0osG5stg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VckeAhk-EeeV4o0osG5stg" points="[0, 0, 128, -37]$[-112, 35, 16, -2]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VdiHUBk-EeeV4o0osG5stg" id="(0.0,0.5223214285714286)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VdiHUBk-EeeV4o0osG5stg" id="(0.0,0.5679611650485437)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VdiHURk-EeeV4o0osG5stg" id="(1.0,0.45569620253164556)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dvymgBlAEeeV4o0osG5stg" type="4001" source="_1uyIgBk7EeeV4o0osG5stg" target="_4nWREBk7EeeV4o0osG5stg">
@@ -3893,10 +3901,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_zQMXcBlBEeeV4o0osG5stg" type="4001" source="_9W6XgBk7EeeV4o0osG5stg" target="_JC2aMBk8EeeV4o0osG5stg">
       <children xmi:type="notation:DecorationNode" xmi:id="_zQMXcxlBEeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zQMXdBlBEeeV4o0osG5stg" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zQMXdBlBEeeV4o0osG5stg" x="2" y="8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_zQMXdRlBEeeV4o0osG5stg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zQMXdhlBEeeV4o0osG5stg" x="-3" y="-5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zQMXdhlBEeeV4o0osG5stg" x="-19" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_zQMXdxlBEeeV4o0osG5stg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_zQMXeBlBEeeV4o0osG5stg" y="-20"/>
@@ -3945,6 +3953,26 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_t2TCVkpcEeexQa2RWFy3AQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t2TCV0pcEeexQa2RWFy3AQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t2TCWEpcEeexQa2RWFy3AQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MzFph0vwEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_ljTtgBk9EeeV4o0osG5stg" target="_MzFpg0vwEee8IN5myVB_oQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MzFpiEvwEee8IN5myVB_oQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MzFpjEvwEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_li1MYBk9EeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MzFpiUvwEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MzFpikvwEee8IN5myVB_oQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MzFpi0vwEee8IN5myVB_oQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OUFiN0vwEee8IN5myVB_oQ" type="StereotypeCommentLink" source="_zQMXcBlBEeeV4o0osG5stg" target="_OUFiM0vwEee8IN5myVB_oQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OUFiOEvwEee8IN5myVB_oQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OUFiPEvwEee8IN5myVB_oQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_zPz88BlBEeeV4o0osG5stg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OUFiOUvwEee8IN5myVB_oQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OUFiOkvwEee8IN5myVB_oQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OUFiO0vwEee8IN5myVB_oQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -179,8 +179,6 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_euQ9YEHBEeWqPKyD1j6LMg" value="*"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_3Qgr4Em0EeaKuvClDq6rqA" name="OperatesOn" client="_-ht5oPMtEeSb-q8_djA2ng" supplier="_oCmjAETtEead1bezhJG4aw"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_dT_qEEm1EeaKuvClDq6rqA" name="Retrieves" client="_SXc0sC5xEea0_JngOlSKcA" supplier="_ejyEgOKyEeSq5fATALSQkQ"/>
       <packagedElement xmi:type="uml:Association" xmi:id="_SoY-cMhmEeaVlemTikmRHw" name="ContextHasNwTopologyService" memberEnd="_SoY-dMhmEeaVlemTikmRHw _SofFEMhmEeaVlemTikmRHw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SoY-cshmEeaVlemTikmRHw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SoY-c8hmEeaVlemTikmRHw" key="nature" value="UML_Nature"/>
@@ -256,8 +254,30 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PXVrsRlrEeeV4o0osG5stg" value="1"/>
         </ownedEnd>
       </packagedElement>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_YdlZUBl9EeeV4o0osG5stg" name="IRGHasCapacityPac" memberEnd="_YdlZUxl9EeeV4o0osG5stg _YdlZVhl9EeeV4o0osG5stg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_YdlZURl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_YdlZUhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_YdlZVhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_YdlZUBl9EeeV4o0osG5stg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ZoiJgBl9EeeV4o0osG5stg" name="IRGHasCostPac" memberEnd="_ZooQIhl9EeeV4o0osG5stg _ZooQJRl9EeeV4o0osG5stg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZooQIBl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZooQIRl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ZooQJRl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_ZoiJgBl9EeeV4o0osG5stg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_arfbUBl9EeeV4o0osG5stg" name="IRGHasRiskPac" memberEnd="_arfbUxl9EeeV4o0osG5stg _arfbVhl9EeeV4o0osG5stg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_arfbURl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_arfbUhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_arfbVhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_arfbUBl9EeeV4o0osG5stg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_aJStMBl9EeeV4o0osG5stg" name="IRGHasTimingPac" memberEnd="_aJStMxl9EeeV4o0osG5stg _aJStNhl9EeeV4o0osG5stg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aJStMRl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aJStMhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_aJStNhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_aJStMBl9EeeV4o0osG5stg"/>
+      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_TVx5YBl6EeeV4o0osG5stg" name="NRGHasCapacityPac" memberEnd="_TVx5Yxl6EeeV4o0osG5stg _TVx5Zhl6EeeV4o0osG5stg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TVx5YRl6EeeV4o0osG5stg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TVx5Yhl6EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
@@ -282,31 +302,9 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_Wi58shl6EeeV4o0osG5stg" name="noderulegroup" type="_xDuuoBk7EeeV4o0osG5stg" association="_Wiz2EBl6EeeV4o0osG5stg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_YdlZUBl9EeeV4o0osG5stg" name="IRGHasCapacityPac" memberEnd="_YdlZUxl9EeeV4o0osG5stg _YdlZVhl9EeeV4o0osG5stg">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_YdlZURl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_YdlZUhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_YdlZVhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_YdlZUBl9EeeV4o0osG5stg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_ZoiJgBl9EeeV4o0osG5stg" name="IRGHasCostPac" memberEnd="_ZooQIhl9EeeV4o0osG5stg _ZooQJRl9EeeV4o0osG5stg">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZooQIBl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZooQIRl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_ZooQJRl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_ZoiJgBl9EeeV4o0osG5stg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_aJStMBl9EeeV4o0osG5stg" name="IRGHasTimingPac" memberEnd="_aJStMxl9EeeV4o0osG5stg _aJStNhl9EeeV4o0osG5stg">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aJStMRl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aJStMhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_aJStNhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_aJStMBl9EeeV4o0osG5stg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_arfbUBl9EeeV4o0osG5stg" name="IRGHasRiskPac" memberEnd="_arfbUxl9EeeV4o0osG5stg _arfbVhl9EeeV4o0osG5stg">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_arfbURl9EeeV4o0osG5stg" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_arfbUhl9EeeV4o0osG5stg" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_arfbVhl9EeeV4o0osG5stg" name="interrulegroup" type="_9W0Q4Bk7EeeV4o0osG5stg" association="_arfbUBl9EeeV4o0osG5stg"/>
-      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_nneO0EvsEee8IN5myVB_oQ" client="_oCmjAETtEead1bezhJG4aw" supplier="_-ht5oPMtEeSb-q8_djA2ng"/>
     </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_QOoHAC5xEea0_JngOlSKcA" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_LArf4DA8Eea4fKwSGMr6CA">
         <importedPackage xmi:type="uml:Model" href="TapiCommon.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
@@ -424,7 +422,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_04ZdoBk8EeeV4o0osG5stg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_04fkQBk8EeeV4o0osG5stg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_T7gvkz_LEeWNAdBR30aJhw" name="_encapTopology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_T7gvkD_LEeWNAdBR30aJhw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_T7gvkz_LEeWNAdBR30aJhw" name="_encapTopology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="shared" association="_T7gvkD_LEeWNAdBR30aJhw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cNt2UD_LEeWNAdBR30aJhw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cNvrgD_LEeWNAdBR30aJhw" value="1"/>
         </ownedAttribute>
@@ -498,6 +496,9 @@ The structure of LTP supports all transport protocols including circuit and pack
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UMztkdnfEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MM6iEEHBEeWqPKyD1j6LMg" name="_mappedServiceInterfacePoint" association="_MM4s4EHBEeWqPKyD1j6LMg">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pWHaEEq8EeexQa2RWFy3AQ" annotatedElement="_MM6iEEHBEeWqPKyD1j6LMg">
+            <body>NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental</body>
+          </ownedComment>
           <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eKdFsEHBEeWqPKyD1j6LMg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eKfh8EHBEeWqPKyD1j6LMg" value="*"/>
@@ -689,7 +690,7 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
         <generalization xmi:type="uml:Generalization" xmi:id="_uF7-cETtEead1bezhJG4aw">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_v4NNVETtEead1bezhJG4aw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_v4NNUETtEead1bezhJG4aw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_v4NNVETtEead1bezhJG4aw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="shared" association="_v4NNUETtEead1bezhJG4aw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1QQQEETtEead1bezhJG4aw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1QaBEETtEead1bezhJG4aw" value="*"/>
         </ownedAttribute>
@@ -745,7 +746,7 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bzj1QBk-EeeV4o0osG5stg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bzwCgBk-EeeV4o0osG5stg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8y7EMxk8EeeV4o0osG5stg" name="_nodeRuleGroup" type="_xDuuoBk7EeeV4o0osG5stg" aggregation="composite" association="_8y7EMBk8EeeV4o0osG5stg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8y7EMxk8EeeV4o0osG5stg" name="_nodeRuleGroup" type="_xDuuoBk7EeeV4o0osG5stg" aggregation="shared" association="_8y7EMBk8EeeV4o0osG5stg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rZhyoBlAEeeV4o0osG5stg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rZhyoRlAEeeV4o0osG5stg" value="*"/>
         </ownedAttribute>
@@ -1174,8 +1175,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_SofFEchmEeaVlemTikmRHw" base_StructuralFeature="_SofFEMhmEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3Tks8MhmEeaVlemTikmRHw" base_StructuralFeature="_3TemVMhmEeaVlemTikmRHw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_3Tks88hmEeaVlemTikmRHw" base_StructuralFeature="_3Tks8shmEeaVlemTikmRHw"/>
-  <OpenModel_Profile:PassedByReference xmi:id="_0n5REBMpEee0L_IMWjydgQ" base_Property="_v4NNVETtEead1bezhJG4aw"/>
-  <OpenModel_Profile:PassedByReference xmi:id="_gzA74BMqEee0L_IMWjydgQ" base_Property="_T7gvkz_LEeWNAdBR30aJhw"/>
   <OpenModel_Profile:Specify xmi:id="_v5HFYBM3Eee0L_IMWjydgQ" base_Abstraction="_ti-UcBM3Eee0L_IMWjydgQ" target="/TapiCommon:Context:_context"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PCwksRhsEeewCs0lkpWskw" base_Property="_STzYBe_tEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PCwkshhsEeewCs0lkpWskw" base_Property="_WSiGVd71EeW-BtRsuJPbqg"/>
@@ -1311,7 +1310,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zPz89RlBEeeV4o0osG5stg" base_Property="_zPz88xlBEeeV4o0osG5stg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zPz89xlBEeeV4o0osG5stg" base_StructuralFeature="_zPz89hlBEeeV4o0osG5stg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zPz8-BlBEeeV4o0osG5stg" base_Property="_zPz89hlBEeeV4o0osG5stg"/>
-  <OpenModel_Profile:PassedByReference xmi:id="_CdzMcBl2EeeV4o0osG5stg" base_Property="_8y7EMxk8EeeV4o0osG5stg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TVx5ZBl6EeeV4o0osG5stg" base_StructuralFeature="_TVx5Yxl6EeeV4o0osG5stg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_TVx5ZRl6EeeV4o0osG5stg" base_Property="_TVx5Yxl6EeeV4o0osG5stg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TVx5Zxl6EeeV4o0osG5stg" base_StructuralFeature="_TVx5Zhl6EeeV4o0osG5stg"/>
@@ -1352,4 +1350,11 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:ExtendedComposite xmi:id="_9GCj8Bl9EeeV4o0osG5stg" base_Association="_ZoiJgBl9EeeV4o0osG5stg"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_96JhcBl9EeeV4o0osG5stg" base_Association="_arfbUBl9EeeV4o0osG5stg"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_-6xQ8Bl9EeeV4o0osG5stg" base_Association="_aJStMBl9EeeV4o0osG5stg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_BMXUkEpcEeexQa2RWFy3AQ" base_Association="_3TemUMhmEeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_KbuAEEpcEeexQa2RWFy3AQ" base_Association="_SoY-cMhmEeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_NPquYEpcEeexQa2RWFy3AQ" base_Association="_9-A9gD_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_PHMQsEpcEeexQa2RWFy3AQ" base_Association="_GkchcD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_UeoPcEpcEeexQa2RWFy3AQ" base_Association="_IzuHYKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_mIZigEpcEeexQa2RWFy3AQ" base_Association="_u4xdgBk8EeeV4o0osG5stg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_t2KfcEpcEeexQa2RWFy3AQ" base_Association="_Qw4ncBk9EeeV4o0osG5stg"/>
 </xmi:XMI>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -191,7 +191,7 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_3Tks8shmEeaVlemTikmRHw" name="context" type="_PSCGoMhmEeaVlemTikmRHw" association="_3TemUMhmEeaVlemTikmRHw"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ti-UcBM3Eee0L_IMWjydgQ" name="AugmentRootContext" client="_PSCGoMhmEeaVlemTikmRHw">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_ti-UcBM3Eee0L_IMWjydgQ" name="AugmentsRootContext" client="_PSCGoMhmEeaVlemTikmRHw">
         <ownedComment xmi:type="uml:Comment" xmi:id="_qahscBh_Eeeaw_DVk4Yi2w" annotatedElement="_ti-UcBM3Eee0L_IMWjydgQ">
           <body>Augments the base TAPI Context with TopologyService information</body>
         </ownedComment>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -1357,4 +1357,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:StrictComposite xmi:id="_UeoPcEpcEeexQa2RWFy3AQ" base_Association="_IzuHYKf4EeW6jfwWQNiYcg"/>
   <OpenModel_Profile:StrictComposite xmi:id="_mIZigEpcEeexQa2RWFy3AQ" base_Association="_u4xdgBk8EeeV4o0osG5stg"/>
   <OpenModel_Profile:StrictComposite xmi:id="_t2KfcEpcEeexQa2RWFy3AQ" base_Association="_Qw4ncBk9EeeV4o0osG5stg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_My_i4EvwEee8IN5myVB_oQ" base_Association="_li1MYBk9EeeV4o0osG5stg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_OT_bkEvwEee8IN5myVB_oQ" base_Association="_zPz88BlBEeeV4o0osG5stg"/>
 </xmi:XMI>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -376,7 +376,9 @@
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IZggA98AEeW-BtRsuJPbqg" name="_state" isReadOnly="true" aggregation="composite" association="_IZggAN8AEeW-BtRsuJPbqg">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_WSiGU971EeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_WSiGUN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WSiGU971EeW-BtRsuJPbqg" name="_transferCapacity" isReadOnly="true" aggregation="composite" association="_WSiGUN71EeW-BtRsuJPbqg">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_cQkyE971EeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_cQkyEN71EeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_gJx4Q971EeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_gJx4QN71EeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_kZ4bg971EeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
@@ -429,7 +431,9 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
         <ownedAttribute xmi:type="uml:Property" xmi:id="_W9zh097-EeW-BtRsuJPbqg" name="_state" isReadOnly="true" aggregation="composite" association="_W9zh0N7-EeW-BtRsuJPbqg">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_tOFAk97rEeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tOFAk97rEeW-BtRsuJPbqg" name="_transferCapacity" isReadOnly="true" aggregation="composite" association="_tOFAkN7rEeW-BtRsuJPbqg">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7DdfM97vEeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lqLYA97wEeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_kTBiY97xEeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
@@ -544,45 +548,6 @@ Where two TopologicalEntities have a common risk characteristic they have an ele
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZW-9yKEeWXdJnxZxtFYA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW_NyKEeWXdJnxZxtFYA" value="*"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="TransferCapacityPac">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXM9yKEeWXdJnxZxtFYA">
-          <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
-A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
-A TopologicalEntity may be directly used in the view or may be assigned to another view for use.&#xD;
-The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.&#xD;
-Represents the capacity available to user (client) along with client interaction and usage. &#xD;
-A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.</body>
-        </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXNdyKEeWXdJnxZxtFYA" name="totalPotentialCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXNdyKEeWXdJnxZxtFYA">
-            <body>An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXN9yKEeWXdJnxZxtFYA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXONyKEeWXdJnxZxtFYA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXOdyKEeWXdJnxZxtFYA" name="availableCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXOtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXOdyKEeWXdJnxZxtFYA">
-            <body>Capacity available to be assigned.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXO9yKEeWXdJnxZxtFYA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXPNyKEeWXdJnxZxtFYA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXPdyKEeWXdJnxZxtFYA" name="capacityAssignedToUserView" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXPtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXPdyKEeWXdJnxZxtFYA">
-            <body>Capacity already assigned</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXP9yKEeWXdJnxZxtFYA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXQNyKEeWXdJnxZxtFYA" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXQdyKEeWXdJnxZxtFYA" name="capacityInteractionAlgorithm" visibility="public" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXQtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXQdyKEeWXdJnxZxtFYA">
-            <body>A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXQ9yKEeWXdJnxZxtFYA" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXRNyKEeWXdJnxZxtFYA" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="TransferCostPac">
@@ -714,7 +679,8 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ju6XsBk9EeeV4o0osG5stg" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jvAeUBk9EeeV4o0osG5stg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_YdlZUxl9EeeV4o0osG5stg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_YdlZUBl9EeeV4o0osG5stg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YdlZUxl9EeeV4o0osG5stg" name="_transferCapacity" aggregation="composite" association="_YdlZUBl9EeeV4o0osG5stg">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4Ja48Bl9EeeV4o0osG5stg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4Ja48Rl9EeeV4o0osG5stg" value="1"/>
         </ownedAttribute>
@@ -751,7 +717,8 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UxnR8Bk9EeeV4o0osG5stg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UxnR8Rk9EeeV4o0osG5stg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_TVx5Yxl6EeeV4o0osG5stg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_TVx5YBl6EeeV4o0osG5stg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TVx5Yxl6EeeV4o0osG5stg" name="_transferCapacity" aggregation="composite" association="_TVx5YBl6EeeV4o0osG5stg">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_isbTQBl6EeeV4o0osG5stg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_isbTQRl6EeeV4o0osG5stg" value="1"/>
         </ownedAttribute>
@@ -786,51 +753,6 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_TTPukC5xEea0_JngOlSKcA" name="TypeDefinitions">
-      <packagedElement xmi:type="uml:DataType" xmi:id="_rNbewL1-EeWdore3Cxez9g" name="Capacity" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_rNbewb1-EeWdore3Cxez9g" annotatedElement="_rNbewL1-EeWdore3Cxez9g">
-          <body>Information on capacity of a particular TopologicalEntity.</body>
-        </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_rNbewr1-EeWdore3Cxez9g" name="totalSize" visibility="public" type="_smkSYL1yEeWdore3Cxez9g">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_rNbew71-EeWdore3Cxez9g" annotatedElement="_rNbewr1-EeWdore3Cxez9g">
-            <body>Total capacity of the TopologicalEntity in MB/s</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNbexL1-EeWdore3Cxez9g" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNbexb1-EeWdore3Cxez9g" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_zB_30D6iEeai_egNtQKqQA" name="packetBwProfileType" type="_EuZIcD6gEeai_egNtQKqQA"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_FKRr0D6jEeai_egNtQKqQA" name="committedInformationRate">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HJt0AD6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HJt0Aj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_VJ4jID6jEeai_egNtQKqQA" name="committedBurstSize">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WDdPcD6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WDdPcj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_aMoEQD6jEeai_egNtQKqQA" name="peakInformationRate">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_btxt8D6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bt634D6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_g9oeAD6jEeai_egNtQKqQA" name="peakBurstSize">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iAAhAD6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iAAhAj6jEeai_egNtQKqQA" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_or7mcD6jEeai_egNtQKqQA" name="colorAware">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wk4fsD6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wlCQsT6jEeai_egNtQKqQA" value="1"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_or7mcT6jEeai_egNtQKqQA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_u_PXkD6jEeai_egNtQKqQA" name="couplingFlag">
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xq1bID6jEeai_egNtQKqQA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xq1bIj6jEeai_egNtQKqQA" value="1"/>
-          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_u_PXkT6jEeai_egNtQKqQA"/>
-        </ownedAttribute>
-      </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqwdv-EeWowYqZXEhn3A" name="CostCharacteristic" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqwtv-EeWowYqZXEhn3A" annotatedElement="_8ZRqwdv-EeWowYqZXEhn3A">
           <body>The information for a particular cost characteristic.</body>
@@ -859,21 +781,6 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRqzdv-EeWowYqZXEhn3A" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRqztv-EeWowYqZXEhn3A" value="1"/>
         </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_smkSYL1yEeWdore3Cxez9g" name="FixedCapacityValue" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_UEqsALvUEeWYrqoqXLgguw">
-          <body>The Capacity (Bandwidth) values that are applicable for digital layers. </body>
-        </ownedComment>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HBQVkL2AEeWdore3Cxez9g" name="NOT_APPLICABLE"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1YyV8L1yEeWdore3Cxez9g" name="10MBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z7f4kL1yEeWdore3Cxez9g" name="100MBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_7cCR0L1yEeWdore3Cxez9g" name="1GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gyYdML1zEeWdore3Cxez9g" name="2.4GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ye91gL1zEeWdore3Cxez9g" name="10GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_bhtNwL1zEeWdore3Cxez9g" name="40GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_x85d4L1yEeWdore3Cxez9g" name="100GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oRItwL1zEeWdore3Cxez9g" name="200GBPS"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mXlyML1zEeWdore3Cxez9g" name="400GBPS"/>
       </packagedElement>
       <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq-dv-EeWowYqZXEhn3A" name="LatencyCharacteristic" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq-tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq-dv-EeWowYqZXEhn3A">
@@ -974,13 +881,6 @@ Depending upon the importance of the traffic being routed different risk charact
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq-Nv-EeWowYqZXEhn3A" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EuZIcD6gEeai_egNtQKqQA" name="BandwidthProfileType" isLeaf="true">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Lrs40D6gEeai_egNtQKqQA" name="NOT_APPLICABLE"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PYdMgD6iEeai_egNtQKqQA" name="MEF_10.x"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_R0GvkD6iEeai_egNtQKqQA" name="RFC_2697"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VNVVMD6iEeai_egNtQKqQA" name="RFC_2698"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YMrbMD6iEeai_egNtQKqQA" name="RFC_4115"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_5Mca0Bk-EeeV4o0osG5stg" name="ForwardingRule" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_EihiQBk_EeeV4o0osG5stg" name="MAY_FORWARD_ACROSS_GROUP"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GcYm4Bk_EeeV4o0osG5stg" name="MUST_FORWARD_ACROSS_GROUP"/>
@@ -1051,7 +951,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelParameter xmi:id="_qRQggbsEEeWYrqoqXLgguw" base_Parameter="_qRQggLsEEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_yctfAbsEEeWYrqoqXLgguw" base_Parameter="_yctfALsEEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_2nCKYbsEEeWYrqoqXLgguw" base_Parameter="_2nCKYLsEEeWYrqoqXLgguw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_rO6sgL1-EeWdore3Cxez9g" base_StructuralFeature="_rNbewr1-EeWdore3Cxez9g" partOfObjectKey="1"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyY9nXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyYtnXEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyZdnXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyZNnXEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_G1pfNNnfEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfM9nfEeWIOYiRCk5bbQ"/>
@@ -1079,10 +978,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkva0NyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXJ9yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkva0dyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXK9yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ksNyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXL9yKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kstyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXNdyKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ks9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXOdyKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ktNyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXPdyKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ktdyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXQdyKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kv9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXXtyKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_mNsdwd6NEeWd9KDn6x5Skg" base_Parameter="_mNsdwN6NEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_tOFAlN7rEeW-BtRsuJPbqg" base_StructuralFeature="_tOFAk97rEeW-BtRsuJPbqg"/>
@@ -1119,7 +1014,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelClass xmi:id="_KkvaxNyKEeWXdJnxZxtFYA" base_Class="_KjZW_dyKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KkvawtyKEeWXdJnxZxtFYA" base_Class="_KjZW99yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KkvawNyKEeWXdJnxZxtFYA" base_Class="_KjZW8dyKEeWXdJnxZxtFYA"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_Kk4ksdyKEeWXdJnxZxtFYA" base_Class="_KjZXM9yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_Kkvax9yKEeWXdJnxZxtFYA" base_Class="_KjZXB9yKEeWXdJnxZxtFYA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_ejyEk-KyEeSq5fATALSQkQ" base_Class="_ejyEgOKyEeSq5fATALSQkQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KkvazNyKEeWXdJnxZxtFYA" base_Class="_KjZXGdyKEeWXdJnxZxtFYA"/>
@@ -1151,13 +1045,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:ExtendedComposite xmi:id="_ceaccDM5EeaULOmJRJKM0Q" base_Association="_kTBiYN7xEeW-BtRsuJPbqg"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_dvC94DM5EeaULOmJRJKM0Q" base_Association="_W9zh0N7-EeW-BtRsuJPbqg"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_9RLnkDM8EeaULOmJRJKM0Q" base_Association="_cQkyEN71EeW-BtRsuJPbqg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_zB_30j6iEeai_egNtQKqQA" base_StructuralFeature="_zB_30D6iEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_FKRr0j6jEeai_egNtQKqQA" base_StructuralFeature="_FKRr0D6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_VJ4jIj6jEeai_egNtQKqQA" base_StructuralFeature="_VJ4jID6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_aMoEQj6jEeai_egNtQKqQA" base_StructuralFeature="_aMoEQD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_g9oeAj6jEeai_egNtQKqQA" base_StructuralFeature="_g9oeAD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_or7mcz6jEeai_egNtQKqQA" base_StructuralFeature="_or7mcD6jEeai_egNtQKqQA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_u_PXkz6jEeai_egNtQKqQA" base_StructuralFeature="_u_PXkD6jEeai_egNtQKqQA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_oDy10ETtEead1bezhJG4aw" base_Class="_oCmjAETtEead1bezhJG4aw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_v4NNVUTtEead1bezhJG4aw" base_StructuralFeature="_v4NNVETtEead1bezhJG4aw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_v4W-UUTtEead1bezhJG4aw" base_StructuralFeature="_v4W-UETtEead1bezhJG4aw"/>
@@ -1231,10 +1118,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OBhsEeewCs0lkpWskw" base_Property="_7vdVA2h_EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_ORhsEeewCs0lkpWskw" base_Property="_7vdU-2h_EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OhhsEeewCs0lkpWskw" base_Property="_KjZW-dyKEeWXdJnxZxtFYA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OxhsEeewCs0lkpWskw" base_Property="_KjZXNdyKEeWXdJnxZxtFYA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_PBhsEeewCs0lkpWskw" base_Property="_KjZXOdyKEeWXdJnxZxtFYA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_PRhsEeewCs0lkpWskw" base_Property="_KjZXPdyKEeWXdJnxZxtFYA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF0BhsEeewCs0lkpWskw" base_Property="_KjZXQdyKEeWXdJnxZxtFYA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF0RhsEeewCs0lkpWskw" base_Property="_KjZW89yKEeWXdJnxZxtFYA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF0hhsEeewCs0lkpWskw" base_Property="_KjZXG9yKEeWXdJnxZxtFYA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF0xhsEeewCs0lkpWskw" base_Property="_KjZXH9yKEeWXdJnxZxtFYA"/>
@@ -1247,14 +1130,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF2hhsEeewCs0lkpWskw" base_Property="_v4NNVETtEead1bezhJG4aw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF2xhsEeewCs0lkpWskw" base_Property="_SoY-dMhmEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3BhsEeewCs0lkpWskw" base_Property="_3TemVMhmEeaVlemTikmRHw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3RhsEeewCs0lkpWskw" base_Property="_rNbewr1-EeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3hhsEeewCs0lkpWskw" base_Property="_zB_30D6iEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDPF3xhsEeewCs0lkpWskw" base_Property="_FKRr0D6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcBhsEeewCs0lkpWskw" base_Property="_VJ4jID6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcRhsEeewCs0lkpWskw" base_Property="_aMoEQD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMchhsEeewCs0lkpWskw" base_Property="_g9oeAD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMcxhsEeewCs0lkpWskw" base_Property="_or7mcD6jEeai_egNtQKqQA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdBhsEeewCs0lkpWskw" base_Property="_u_PXkD6jEeai_egNtQKqQA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdRhsEeewCs0lkpWskw" base_Property="_8ZRqw9v-EeWowYqZXEhn3A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdhhsEeewCs0lkpWskw" base_Property="_8ZRqx9v-EeWowYqZXEhn3A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDVMdxhsEeewCs0lkpWskw" base_Property="_8ZRqy9v-EeWowYqZXEhn3A"/>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -506,9 +506,6 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_STzYA-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_STzYAO_tEeWLlrwIF3w0vA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_093zYKU7EeWkWNPM1BHzGA" name="terminationDirection" isReadOnly="true">
-          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7vdVA2h_EeWZEqTYAF8eqA" name="linkPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_7vdVBGh_EeWZEqTYAF8eqA" annotatedElement="_7vdVA2h_EeWZEqTYAF8eqA">
             <body>The orientation of defined flow at the LinkEnd.</body>
@@ -1049,7 +1046,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_7wyxtWh_EeWZEqTYAF8eqA" base_StructuralFeature="_7vdVA2h_EeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_tQQ4Vmj_EeWZEqTYAF8eqA" base_StructuralFeature="_tQQ4VWj_EeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_QpQJJINtEeW35P6IpRw6Dg" base_StructuralFeature="_QpQJIINtEeW35P6IpRw6Dg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_093zYaU7EeWkWNPM1BHzGA" base_StructuralFeature="_093zYKU7EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Iz0OAaf4EeW6jfwWQNiYcg" base_StructuralFeature="_Iz0OAKf4EeW6jfwWQNiYcg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Iz6Uoaf4EeW6jfwWQNiYcg" base_StructuralFeature="_Iz6UoKf4EeW6jfwWQNiYcg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_qRQggbsEEeWYrqoqXLgguw" base_Parameter="_qRQggLsEEeWYrqoqXLgguw"/>
@@ -1232,7 +1228,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NBhsEeewCs0lkpWskw" base_Property="_G1pfM9nfEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NRhsEeewCs0lkpWskw" base_Property="_MM6iEEHBEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NhhsEeewCs0lkpWskw" base_Property="_STzYA-_tEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NxhsEeewCs0lkpWskw" base_Property="_093zYKU7EeWkWNPM1BHzGA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OBhsEeewCs0lkpWskw" base_Property="_7vdVA2h_EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_ORhsEeewCs0lkpWskw" base_Property="_7vdU-2h_EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_OhhsEeewCs0lkpWskw" base_Property="_KjZW-dyKEeWXdJnxZxtFYA"/>

--- a/YANG/tapi-common.tree
+++ b/YANG/tapi-common.tree
@@ -11,6 +11,25 @@ module: tapi-common
        |  |     +--ro value?        string
        |  +--ro state
        |  |  +--ro lifecycle-state?   lifecycle-state
+       |  +--ro capacity
+       |  |  +--ro total-potential-capacity
+       |  |  |  +--ro total-size?                   fixed-capacity-value
+       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |  |  +--ro committed-information-rate?   uint64
+       |  |  |  +--ro committed-burst-size?         uint64
+       |  |  |  +--ro peak-information-rate?        uint64
+       |  |  |  +--ro peak-burst-size?              uint64
+       |  |  |  +--ro color-aware?                  boolean
+       |  |  |  +--ro coupling-flag?                boolean
+       |  |  +--ro available-capacity
+       |  |     +--ro total-size?                   fixed-capacity-value
+       |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |     +--ro committed-information-rate?   uint64
+       |  |     +--ro committed-burst-size?         uint64
+       |  |     +--ro peak-information-rate?        uint64
+       |  |     +--ro peak-burst-size?              uint64
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
        |  +--ro uuid              universal-id
        |  +--ro name* [value-name]
        |     +--ro value-name    string
@@ -36,6 +55,25 @@ module: tapi-common
     |        |     +--ro value?        string
     |        +--ro state
     |        |  +--ro lifecycle-state?   lifecycle-state
+    |        +--ro capacity
+    |        |  +--ro total-potential-capacity
+    |        |  |  +--ro total-size?                   fixed-capacity-value
+    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  +--ro committed-information-rate?   uint64
+    |        |  |  +--ro committed-burst-size?         uint64
+    |        |  |  +--ro peak-information-rate?        uint64
+    |        |  |  +--ro peak-burst-size?              uint64
+    |        |  |  +--ro color-aware?                  boolean
+    |        |  |  +--ro coupling-flag?                boolean
+    |        |  +--ro available-capacity
+    |        |     +--ro total-size?                   fixed-capacity-value
+    |        |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |     +--ro committed-information-rate?   uint64
+    |        |     +--ro committed-burst-size?         uint64
+    |        |     +--ro peak-information-rate?        uint64
+    |        |     +--ro peak-burst-size?              uint64
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
     |        +--ro uuid?             universal-id
     |        +--ro name* [value-name]
     |           +--ro value-name    string
@@ -53,6 +91,25 @@ module: tapi-common
              |     +--ro value?        string
              +--ro state
              |  +--ro lifecycle-state?   lifecycle-state
+             +--ro capacity
+             |  +--ro total-potential-capacity
+             |  |  +--ro total-size?                   fixed-capacity-value
+             |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |  +--ro committed-information-rate?   uint64
+             |  |  +--ro committed-burst-size?         uint64
+             |  |  +--ro peak-information-rate?        uint64
+             |  |  +--ro peak-burst-size?              uint64
+             |  |  +--ro color-aware?                  boolean
+             |  |  +--ro coupling-flag?                boolean
+             |  +--ro available-capacity
+             |     +--ro total-size?                   fixed-capacity-value
+             |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |     +--ro committed-information-rate?   uint64
+             |     +--ro committed-burst-size?         uint64
+             |     +--ro peak-information-rate?        uint64
+             |     +--ro peak-burst-size?              uint64
+             |     +--ro color-aware?                  boolean
+             |     +--ro coupling-flag?                boolean
              +--ro uuid?             universal-id
              +--ro name* [value-name]
                 +--ro value-name    string

--- a/YANG/tapi-common.tree
+++ b/YANG/tapi-common.tree
@@ -11,7 +11,6 @@ module: tapi-common
        |  |     +--ro value?        string
        |  +--ro state
        |  |  +--ro lifecycle-state?   lifecycle-state
-       |  +--ro direction?        termination-direction
        |  +--ro uuid              universal-id
        |  +--ro name* [value-name]
        |     +--ro value-name    string
@@ -37,7 +36,6 @@ module: tapi-common
     |        |     +--ro value?        string
     |        +--ro state
     |        |  +--ro lifecycle-state?   lifecycle-state
-    |        +--ro direction?        termination-direction
     |        +--ro uuid?             universal-id
     |        +--ro name* [value-name]
     |           +--ro value-name    string
@@ -55,7 +53,6 @@ module: tapi-common
              |     +--ro value?        string
              +--ro state
              |  +--ro lifecycle-state?   lifecycle-state
-             +--ro direction?        termination-direction
              +--ro uuid?             universal-id
              +--ro name* [value-name]
                 +--ro value-name    string

--- a/YANG/tapi-common.tree
+++ b/YANG/tapi-common.tree
@@ -14,16 +14,10 @@ module: tapi-common
        |  +--ro direction?        termination-direction
        |  +--ro uuid              universal-id
        |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
        +--rw uuid?                      universal-id
        +--rw name* [value-name]
-       |  +--rw value-name    string
-       |  +--rw value?        string
-       +--rw label* [value-name]
           +--rw value-name    string
           +--rw value?        string
 
@@ -46,9 +40,6 @@ module: tapi-common
     |        +--ro direction?        termination-direction
     |        +--ro uuid?             universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-service-interface-point-list
@@ -67,8 +58,5 @@ module: tapi-common
              +--ro direction?        termination-direction
              +--ro uuid?             universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -43,11 +43,6 @@ module tapi-common {
                 uses name-and-value-g;
                 description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
             }
-            list label {
-                key 'value-name';
-                uses name-and-value-g;
-                description "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.";
-            }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
         }
         grouping layer-protocol-g {
@@ -142,7 +137,7 @@ module tapi-common {
                 config false;
                 min-elements 1;
                 uses layer-protocol-g;
-                description "none";
+                description "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental";
             }
             container state {
                 config false;

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -144,9 +144,31 @@ module tapi-common {
                 uses lifecycle-state-pac-g;
                 description "none";
             }
+            container capacity {
+                uses capacity-pac-g;
+                description "none";
+            }
             uses resource-spec-g;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
+        }
+        grouping capacity-pac-g {
+            container total-potential-capacity {
+                config false;
+                uses capacity-g;
+                description "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.";
+            }
+            container available-capacity {
+                config false;
+                uses capacity-g;
+                description "Capacity available to be assigned.";
+            }
+            description "The TopologicalEntity derives capacity from the underlying realization. 
+                A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.
+                A TopologicalEntity may be directly used in the view or may be assigned to another view for use.
+                The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.
+                Represents the capacity available to user (client) along with client interaction and usage. 
+                A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
         }
 
     /***********************
@@ -380,6 +402,96 @@ module tapi-common {
                 UUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.
                 Pattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} 
                 Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+        }
+        grouping capacity-g {
+            leaf total-size {
+                type fixed-capacity-value;
+                description "Total capacity of the TopologicalEntity in MB/s";
+            }
+            leaf packet-bw-profile-type {
+                type bandwidth-profile-type;
+                description "none";
+            }
+            leaf committed-information-rate {
+                type uint64;
+                description "none";
+            }
+            leaf committed-burst-size {
+                type uint64;
+                description "none";
+            }
+            leaf peak-information-rate {
+                type uint64;
+                description "none";
+            }
+            leaf peak-burst-size {
+                type uint64;
+                description "none";
+            }
+            leaf color-aware {
+                type boolean;
+                description "none";
+            }
+            leaf coupling-flag {
+                type boolean;
+                description "none";
+            }
+            description "Information on capacity of a particular TopologicalEntity.";
+        }
+        typedef fixed-capacity-value {
+            type enumeration {
+                enum not-applicable {
+                    description "none";
+                }
+                enum 10mbps {
+                    description "none";
+                }
+                enum 100mbps {
+                    description "none";
+                }
+                enum 1gbps {
+                    description "none";
+                }
+                enum 2.4gbps {
+                    description "none";
+                }
+                enum 10gbps {
+                    description "none";
+                }
+                enum 40gbps {
+                    description "none";
+                }
+                enum 100gbps {
+                    description "none";
+                }
+                enum 200gbps {
+                    description "none";
+                }
+                enum 400gbps {
+                    description "none";
+                }
+            }
+            description "The Capacity (Bandwidth) values that are applicable for digital layers. ";
+        }
+        typedef bandwidth-profile-type {
+            type enumeration {
+                enum not-applicable {
+                    description "none";
+                }
+                enum mef-10.x {
+                    description "none";
+                }
+                enum rfc-2697 {
+                    description "none";
+                }
+                enum rfc-2698 {
+                    description "none";
+                }
+                enum rfc-4115 {
+                    description "none";
+                }
+            }
+            description "none";
         }
 
     /***********************

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -144,11 +144,6 @@ module tapi-common {
                 uses lifecycle-state-pac-g;
                 description "none";
             }
-            leaf direction {
-                type termination-direction;
-                config false;
-                description "none";
-            }
             uses resource-spec-g;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -72,6 +72,8 @@ module: tapi-connectivity
     |  |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |  |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |  |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  +--rw local-id?                    string
     |  |  +--rw name* [value-name]
@@ -299,6 +301,8 @@ module: tapi-connectivity
     |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        |  +--ro local-id?                    string
     |        |  +--ro name* [value-name]
@@ -393,6 +397,8 @@ module: tapi-connectivity
     |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        |  +--ro local-id?                    string
     |        |  +--ro name* [value-name]
@@ -483,6 +489,8 @@ module: tapi-connectivity
     |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |  |  |  +---w include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |  |  |  +---w exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  +---w include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  +---w exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  |  +---w local-id?                    string
     |  |  |  +---w name* [value-name]
@@ -568,6 +576,8 @@ module: tapi-connectivity
     |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        |  +--ro local-id?                    string
     |        |  +--ro name* [value-name]
@@ -659,6 +669,8 @@ module: tapi-connectivity
     |  |  |  +---w exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |  |  |  +---w include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |  |  |  +---w exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  |  |  +---w include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  |  |  +---w exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
     |  |  |  +---w local-id?                    string
     |  |  |  +---w name* [value-name]
@@ -744,6 +756,8 @@ module: tapi-connectivity
     |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
     |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
     |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
     |        |  +--ro local-id?                    string
     |        |  +--ro name* [value-name]
@@ -838,6 +852,8 @@ module: tapi-connectivity
              |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
              |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
              |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
+             |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
+             |  +--ro exlude-node*                 -> /tapi-common:context/tapi-topology:topology/node/uuid
              |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
              |  +--ro local-id?                    string
              |  +--ro name* [value-name]

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -80,7 +80,6 @@ module: tapi-connectivity
        |  +--ro state
        |  |  +--ro operational-state?   operational-state
        |  |  +--ro lifecycle-state?     lifecycle-state
-       |  +--ro termination-direction?       tapi-common:termination-direction
        |  +--ro connection-port-direction?   tapi-common:port-direction
        |  +--ro connection-port-role?        tapi-common:port-role
        |  +--ro uuid                         universal-id
@@ -150,7 +149,6 @@ module: tapi-connectivity
     |        |  +--ro state
     |        |  |  +--ro operational-state?   operational-state
     |        |  |  +--ro lifecycle-state?     lifecycle-state
-    |        |  +--ro termination-direction?       tapi-common:termination-direction
     |        |  +--ro connection-port-direction?   tapi-common:port-direction
     |        |  +--ro connection-port-role?        tapi-common:port-role
     |        |  +--ro uuid                         universal-id

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -62,9 +62,6 @@ module: tapi-connectivity
     |  +--rw layer-protocol-name?   tapi-common:layer-protocol-name
     |  +--rw uuid                   universal-id
     |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw label* [value-name]
     |     +--rw value-name    string
     |     +--rw value?        string
     +--ro connection* [uuid]
@@ -88,9 +85,6 @@ module: tapi-connectivity
        |  +--ro connection-port-role?        tapi-common:port-role
        |  +--ro uuid                         universal-id
        |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
        +--ro route* [local-id]
@@ -113,7 +107,7 @@ module: tapi-connectivity
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
        |  +--ro control-parameters
-       |  |  +--ro prot-type?                            protection-type
+       |  |  +--ro switch-type?                          switch-type
        |  |  +--ro reversion-mode?                       reversion-mode
        |  |  +--ro wait-to-revert-time?                  uint64
        |  |  +--ro hold-off-time?                        uint64
@@ -131,9 +125,6 @@ module: tapi-connectivity
        +--ro direction?              tapi-common:forwarding-direction
        +--ro uuid                    universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string
 
@@ -164,9 +155,6 @@ module: tapi-connectivity
     |        |  +--ro connection-port-role?        tapi-common:port-role
     |        |  +--ro uuid                         universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro route* [local-id]
@@ -189,7 +177,7 @@ module: tapi-connectivity
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
     |        |  +--ro control-parameters
-    |        |  |  +--ro prot-type?                            protection-type
+    |        |  |  +--ro switch-type?                          switch-type
     |        |  |  +--ro reversion-mode?                       reversion-mode
     |        |  |  +--ro wait-to-revert-time?                  uint64
     |        |  |  +--ro hold-off-time?                        uint64
@@ -207,9 +195,6 @@ module: tapi-connectivity
     |        +--ro direction?              tapi-common:forwarding-direction
     |        +--ro uuid?                   universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-connectivity-service-list
@@ -276,9 +261,6 @@ module: tapi-connectivity
     |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-connectivity-service-details
@@ -347,9 +329,6 @@ module: tapi-connectivity
     |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x create-connectivity-service
@@ -473,9 +452,6 @@ module: tapi-connectivity
     |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x update-connectivity-service
@@ -600,9 +576,6 @@ module: tapi-connectivity
     |        +--ro layer-protocol-name?   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x delete-connectivity-service
@@ -671,8 +644,5 @@ module: tapi-connectivity
              +--ro layer-protocol-name?   tapi-common:layer-protocol-name
              +--ro uuid?                  universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -3,10 +3,36 @@ module: tapi-connectivity
     +--rw connectivity-service* [uuid]
     |  +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
     |  +--rw end-point* [local-id]
+    |  |  +--rw layer-protocol* [local-id]
+    |  |  |  +--rw layer-protocol-name?     layer-protocol-name
+    |  |  |  +--rw termination-direction?   termination-direction
+    |  |  |  +--rw termination-state?       termination-state
+    |  |  |  +--rw local-id                 string
+    |  |  |  +--rw name* [value-name]
+    |  |  |     +--rw value-name    string
+    |  |  |     +--rw value?        string
     |  |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--ro role?                      tapi-common:port-role
+    |  |  +--rw capacity
+    |  |  |  +--ro total-potential-capacity
+    |  |  |  |  +--ro total-size?                   fixed-capacity-value
+    |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |  |  +--ro committed-information-rate?   uint64
+    |  |  |  |  +--ro committed-burst-size?         uint64
+    |  |  |  |  +--ro peak-information-rate?        uint64
+    |  |  |  |  +--ro peak-burst-size?              uint64
+    |  |  |  |  +--ro color-aware?                  boolean
+    |  |  |  |  +--ro coupling-flag?                boolean
+    |  |  |  +--ro available-capacity
+    |  |  |     +--ro total-size?                   fixed-capacity-value
+    |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |     +--ro committed-information-rate?   uint64
+    |  |  |     +--ro committed-burst-size?         uint64
+    |  |  |     +--ro peak-information-rate?        uint64
+    |  |  |     +--ro peak-burst-size?              uint64
+    |  |  |     +--ro color-aware?                  boolean
+    |  |  |     +--ro coupling-flag?                boolean
     |  |  +--ro direction?                 tapi-common:port-direction
-    |  |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  +--ro role?                      tapi-common:port-role
     |  |  +--rw local-id                   string
     |  |  +--rw name* [value-name]
     |  |     +--rw value-name    string
@@ -200,10 +226,36 @@ module: tapi-connectivity
     |     +--ro service*
     |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
     |        +--ro end-point* [local-id]
+    |        |  +--ro layer-protocol* [local-id]
+    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+    |        |  |  +--ro termination-direction?   termination-direction
+    |        |  |  +--ro termination-state?       termination-state
+    |        |  |  +--ro local-id                 string
+    |        |  |  +--ro name* [value-name]
+    |        |  |     +--ro value-name    string
+    |        |  |     +--ro value?        string
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro role?                      tapi-common:port-role
+    |        |  +--ro capacity
+    |        |  |  +--ro total-potential-capacity
+    |        |  |  |  +--ro total-size?                   fixed-capacity-value
+    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |  +--ro committed-information-rate?   uint64
+    |        |  |  |  +--ro committed-burst-size?         uint64
+    |        |  |  |  +--ro peak-information-rate?        uint64
+    |        |  |  |  +--ro peak-burst-size?              uint64
+    |        |  |  |  +--ro color-aware?                  boolean
+    |        |  |  |  +--ro coupling-flag?                boolean
+    |        |  |  +--ro available-capacity
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
@@ -268,10 +320,36 @@ module: tapi-connectivity
     |     +--ro service
     |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
     |        +--ro end-point* [local-id]
+    |        |  +--ro layer-protocol* [local-id]
+    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+    |        |  |  +--ro termination-direction?   termination-direction
+    |        |  |  +--ro termination-state?       termination-state
+    |        |  |  +--ro local-id                 string
+    |        |  |  +--ro name* [value-name]
+    |        |  |     +--ro value-name    string
+    |        |  |     +--ro value?        string
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro role?                      tapi-common:port-role
+    |        |  +--ro capacity
+    |        |  |  +--ro total-potential-capacity
+    |        |  |  |  +--ro total-size?                   fixed-capacity-value
+    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |  +--ro committed-information-rate?   uint64
+    |        |  |  |  +--ro committed-burst-size?         uint64
+    |        |  |  |  +--ro peak-information-rate?        uint64
+    |        |  |  |  +--ro peak-burst-size?              uint64
+    |        |  |  |  +--ro color-aware?                  boolean
+    |        |  |  |  +--ro coupling-flag?                boolean
+    |        |  |  +--ro available-capacity
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
@@ -332,10 +410,36 @@ module: tapi-connectivity
     +---x create-connectivity-service
     |  +---w input
     |  |  +---w end-point*
+    |  |  |  +---w layer-protocol* [local-id]
+    |  |  |  |  +---w layer-protocol-name?     layer-protocol-name
+    |  |  |  |  +---w termination-direction?   termination-direction
+    |  |  |  |  +---w termination-state?       termination-state
+    |  |  |  |  +---w local-id                 string
+    |  |  |  |  +---w name* [value-name]
+    |  |  |  |     +---w value-name    string
+    |  |  |  |     +---w value?        string
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w role?                      tapi-common:port-role
+    |  |  |  +---w capacity
+    |  |  |  |  +---w total-potential-capacity
+    |  |  |  |  |  +---w total-size?                   fixed-capacity-value
+    |  |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |  |  |  +---w committed-information-rate?   uint64
+    |  |  |  |  |  +---w committed-burst-size?         uint64
+    |  |  |  |  |  +---w peak-information-rate?        uint64
+    |  |  |  |  |  +---w peak-burst-size?              uint64
+    |  |  |  |  |  +---w color-aware?                  boolean
+    |  |  |  |  |  +---w coupling-flag?                boolean
+    |  |  |  |  +---w available-capacity
+    |  |  |  |     +---w total-size?                   fixed-capacity-value
+    |  |  |  |     +---w packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |  |     +---w committed-information-rate?   uint64
+    |  |  |  |     +---w committed-burst-size?         uint64
+    |  |  |  |     +---w peak-information-rate?        uint64
+    |  |  |  |     +---w peak-burst-size?              uint64
+    |  |  |  |     +---w color-aware?                  boolean
+    |  |  |  |     +---w coupling-flag?                boolean
     |  |  |  +---w direction?                 tapi-common:port-direction
-    |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  |  +---w role?                      tapi-common:port-role
     |  |  |  +---w local-id?                  string
     |  |  |  +---w name* [value-name]
     |  |  |     +---w value-name    string
@@ -391,10 +495,36 @@ module: tapi-connectivity
     |     +--ro service
     |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
     |        +--ro end-point* [local-id]
+    |        |  +--ro layer-protocol* [local-id]
+    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+    |        |  |  +--ro termination-direction?   termination-direction
+    |        |  |  +--ro termination-state?       termination-state
+    |        |  |  +--ro local-id                 string
+    |        |  |  +--ro name* [value-name]
+    |        |  |     +--ro value-name    string
+    |        |  |     +--ro value?        string
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro role?                      tapi-common:port-role
+    |        |  +--ro capacity
+    |        |  |  +--ro total-potential-capacity
+    |        |  |  |  +--ro total-size?                   fixed-capacity-value
+    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |  +--ro committed-information-rate?   uint64
+    |        |  |  |  +--ro committed-burst-size?         uint64
+    |        |  |  |  +--ro peak-information-rate?        uint64
+    |        |  |  |  +--ro peak-burst-size?              uint64
+    |        |  |  |  +--ro color-aware?                  boolean
+    |        |  |  |  +--ro coupling-flag?                boolean
+    |        |  |  +--ro available-capacity
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
@@ -456,10 +586,36 @@ module: tapi-connectivity
     |  +---w input
     |  |  +---w service-id-or-name?   string
     |  |  +---w end-point
+    |  |  |  +---w layer-protocol* [local-id]
+    |  |  |  |  +---w layer-protocol-name?     layer-protocol-name
+    |  |  |  |  +---w termination-direction?   termination-direction
+    |  |  |  |  +---w termination-state?       termination-state
+    |  |  |  |  +---w local-id                 string
+    |  |  |  |  +---w name* [value-name]
+    |  |  |  |     +---w value-name    string
+    |  |  |  |     +---w value?        string
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w role?                      tapi-common:port-role
+    |  |  |  +---w capacity
+    |  |  |  |  +---w total-potential-capacity
+    |  |  |  |  |  +---w total-size?                   fixed-capacity-value
+    |  |  |  |  |  +---w packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |  |  |  +---w committed-information-rate?   uint64
+    |  |  |  |  |  +---w committed-burst-size?         uint64
+    |  |  |  |  |  +---w peak-information-rate?        uint64
+    |  |  |  |  |  +---w peak-burst-size?              uint64
+    |  |  |  |  |  +---w color-aware?                  boolean
+    |  |  |  |  |  +---w coupling-flag?                boolean
+    |  |  |  |  +---w available-capacity
+    |  |  |  |     +---w total-size?                   fixed-capacity-value
+    |  |  |  |     +---w packet-bw-profile-type?       bandwidth-profile-type
+    |  |  |  |     +---w committed-information-rate?   uint64
+    |  |  |  |     +---w committed-burst-size?         uint64
+    |  |  |  |     +---w peak-information-rate?        uint64
+    |  |  |  |     +---w peak-burst-size?              uint64
+    |  |  |  |     +---w color-aware?                  boolean
+    |  |  |  |     +---w coupling-flag?                boolean
     |  |  |  +---w direction?                 tapi-common:port-direction
-    |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  |  +---w role?                      tapi-common:port-role
     |  |  |  +---w local-id?                  string
     |  |  |  +---w name* [value-name]
     |  |  |     +---w value-name    string
@@ -515,10 +671,36 @@ module: tapi-connectivity
     |     +--ro service
     |        +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
     |        +--ro end-point* [local-id]
+    |        |  +--ro layer-protocol* [local-id]
+    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
+    |        |  |  +--ro termination-direction?   termination-direction
+    |        |  |  +--ro termination-state?       termination-state
+    |        |  |  +--ro local-id                 string
+    |        |  |  +--ro name* [value-name]
+    |        |  |     +--ro value-name    string
+    |        |  |     +--ro value?        string
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro role?                      tapi-common:port-role
+    |        |  +--ro capacity
+    |        |  |  +--ro total-potential-capacity
+    |        |  |  |  +--ro total-size?                   fixed-capacity-value
+    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |  +--ro committed-information-rate?   uint64
+    |        |  |  |  +--ro committed-burst-size?         uint64
+    |        |  |  |  +--ro peak-information-rate?        uint64
+    |        |  |  |  +--ro peak-burst-size?              uint64
+    |        |  |  |  +--ro color-aware?                  boolean
+    |        |  |  |  +--ro coupling-flag?                boolean
+    |        |  |  +--ro available-capacity
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro direction?                 tapi-common:port-direction
-    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro role?                      tapi-common:port-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
@@ -583,10 +765,36 @@ module: tapi-connectivity
           +--ro service
              +--ro connection*            -> /tapi-common:context/tapi-connectivity:connection/uuid
              +--ro end-point* [local-id]
+             |  +--ro layer-protocol* [local-id]
+             |  |  +--ro layer-protocol-name?     layer-protocol-name
+             |  |  +--ro termination-direction?   termination-direction
+             |  |  +--ro termination-state?       termination-state
+             |  |  +--ro local-id                 string
+             |  |  +--ro name* [value-name]
+             |  |     +--ro value-name    string
+             |  |     +--ro value?        string
              |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-             |  +--ro role?                      tapi-common:port-role
+             |  +--ro capacity
+             |  |  +--ro total-potential-capacity
+             |  |  |  +--ro total-size?                   fixed-capacity-value
+             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |  |  +--ro committed-information-rate?   uint64
+             |  |  |  +--ro committed-burst-size?         uint64
+             |  |  |  +--ro peak-information-rate?        uint64
+             |  |  |  +--ro peak-burst-size?              uint64
+             |  |  |  +--ro color-aware?                  boolean
+             |  |  |  +--ro coupling-flag?                boolean
+             |  |  +--ro available-capacity
+             |  |     +--ro total-size?                   fixed-capacity-value
+             |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |     +--ro committed-information-rate?   uint64
+             |  |     +--ro committed-burst-size?         uint64
+             |  |     +--ro peak-information-rate?        uint64
+             |  |     +--ro peak-burst-size?              uint64
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
              |  +--ro direction?                 tapi-common:port-direction
-             |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+             |  +--ro role?                      tapi-common:port-role
              |  +--ro local-id                   string
              |  +--ro name* [value-name]
              |     +--ro value-name    string

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -112,13 +112,15 @@ module: tapi-connectivity
        |  +--ro name* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
+       +--ro lower-connection*       -> /tapi-common:context/tapi-connectivity:connection/uuid
+       +--ro supported-link*         -> /tapi-common:context/tapi-topology:topology/link/uuid
+       +--ro container-node?         -> /tapi-common:context/tapi-topology:topology/node/uuid
        +--ro route* [local-id]
-       |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
-       |  +--ro local-id            string
+       |  +--ro connection-end-point*   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
+       |  +--ro local-id                string
        |  +--ro name* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
-       +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
        +--ro switch-control* [local-id]
        |  +--ro sub-switch-control*   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
        |  +--ro switch* [local-id]
@@ -181,13 +183,15 @@ module: tapi-connectivity
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
+    |        +--ro lower-connection*       -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        +--ro supported-link*         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro container-node?         -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        +--ro route* [local-id]
-    |        |  +--ro lower-connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        |  +--ro local-id            string
+    |        |  +--ro connection-end-point*   -> /tapi-common:context/tapi-connectivity:connection/connection-end-point/uuid
+    |        |  +--ro local-id                string
     |        |  +--ro name* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
-    |        +--ro node?                   -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        +--ro switch-control* [local-id]
     |        |  +--ro sub-switch-control*   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
     |        |  +--ro switch* [local-id]

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -36,17 +36,32 @@ module tapi-connectivity {
                 uses connection-end-point-g;
                 description "none";
             }
-            list route {
-                key 'local-id';
-                config false;
-                uses route-g;
-                description "none";
+            leaf-list lower-connection {
+                type leafref {
+                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid';
+                }
+                description "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).
+                    Aggregation is used as for the Node/Topology  to allow changes in hierarchy. 
+                    Connection aggregation reflects Node/Topology aggregation. 
+                    The FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning.";
             }
-            leaf node {
+            leaf-list supported-link {
+                type leafref {
+                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
+                }
+                description "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer.";
+            }
+            leaf container-node {
                 type leafref {
                     path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
+                description "none";
+            }
+            list route {
+                key 'local-id';
+                config false;
+                uses route-g;
                 description "none";
             }
             list switch-control {
@@ -247,9 +262,9 @@ module tapi-connectivity {
                 The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
         }
         grouping route-g {
-            leaf-list lower-connection {
+            leaf-list connection-end-point {
                 type leafref {
-                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid';
+                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
                 }
                 config false;
                 min-elements 1;

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -336,8 +336,8 @@ module tapi-connectivity {
             description "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme.";
         }
         grouping control-parameters-pac-g {
-            leaf prot-type {
-                type protection-type;
+            leaf switch-type {
+                type switch-type;
                 description "Indicates the protection scheme that is used for the ProtectionGroup.";
             }
             leaf reversion-mode {
@@ -355,11 +355,16 @@ module tapi-connectivity {
             }
             leaf is-lock-out {
                 type boolean;
-                description "none";
+                description "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.
+                    This overrides all other protection control states including forced.
+                    If the item is locked out then it cannot be used under any circumstances.
+                    Note: Only relevant when part of a protection scheme.";
             }
             leaf is-frozen {
                 type boolean;
-                description "none";
+                description "Temporarily prevents any switch action to be taken and, as such, freezes the current state. 
+                    Until the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.
+                    All administrative controls of any aspect of protection are rejected.";
             }
             leaf is-coordinated-switching-both-ends {
                 type boolean;
@@ -493,7 +498,7 @@ module tapi-connectivity {
             }
             description "The cause of the current route selection.";
         }
-        typedef protection-type {
+        typedef switch-type {
             type enumeration {
                 enum linear-1-plus-1 {
                     description "none";

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -108,11 +108,6 @@ module tapi-connectivity {
                 uses tapi-common:operational-state-pac-g;
                 description "none";
             }
-            leaf termination-direction {
-                type tapi-common:termination-direction;
-                config false;
-                description "none";
-            }
             leaf connection-port-direction {
                 type tapi-common:port-direction;
                 config false;

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -421,11 +421,25 @@ module tapi-connectivity {
                     path '/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
                 }
                 config false;
-                description "none";
+                description "This is a loose constraint - that is it is unordered and could be a partial list ";
             }
             leaf-list exclude-link {
                 type leafref {
                     path '/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf-list include-node {
+                type leafref {
+                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
+                }
+                config false;
+                description "This is a loose constraint - that is it is unordered and could be a partial list";
+            }
+            leaf-list exlude-node {
+                type leafref {
+                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
                 }
                 config false;
                 description "none";

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -135,7 +135,7 @@ module tapi-connectivity {
             }
             container requested-capacity {
                 config false;
-                uses tapi-topology:capacity-g;
+                uses tapi-common:capacity-g;
                 description "none";
             }
             list cost-characteristic {
@@ -210,6 +210,12 @@ module tapi-connectivity {
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
         grouping connectivity-service-end-point-g {
+            list layer-protocol {
+                key 'local-id';
+                min-elements 1;
+                uses tapi-common:layer-protocol-g;
+                description "none";
+            }
             leaf service-interface-point {
                 type leafref {
                     path '/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid';
@@ -217,20 +223,19 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
-            leaf role {
-                type tapi-common:port-role;
-                config false;
-                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            container capacity {
+                uses tapi-common:capacity-pac-g;
+                description "none";
             }
             leaf direction {
                 type tapi-common:port-direction;
                 config false;
                 description "The orientation of defined flow at the EndPoint.";
             }
-            leaf layer-protocol-name {
-                type tapi-common:layer-protocol-name;
+            leaf role {
+                type tapi-common:port-role;
                 config false;
-                description "none";
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
             }
             uses tapi-common:local-class-g;
             description "The association of the FC to LTPs is made via EndPoints.

--- a/YANG/tapi-notification.tree
+++ b/YANG/tapi-notification.tree
@@ -32,9 +32,6 @@ module: tapi-notification
     |  |  |  +--ro service-affecting?     service-affecting
     |  |  +--ro uuid                        universal-id
     |  |  +--ro name* [value-name]
-    |  |  |  +--ro value-name    string
-    |  |  |  +--ro value?        string
-    |  |  +--ro label* [value-name]
     |  |     +--ro value-name    string
     |  |     +--ro value?        string
     |  +--rw notification-channel
@@ -59,9 +56,6 @@ module: tapi-notification
     |  +--ro supported-object-types*         object-type
     |  +--rw uuid                            universal-id
     |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw label* [value-name]
     |     +--rw value-name    string
     |     +--rw value?        string
     +--ro notification* [uuid]
@@ -95,9 +89,6 @@ module: tapi-notification
        |  +--ro service-affecting?     service-affecting
        +--ro uuid                        universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string
 
@@ -152,9 +143,6 @@ module: tapi-notification
     |        |  |  +--ro service-affecting?     service-affecting
     |        |  +--ro uuid                        universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro notification-channel
@@ -179,9 +167,6 @@ module: tapi-notification
     |        +--ro supported-object-types*         object-type
     |        +--ro uuid?                           universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x update-notification-subscription-service
@@ -231,9 +216,6 @@ module: tapi-notification
     |        |  |  +--ro service-affecting?     service-affecting
     |        |  +--ro uuid                        universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro notification-channel
@@ -258,9 +240,6 @@ module: tapi-notification
     |        +--ro supported-object-types*         object-type
     |        +--ro uuid?                           universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x delete-notification-subscription-service
@@ -299,9 +278,6 @@ module: tapi-notification
     |        |  |  +--ro service-affecting?     service-affecting
     |        |  +--ro uuid                        universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro notification-channel
@@ -326,9 +302,6 @@ module: tapi-notification
     |        +--ro supported-object-types*         object-type
     |        +--ro uuid?                           universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-notification-subscription-service-details
@@ -367,9 +340,6 @@ module: tapi-notification
     |        |  |  +--ro service-affecting?     service-affecting
     |        |  +--ro uuid                        universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro notification-channel
@@ -394,9 +364,6 @@ module: tapi-notification
     |        +--ro supported-object-types*         object-type
     |        +--ro uuid?                           universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-notification-subscription-service-list
@@ -433,9 +400,6 @@ module: tapi-notification
     |        |  |  +--ro service-affecting?     service-affecting
     |        |  +--ro uuid                        universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro notification-channel
@@ -460,9 +424,6 @@ module: tapi-notification
     |        +--ro supported-object-types*         object-type
     |        +--ro uuid?                           universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-notification-list
@@ -503,9 +464,6 @@ module: tapi-notification
              |  +--ro service-affecting?     service-affecting
              +--ro uuid?                       universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string
 
@@ -541,8 +499,5 @@ module: tapi-notification
        |  +--ro service-affecting?     service-affecting
        +--ro uuid?                       universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string

--- a/YANG/tapi-oam.tree
+++ b/YANG/tapi-oam.tree
@@ -14,9 +14,6 @@ module: tapi-oam
     |  +--ro connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
     |  +--rw uuid          universal-id
     |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw label* [value-name]
     |     +--rw value-name    string
     |     +--rw value?        string
     +--ro meg* [uuid]
@@ -30,9 +27,6 @@ module: tapi-oam
        +--ro meg-level?   uint64
        +--ro uuid         universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string
   augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:

--- a/YANG/tapi-oam.tree
+++ b/YANG/tapi-oam.tree
@@ -1,18 +1,24 @@
 module: tapi-oam
   augment /tapi-common:context:
     +--rw oam-service* [uuid]
-    |  +--ro meg*          -> /tapi-common:context/tapi-oam:meg/uuid
+    |  +--ro meg*         -> /tapi-common:context/tapi-oam:meg/uuid
     |  +--rw end-point* [local-id]
+    |  |  +--rw layer-protocol* [local-id]
+    |  |  |  +--rw layer-protocol-name?     layer-protocol-name
+    |  |  |  +--rw termination-direction?   termination-direction
+    |  |  |  +--rw termination-state?       termination-state
+    |  |  |  +--rw local-id                 string
+    |  |  |  +--rw name* [value-name]
+    |  |  |     +--rw value-name    string
+    |  |  |     +--rw value?        string
     |  |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--ro role?                      tapi-common:port-role
     |  |  +--ro direction?                 tapi-common:port-direction
-    |  |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  +--ro role?                      tapi-common:port-role
     |  |  +--rw local-id                   string
     |  |  +--rw name* [value-name]
     |  |     +--rw value-name    string
     |  |     +--rw value?        string
-    |  +--ro connection*   -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |  +--rw uuid          universal-id
+    |  +--rw uuid         universal-id
     |  +--rw name* [value-name]
     |     +--rw value-name    string
     |     +--rw value?        string

--- a/YANG/tapi-oam.yang
+++ b/YANG/tapi-oam.yang
@@ -34,31 +34,38 @@ module tapi-oam {
                 type leafref {
                     path '/tapi-common:context/tapi-oam:meg/tapi-oam:me/tapi-oam:local-id';
                 }
+                config false;
                 description "none";
             }
             container mep-bidirectional {
+                config false;
                 uses mep-bidirectional-pac-g;
                 description "none";
             }
             container mep-sink {
+                config false;
                 uses mep-sink-pac-g;
                 description "none";
             }
             container mep-source {
+                config false;
                 uses mep-source-pac-g;
                 description "none";
             }
             list on-demand-measurement-job {
+                config false;
                 uses on-demand-measurement-job-g;
                 description "none";
             }
             list pro-active-measurement-job {
+                config false;
                 uses pro-active-measurement-job-g;
                 description "none";
             }
             leaf meg-identifier {
                 type string;
                 default "true";
+                config false;
                 description "none";
             }
             leaf admin-state {
@@ -97,11 +104,13 @@ module tapi-oam {
         grouping meg-g {
             list me {
                 key 'local-id';
+                config false;
                 uses me-g;
                 description "none";
             }
             leaf meg-level {
                 type uint64;
+                config false;
                 description "none";
             }
             uses tapi-common:resource-spec-g;
@@ -112,6 +121,7 @@ module tapi-oam {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-oam:mep/tapi-oam:local-id';
                 }
+                config false;
                 max-elements 2;
                 description "none";
             }
@@ -119,6 +129,7 @@ module tapi-oam {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol/tapi-oam:mip/tapi-oam:local-id';
                 }
+                config false;
                 description "none";
             }
             uses tapi-common:local-class-g;
@@ -129,6 +140,7 @@ module tapi-oam {
                 type leafref {
                     path '/tapi-common:context/tapi-oam:meg/tapi-oam:me/tapi-oam:local-id';
                 }
+                config false;
                 description "none";
             }
             uses tapi-common:local-class-g;
@@ -146,13 +158,6 @@ module tapi-oam {
                 key 'local-id';
                 min-elements 2;
                 uses oam-service-end-point-g;
-                description "none";
-            }
-            leaf-list connection {
-                type leafref {
-                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid';
-                }
-                config false;
                 description "none";
             }
             uses tapi-common:service-spec-g;
@@ -175,26 +180,29 @@ module tapi-oam {
         grouping mep-mip-reference-g {
             list mip {
                 key 'local-id';
+                config false;
                 uses mip-g;
                 description "none";
             }
             list mep {
                 key 'local-id';
+                config false;
                 uses mep-g;
                 description "none";
             }
             description "none";
         }
         grouping oam-service-end-point-g {
+            list layer-protocol {
+                key 'local-id';
+                min-elements 1;
+                uses tapi-common:layer-protocol-g;
+                description "none";
+            }
             leaf service-interface-point {
                 type leafref {
                     path '/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid';
                 }
-                config false;
-                description "none";
-            }
-            leaf role {
-                type tapi-common:port-role;
                 config false;
                 description "none";
             }
@@ -203,8 +211,8 @@ module tapi-oam {
                 config false;
                 description "none";
             }
-            leaf layer-protocol-name {
-                type tapi-common:layer-protocol-name;
+            leaf role {
+                type tapi-common:port-role;
                 config false;
                 description "none";
             }

--- a/YANG/tapi-oam.yang
+++ b/YANG/tapi-oam.yang
@@ -23,7 +23,7 @@ module tapi-oam {
         description "Augments the base TAPI Context with OamService information";
     }
     augment "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol" {
-        uses oam-lp-spec-g;
+        uses mep-mip-reference-g;
         description "none";
     }
     /***********************
@@ -172,7 +172,7 @@ module tapi-oam {
             }
             description "none";
         }
-        grouping oam-lp-spec-g {
+        grouping mep-mip-reference-g {
             list mip {
                 key 'local-id';
                 uses mip-g;

--- a/YANG/tapi-path-computation.tree
+++ b/YANG/tapi-path-computation.tree
@@ -57,9 +57,6 @@ module: tapi-path-computation
     |  |     +--rw value?        string
     |  +--rw uuid                       universal-id
     |  +--rw name* [value-name]
-    |  |  +--rw value-name    string
-    |  |  +--rw value?        string
-    |  +--rw label* [value-name]
     |     +--rw value-name    string
     |     +--rw value?        string
     +--ro path* [uuid]
@@ -94,9 +91,6 @@ module: tapi-path-computation
        |     +--ro value?        string
        +--ro uuid                  universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string
 
@@ -208,9 +202,6 @@ module: tapi-path-computation
     |        |     +--ro value?        string
     |        +--ro uuid?                      universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x optimize-p-2-p-path
@@ -318,9 +309,6 @@ module: tapi-path-computation
     |        |     +--ro value?        string
     |        +--ro uuid?                      universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x delete-p-2-p-path
@@ -384,8 +372,5 @@ module: tapi-path-computation
              |     +--ro value?        string
              +--ro uuid?                      universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string

--- a/YANG/tapi-path-computation.yang
+++ b/YANG/tapi-path-computation.yang
@@ -146,7 +146,7 @@ module tapi-path-computation {
         grouping routing-constraint-g {
             container requested-capacity {
                 config false;
-                uses tapi-topology:capacity-g;
+                uses tapi-common:capacity-g;
                 description "none";
             }
             leaf service-level {

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -23,7 +23,6 @@ module: tapi-topology
        |  |  |  +--ro administrative-state?   administrative-state
        |  |  |  +--ro operational-state?      operational-state
        |  |  |  +--ro lifecycle-state?        lifecycle-state
-       |  |  +--ro termination-direction?            tapi-common:termination-direction
        |  |  +--ro link-port-direction?              tapi-common:port-direction
        |  |  +--ro link-port-role?                   tapi-common:port-role
        |  |  +--ro uuid                              universal-id
@@ -308,7 +307,6 @@ module: tapi-topology
     |        |  |  |  +--ro administrative-state?   administrative-state
     |        |  |  |  +--ro operational-state?      operational-state
     |        |  |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  |  +--ro termination-direction?            tapi-common:termination-direction
     |        |  |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  |  +--ro link-port-role?                   tapi-common:port-role
     |        |  |  +--ro uuid                              universal-id
@@ -591,7 +589,6 @@ module: tapi-topology
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
     |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro termination-direction?            tapi-common:termination-direction
     |        |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  +--ro link-port-role?                   tapi-common:port-role
     |        |  +--ro uuid                              universal-id
@@ -797,7 +794,6 @@ module: tapi-topology
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
     |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro termination-direction?            tapi-common:termination-direction
     |        +--ro link-port-direction?              tapi-common:port-direction
     |        +--ro link-port-role?                   tapi-common:port-role
     |        +--ro uuid?                             universal-id
@@ -900,7 +896,6 @@ module: tapi-topology
              |  |  |  +--ro administrative-state?   administrative-state
              |  |  |  +--ro operational-state?      operational-state
              |  |  |  +--ro lifecycle-state?        lifecycle-state
-             |  |  +--ro termination-direction?            tapi-common:termination-direction
              |  |  +--ro link-port-direction?              tapi-common:port-direction
              |  |  +--ro link-port-role?                   tapi-common:port-role
              |  |  +--ro uuid                              universal-id

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -62,24 +62,14 @@ module: tapi-topology
        |  |  |  |  |  +--ro color-aware?                  boolean
        |  |  |  |  |  +--ro coupling-flag?                boolean
        |  |  |  |  +--ro available-capacity
-       |  |  |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  |  |  +--ro color-aware?                  boolean
-       |  |  |  |  |  +--ro coupling-flag?                boolean
-       |  |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  |  |  +--ro color-aware?                  boolean
-       |  |  |  |  |  +--ro coupling-flag?                boolean
-       |  |  |  |  +--ro capacity-interaction-algorithm?   string
+       |  |  |  |     +--ro total-size?                   fixed-capacity-value
+       |  |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |  |  |     +--ro committed-information-rate?   uint64
+       |  |  |  |     +--ro committed-burst-size?         uint64
+       |  |  |  |     +--ro peak-information-rate?        uint64
+       |  |  |  |     +--ro peak-burst-size?              uint64
+       |  |  |  |     +--ro color-aware?                  boolean
+       |  |  |  |     +--ro coupling-flag?                boolean
        |  |  |  +--ro transfer-cost
        |  |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
        |  |  |  |     +--ro cost-name         string
@@ -111,24 +101,14 @@ module: tapi-topology
        |  |  |  |  +--ro color-aware?                  boolean
        |  |  |  |  +--ro coupling-flag?                boolean
        |  |  |  +--ro available-capacity
-       |  |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  |  +--ro color-aware?                  boolean
-       |  |  |  |  +--ro coupling-flag?                boolean
-       |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  |  +--ro color-aware?                  boolean
-       |  |  |  |  +--ro coupling-flag?                boolean
-       |  |  |  +--ro capacity-interaction-algorithm?   string
+       |  |  |     +--ro total-size?                   fixed-capacity-value
+       |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |  |     +--ro committed-information-rate?   uint64
+       |  |  |     +--ro committed-burst-size?         uint64
+       |  |  |     +--ro peak-information-rate?        uint64
+       |  |  |     +--ro peak-burst-size?              uint64
+       |  |  |     +--ro color-aware?                  boolean
+       |  |  |     +--ro coupling-flag?                boolean
        |  |  +--ro transfer-cost
        |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
        |  |  |     +--ro cost-name         string
@@ -165,24 +145,14 @@ module: tapi-topology
        |  |  |  +--ro color-aware?                  boolean
        |  |  |  +--ro coupling-flag?                boolean
        |  |  +--ro available-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-interaction-algorithm?   string
+       |  |     +--ro total-size?                   fixed-capacity-value
+       |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |     +--ro committed-information-rate?   uint64
+       |  |     +--ro committed-burst-size?         uint64
+       |  |     +--ro peak-information-rate?        uint64
+       |  |     +--ro peak-burst-size?              uint64
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
        |  +--ro transfer-cost
        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
        |  |     +--ro cost-name         string
@@ -225,24 +195,14 @@ module: tapi-topology
        |  |  |  +--ro color-aware?                  boolean
        |  |  |  +--ro coupling-flag?                boolean
        |  |  +--ro available-capacity
-       |  |  |  +--ro total-size?                   fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-assigned-to-user-view* [total-size]
-       |  |  |  +--ro total-size                    fixed-capacity-value
-       |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-       |  |  |  +--ro committed-information-rate?   uint64
-       |  |  |  +--ro committed-burst-size?         uint64
-       |  |  |  +--ro peak-information-rate?        uint64
-       |  |  |  +--ro peak-burst-size?              uint64
-       |  |  |  +--ro color-aware?                  boolean
-       |  |  |  +--ro coupling-flag?                boolean
-       |  |  +--ro capacity-interaction-algorithm?   string
+       |  |     +--ro total-size?                   fixed-capacity-value
+       |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+       |  |     +--ro committed-information-rate?   uint64
+       |  |     +--ro committed-burst-size?         uint64
+       |  |     +--ro peak-information-rate?        uint64
+       |  |     +--ro peak-burst-size?              uint64
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
        |  +--ro transfer-cost
        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
        |  |     +--ro cost-name         string
@@ -346,24 +306,14 @@ module: tapi-topology
     |        |  |  |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  |  |  +--ro coupling-flag?                boolean
     |        |  |  |  |  +--ro available-capacity
-    |        |  |  |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |  |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |  |     +--ro committed-information-rate?   uint64
+    |        |  |  |  |     +--ro committed-burst-size?         uint64
+    |        |  |  |  |     +--ro peak-information-rate?        uint64
+    |        |  |  |  |     +--ro peak-burst-size?              uint64
+    |        |  |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |  |     +--ro coupling-flag?                boolean
     |        |  |  |  +--ro transfer-cost
     |        |  |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |  |  |     +--ro cost-name         string
@@ -395,24 +345,14 @@ module: tapi-topology
     |        |  |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  |  +--ro coupling-flag?                boolean
     |        |  |  |  +--ro available-capacity
-    |        |  |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |     +--ro committed-information-rate?   uint64
+    |        |  |  |     +--ro committed-burst-size?         uint64
+    |        |  |  |     +--ro peak-information-rate?        uint64
+    |        |  |  |     +--ro peak-burst-size?              uint64
+    |        |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |     +--ro coupling-flag?                boolean
     |        |  |  +--ro transfer-cost
     |        |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |  |     +--ro cost-name         string
@@ -449,24 +389,14 @@ module: tapi-topology
     |        |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  +--ro coupling-flag?                boolean
     |        |  |  +--ro available-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro transfer-cost
     |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |     +--ro cost-name         string
@@ -509,24 +439,14 @@ module: tapi-topology
     |        |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  +--ro coupling-flag?                boolean
     |        |  |  +--ro available-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro transfer-cost
     |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |     +--ro cost-name         string
@@ -628,24 +548,14 @@ module: tapi-topology
     |        |  |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  |  +--ro coupling-flag?                boolean
     |        |  |  |  +--ro available-capacity
-    |        |  |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |  |     +--ro committed-information-rate?   uint64
+    |        |  |  |     +--ro committed-burst-size?         uint64
+    |        |  |  |     +--ro peak-information-rate?        uint64
+    |        |  |  |     +--ro peak-burst-size?              uint64
+    |        |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |     +--ro coupling-flag?                boolean
     |        |  |  +--ro transfer-cost
     |        |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |  |     +--ro cost-name         string
@@ -677,24 +587,14 @@ module: tapi-topology
     |        |  |  |  +--ro color-aware?                  boolean
     |        |  |  |  +--ro coupling-flag?                boolean
     |        |  |  +--ro available-capacity
-    |        |  |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  |  +--ro committed-information-rate?   uint64
-    |        |  |  |  +--ro committed-burst-size?         uint64
-    |        |  |  |  +--ro peak-information-rate?        uint64
-    |        |  |  |  +--ro peak-burst-size?              uint64
-    |        |  |  |  +--ro color-aware?                  boolean
-    |        |  |  |  +--ro coupling-flag?                boolean
-    |        |  |  +--ro capacity-interaction-algorithm?   string
+    |        |  |     +--ro total-size?                   fixed-capacity-value
+    |        |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate?   uint64
+    |        |  |     +--ro committed-burst-size?         uint64
+    |        |  |     +--ro peak-information-rate?        uint64
+    |        |  |     +--ro peak-burst-size?              uint64
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro transfer-cost
     |        |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |  |     +--ro cost-name         string
@@ -731,24 +631,14 @@ module: tapi-topology
     |        |  |  +--ro color-aware?                  boolean
     |        |  |  +--ro coupling-flag?                boolean
     |        |  +--ro available-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-interaction-algorithm?   string
+    |        |     +--ro total-size?                   fixed-capacity-value
+    |        |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |     +--ro committed-information-rate?   uint64
+    |        |     +--ro committed-burst-size?         uint64
+    |        |     +--ro peak-information-rate?        uint64
+    |        |     +--ro peak-burst-size?              uint64
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
     |        +--ro transfer-cost
     |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |     +--ro cost-name         string
@@ -823,24 +713,14 @@ module: tapi-topology
     |        |  |  +--ro color-aware?                  boolean
     |        |  |  +--ro coupling-flag?                boolean
     |        |  +--ro available-capacity
-    |        |  |  +--ro total-size?                   fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-assigned-to-user-view* [total-size]
-    |        |  |  +--ro total-size                    fixed-capacity-value
-    |        |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-    |        |  |  +--ro committed-information-rate?   uint64
-    |        |  |  +--ro committed-burst-size?         uint64
-    |        |  |  +--ro peak-information-rate?        uint64
-    |        |  |  +--ro peak-burst-size?              uint64
-    |        |  |  +--ro color-aware?                  boolean
-    |        |  |  +--ro coupling-flag?                boolean
-    |        |  +--ro capacity-interaction-algorithm?   string
+    |        |     +--ro total-size?                   fixed-capacity-value
+    |        |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+    |        |     +--ro committed-information-rate?   uint64
+    |        |     +--ro committed-burst-size?         uint64
+    |        |     +--ro peak-information-rate?        uint64
+    |        |     +--ro peak-burst-size?              uint64
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
     |        +--ro transfer-cost
     |        |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
     |        |     +--ro cost-name         string
@@ -935,24 +815,14 @@ module: tapi-topology
              |  |  |  |  |  +--ro color-aware?                  boolean
              |  |  |  |  |  +--ro coupling-flag?                boolean
              |  |  |  |  +--ro available-capacity
-             |  |  |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  |  |  +--ro color-aware?                  boolean
-             |  |  |  |  |  +--ro coupling-flag?                boolean
-             |  |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  |  |  +--ro color-aware?                  boolean
-             |  |  |  |  |  +--ro coupling-flag?                boolean
-             |  |  |  |  +--ro capacity-interaction-algorithm?   string
+             |  |  |  |     +--ro total-size?                   fixed-capacity-value
+             |  |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |  |  |     +--ro committed-information-rate?   uint64
+             |  |  |  |     +--ro committed-burst-size?         uint64
+             |  |  |  |     +--ro peak-information-rate?        uint64
+             |  |  |  |     +--ro peak-burst-size?              uint64
+             |  |  |  |     +--ro color-aware?                  boolean
+             |  |  |  |     +--ro coupling-flag?                boolean
              |  |  |  +--ro transfer-cost
              |  |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
              |  |  |  |     +--ro cost-name         string
@@ -984,24 +854,14 @@ module: tapi-topology
              |  |  |  |  +--ro color-aware?                  boolean
              |  |  |  |  +--ro coupling-flag?                boolean
              |  |  |  +--ro available-capacity
-             |  |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  |  +--ro color-aware?                  boolean
-             |  |  |  |  +--ro coupling-flag?                boolean
-             |  |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  |  +--ro color-aware?                  boolean
-             |  |  |  |  +--ro coupling-flag?                boolean
-             |  |  |  +--ro capacity-interaction-algorithm?   string
+             |  |  |     +--ro total-size?                   fixed-capacity-value
+             |  |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |  |     +--ro committed-information-rate?   uint64
+             |  |  |     +--ro committed-burst-size?         uint64
+             |  |  |     +--ro peak-information-rate?        uint64
+             |  |  |     +--ro peak-burst-size?              uint64
+             |  |  |     +--ro color-aware?                  boolean
+             |  |  |     +--ro coupling-flag?                boolean
              |  |  +--ro transfer-cost
              |  |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
              |  |  |     +--ro cost-name         string
@@ -1038,24 +898,14 @@ module: tapi-topology
              |  |  |  +--ro color-aware?                  boolean
              |  |  |  +--ro coupling-flag?                boolean
              |  |  +--ro available-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-interaction-algorithm?   string
+             |  |     +--ro total-size?                   fixed-capacity-value
+             |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |     +--ro committed-information-rate?   uint64
+             |  |     +--ro committed-burst-size?         uint64
+             |  |     +--ro peak-information-rate?        uint64
+             |  |     +--ro peak-burst-size?              uint64
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
              |  +--ro transfer-cost
              |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
              |  |     +--ro cost-name         string
@@ -1098,24 +948,14 @@ module: tapi-topology
              |  |  |  +--ro color-aware?                  boolean
              |  |  |  +--ro coupling-flag?                boolean
              |  |  +--ro available-capacity
-             |  |  |  +--ro total-size?                   fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-assigned-to-user-view* [total-size]
-             |  |  |  +--ro total-size                    fixed-capacity-value
-             |  |  |  +--ro packet-bw-profile-type?       bandwidth-profile-type
-             |  |  |  +--ro committed-information-rate?   uint64
-             |  |  |  +--ro committed-burst-size?         uint64
-             |  |  |  +--ro peak-information-rate?        uint64
-             |  |  |  +--ro peak-burst-size?              uint64
-             |  |  |  +--ro color-aware?                  boolean
-             |  |  |  +--ro coupling-flag?                boolean
-             |  |  +--ro capacity-interaction-algorithm?   string
+             |  |     +--ro total-size?                   fixed-capacity-value
+             |  |     +--ro packet-bw-profile-type?       bandwidth-profile-type
+             |  |     +--ro committed-information-rate?   uint64
+             |  |     +--ro committed-burst-size?         uint64
+             |  |     +--ro peak-information-rate?        uint64
+             |  |     +--ro peak-burst-size?              uint64
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
              |  +--ro transfer-cost
              |  |  +--ro cost-characteristic* [cost-name cost-value cost-algorithm]
              |  |     +--ro cost-name         string

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -4,9 +4,6 @@ module: tapi-topology
     |  +--ro topology*   -> /tapi-common:context/tapi-topology:topology/uuid
     |  +--ro uuid?       universal-id
     |  +--ro name* [value-name]
-    |  |  +--ro value-name    string
-    |  |  +--ro value?        string
-    |  +--ro label* [value-name]
     |     +--ro value-name    string
     |     +--ro value?        string
     +--ro topology* [uuid]
@@ -31,9 +28,6 @@ module: tapi-topology
        |  |  +--ro link-port-role?                   tapi-common:port-role
        |  |  +--ro uuid                              universal-id
        |  |  +--ro name* [value-name]
-       |  |  |  +--ro value-name    string
-       |  |  |  +--ro value?        string
-       |  |  +--ro label* [value-name]
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
        |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
@@ -105,9 +99,6 @@ module: tapi-topology
        |  |  |  |     +--ro risk-identifier-list*       string
        |  |  |  +--ro uuid                          universal-id
        |  |  |  +--ro name* [value-name]
-       |  |  |  |  +--ro value-name    string
-       |  |  |  |  +--ro value?        string
-       |  |  |  +--ro label* [value-name]
        |  |  |     +--ro value-name    string
        |  |  |     +--ro value?        string
        |  |  +--ro transfer-capacity
@@ -157,9 +148,6 @@ module: tapi-topology
        |  |  |     +--ro risk-identifier-list*       string
        |  |  +--ro uuid                 universal-id
        |  |  +--ro name* [value-name]
-       |  |  |  +--ro value-name    string
-       |  |  |  +--ro value?        string
-       |  |  +--ro label* [value-name]
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
        |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
@@ -218,9 +206,6 @@ module: tapi-topology
        |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
        |  +--ro uuid                          universal-id
        |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
        +--ro link* [uuid]
@@ -293,17 +278,11 @@ module: tapi-topology
        |  +--ro direction?             tapi-common:forwarding-direction
        |  +--ro uuid                   universal-id
        |  +--ro name* [value-name]
-       |  |  +--ro value-name    string
-       |  |  +--ro value?        string
-       |  +--ro label* [value-name]
        |     +--ro value-name    string
        |     +--ro value?        string
        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
        +--ro uuid                   universal-id
        +--ro name* [value-name]
-       |  +--ro value-name    string
-       |  +--ro value?        string
-       +--ro label* [value-name]
           +--ro value-name    string
           +--ro value?        string
 
@@ -334,9 +313,6 @@ module: tapi-topology
     |        |  |  +--ro link-port-role?                   tapi-common:port-role
     |        |  |  +--ro uuid                              universal-id
     |        |  |  +--ro name* [value-name]
-    |        |  |  |  +--ro value-name    string
-    |        |  |  |  +--ro value?        string
-    |        |  |  +--ro label* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
     |        |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
@@ -408,9 +384,6 @@ module: tapi-topology
     |        |  |  |  |     +--ro risk-identifier-list*       string
     |        |  |  |  +--ro uuid                          universal-id
     |        |  |  |  +--ro name* [value-name]
-    |        |  |  |  |  +--ro value-name    string
-    |        |  |  |  |  +--ro value?        string
-    |        |  |  |  +--ro label* [value-name]
     |        |  |  |     +--ro value-name    string
     |        |  |  |     +--ro value?        string
     |        |  |  +--ro transfer-capacity
@@ -460,9 +433,6 @@ module: tapi-topology
     |        |  |  |     +--ro risk-identifier-list*       string
     |        |  |  +--ro uuid                 universal-id
     |        |  |  +--ro name* [value-name]
-    |        |  |  |  +--ro value-name    string
-    |        |  |  |  +--ro value?        string
-    |        |  |  +--ro label* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
     |        |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
@@ -521,9 +491,6 @@ module: tapi-topology
     |        |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
     |        |  +--ro uuid                          universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro link* [uuid]
@@ -596,17 +563,11 @@ module: tapi-topology
     |        |  +--ro direction?             tapi-common:forwarding-direction
     |        |  +--ro uuid                   universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-node-details
@@ -635,9 +596,6 @@ module: tapi-topology
     |        |  +--ro link-port-role?                   tapi-common:port-role
     |        |  +--ro uuid                              universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
@@ -709,9 +667,6 @@ module: tapi-topology
     |        |  |  |     +--ro risk-identifier-list*       string
     |        |  |  +--ro uuid                          universal-id
     |        |  |  +--ro name* [value-name]
-    |        |  |  |  +--ro value-name    string
-    |        |  |  |  +--ro value?        string
-    |        |  |  +--ro label* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
     |        |  +--ro transfer-capacity
@@ -761,9 +716,6 @@ module: tapi-topology
     |        |  |     +--ro risk-identifier-list*       string
     |        |  +--ro uuid                 universal-id
     |        |  +--ro name* [value-name]
-    |        |  |  +--ro value-name    string
-    |        |  |  +--ro value?        string
-    |        |  +--ro label* [value-name]
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
@@ -822,9 +774,6 @@ module: tapi-topology
     |        +--ro layer-protocol-name*          tapi-common:layer-protocol-name
     |        +--ro uuid?                         universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-node-edge-point-details
@@ -853,9 +802,6 @@ module: tapi-topology
     |        +--ro link-port-role?                   tapi-common:port-role
     |        +--ro uuid?                             universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-link-details
@@ -933,9 +879,6 @@ module: tapi-topology
     |        +--ro direction?             tapi-common:forwarding-direction
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-topology-list
@@ -962,9 +905,6 @@ module: tapi-topology
              |  |  +--ro link-port-role?                   tapi-common:port-role
              |  |  +--ro uuid                              universal-id
              |  |  +--ro name* [value-name]
-             |  |  |  +--ro value-name    string
-             |  |  |  +--ro value?        string
-             |  |  +--ro label* [value-name]
              |  |     +--ro value-name    string
              |  |     +--ro value?        string
              |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
@@ -1036,9 +976,6 @@ module: tapi-topology
              |  |  |  |     +--ro risk-identifier-list*       string
              |  |  |  +--ro uuid                          universal-id
              |  |  |  +--ro name* [value-name]
-             |  |  |  |  +--ro value-name    string
-             |  |  |  |  +--ro value?        string
-             |  |  |  +--ro label* [value-name]
              |  |  |     +--ro value-name    string
              |  |  |     +--ro value?        string
              |  |  +--ro transfer-capacity
@@ -1088,9 +1025,6 @@ module: tapi-topology
              |  |  |     +--ro risk-identifier-list*       string
              |  |  +--ro uuid                 universal-id
              |  |  +--ro name* [value-name]
-             |  |  |  +--ro value-name    string
-             |  |  |  +--ro value?        string
-             |  |  +--ro label* [value-name]
              |  |     +--ro value-name    string
              |  |     +--ro value?        string
              |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
@@ -1149,9 +1083,6 @@ module: tapi-topology
              |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
              |  +--ro uuid                          universal-id
              |  +--ro name* [value-name]
-             |  |  +--ro value-name    string
-             |  |  +--ro value?        string
-             |  +--ro label* [value-name]
              |     +--ro value-name    string
              |     +--ro value?        string
              +--ro link* [uuid]
@@ -1224,16 +1155,10 @@ module: tapi-topology
              |  +--ro direction?             tapi-common:forwarding-direction
              |  +--ro uuid                   universal-id
              |  +--ro name* [value-name]
-             |  |  +--ro value-name    string
-             |  |  +--ro value?        string
-             |  +--ro label* [value-name]
              |     +--ro value-name    string
              |     +--ro value?        string
              +--ro layer-protocol-name*   tapi-common:layer-protocol-name
              +--ro uuid?                  universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -46,7 +46,7 @@ module tapi-topology {
             }
             container transfer-capacity {
                 config false;
-                uses transfer-capacity-pac-g;
+                uses tapi-common:capacity-pac-g;
                 description "none";
             }
             container transfer-cost {
@@ -128,7 +128,7 @@ module tapi-topology {
             }
             container transfer-capacity {
                 config false;
-                uses transfer-capacity-pac-g;
+                uses tapi-common:capacity-pac-g;
                 description "none";
             }
             container transfer-cost {
@@ -252,35 +252,6 @@ module tapi-topology {
                 Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.
                 Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.";
         }
-        grouping transfer-capacity-pac-g {
-            container total-potential-capacity {
-                config false;
-                uses capacity-g;
-                description "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.";
-            }
-            container available-capacity {
-                config false;
-                uses capacity-g;
-                description "Capacity available to be assigned.";
-            }
-            list capacity-assigned-to-user-view {
-                key 'total-size';
-                config false;
-                uses capacity-g;
-                description "Capacity already assigned";
-            }
-            leaf capacity-interaction-algorithm {
-                type string;
-                config false;
-                description "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)";
-            }
-            description "The TopologicalEntity derives capacity from the underlying realization. 
-                A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.
-                A TopologicalEntity may be directly used in the view or may be assigned to another view for use.
-                The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.
-                Represents the capacity available to user (client) along with client interaction and usage. 
-                A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
-        }
         grouping transfer-cost-pac-g {
             list cost-characteristic {
                 key 'cost-name cost-value cost-algorithm';
@@ -393,7 +364,7 @@ module tapi-topology {
                 description "none";
             }
             container transfer-capacity {
-                uses transfer-capacity-pac-g;
+                uses tapi-common:capacity-pac-g;
                 description "none";
             }
             container transfer-cost {
@@ -437,7 +408,7 @@ module tapi-topology {
                 description "none";
             }
             container transfer-capacity {
-                uses transfer-capacity-pac-g;
+                uses tapi-common:capacity-pac-g;
                 description "none";
             }
             container transfer-cost {
@@ -475,41 +446,6 @@ module tapi-topology {
     /***********************
     * package type-definitions
     **********************/ 
-        grouping capacity-g {
-            leaf total-size {
-                type fixed-capacity-value;
-                description "Total capacity of the TopologicalEntity in MB/s";
-            }
-            leaf packet-bw-profile-type {
-                type bandwidth-profile-type;
-                description "none";
-            }
-            leaf committed-information-rate {
-                type uint64;
-                description "none";
-            }
-            leaf committed-burst-size {
-                type uint64;
-                description "none";
-            }
-            leaf peak-information-rate {
-                type uint64;
-                description "none";
-            }
-            leaf peak-burst-size {
-                type uint64;
-                description "none";
-            }
-            leaf color-aware {
-                type boolean;
-                description "none";
-            }
-            leaf coupling-flag {
-                type boolean;
-                description "none";
-            }
-            description "Information on capacity of a particular TopologicalEntity.";
-        }
         grouping cost-characteristic-g {
             leaf cost-name {
                 type string;
@@ -524,41 +460,6 @@ module tapi-topology {
                 description "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.";
             }
             description "The information for a particular cost characteristic.";
-        }
-        typedef fixed-capacity-value {
-            type enumeration {
-                enum not-applicable {
-                    description "none";
-                }
-                enum 10mbps {
-                    description "none";
-                }
-                enum 100mbps {
-                    description "none";
-                }
-                enum 1gbps {
-                    description "none";
-                }
-                enum 2.4gbps {
-                    description "none";
-                }
-                enum 10gbps {
-                    description "none";
-                }
-                enum 40gbps {
-                    description "none";
-                }
-                enum 100gbps {
-                    description "none";
-                }
-                enum 200gbps {
-                    description "none";
-                }
-                enum 400gbps {
-                    description "none";
-                }
-            }
-            description "The Capacity (Bandwidth) values that are applicable for digital layers. ";
         }
         grouping latency-characteristic-g {
             leaf fixed-latency-characteristic {
@@ -616,26 +517,6 @@ module tapi-topology {
                 description "Quality of validation (i.e. how likely is the stated validation to be invalid)";
             }
             description "Identifies the validation mechanism and describes the characteristics of that mechanism";
-        }
-        typedef bandwidth-profile-type {
-            type enumeration {
-                enum not-applicable {
-                    description "none";
-                }
-                enum mef-10.x {
-                    description "none";
-                }
-                enum rfc-2697 {
-                    description "none";
-                }
-                enum rfc-2698 {
-                    description "none";
-                }
-                enum rfc-4115 {
-                    description "none";
-                }
-            }
-            description "none";
         }
         typedef forwarding-rule {
             type enumeration {

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -210,7 +210,7 @@ module tapi-topology {
                 type leafref {
                     path '/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid';
                 }
-                description "none";
+                description "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental";
             }
             container state {
                 config false;

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -217,11 +217,6 @@ module tapi-topology {
                 uses tapi-common:admin-state-pac-g;
                 description "none";
             }
-            leaf termination-direction {
-                type tapi-common:termination-direction;
-                config false;
-                description "none";
-            }
             leaf link-port-direction {
                 type tapi-common:port-direction;
                 config false;

--- a/YANG/tapi-virtual-network.tree
+++ b/YANG/tapi-virtual-network.tree
@@ -50,9 +50,6 @@ module: tapi-virtual-network
        +--rw layer-protocol-name*   tapi-common:layer-protocol-name
        +--rw uuid                   universal-id
        +--rw name* [value-name]
-       |  +--rw value-name    string
-       |  +--rw value?        string
-       +--rw label* [value-name]
           +--rw value-name    string
           +--rw value?        string
 
@@ -151,9 +148,6 @@ module: tapi-virtual-network
     |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x delete-virtual-network-service
@@ -210,9 +204,6 @@ module: tapi-virtual-network
     |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-virtual-network-service-details
@@ -269,9 +260,6 @@ module: tapi-virtual-network
     |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
     |        +--ro uuid?                  universal-id
     |        +--ro name* [value-name]
-    |        |  +--ro value-name    string
-    |        |  +--ro value?        string
-    |        +--ro label* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-virtual-network-service-list
@@ -326,8 +314,5 @@ module: tapi-virtual-network
              +--ro layer-protocol-name*   tapi-common:layer-protocol-name
              +--ro uuid?                  universal-id
              +--ro name* [value-name]
-             |  +--ro value-name    string
-             |  +--ro value?        string
-             +--ro label* [value-name]
                 +--ro value-name    string
                 +--ro value?        string

--- a/YANG/tapi-virtual-network.yang
+++ b/YANG/tapi-virtual-network.yang
@@ -48,7 +48,7 @@ module tapi-virtual-network {
                 description "none";
             }
             container requested-capacity {
-                uses tapi-topology:capacity-g;
+                uses tapi-common:capacity-g;
                 description "none";
             }
             leaf service-level {


### PR DESCRIPTION
- Fix #191 - Removed label attribute from the TAPI GlobalClass
- Fix #215 - Deleted TerminationDirection from SIP, NEP & CEP classes
- Fixes #199, #200 Added Capacity to SIP, CSEP
- Fixes #201 Added LayerProtocol to CSEP. Also moved the CapacityPac and Capacity DataTypes from TapiTopology to TapiCommon
- Fixes #224, Added following association to Connection: ConnectionSupportsLinks
- Fixes #225 Redefined Route as series of CEPs instead of Connections and added following association to Connection: ConnectionHasLowerLevelConnections