### PR TITLE
Oam Model updates as per 06/22/17 IMP call

### DIFF
--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -610,6 +610,54 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nWSEIldQEeejsLaQeGcDdg" x="-210" y="47"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_Hwr9I1dVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Hwr9JFdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hwr9JldVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hwr9JVdVEeejsLaQeGcDdg" x="-343" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HwyDw1dVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HwyDxFdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HwyDxldVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HwyDxVdVEeejsLaQeGcDdg" x="-227" y="-117"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HxRzAFdVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HxRzAVdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxRzA1dVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HxRzAldVEeejsLaQeGcDdg" x="-311" y="10"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HxXSkFdVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HxXSkVdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxXSk1dVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HxXSkldVEeejsLaQeGcDdg" x="-311" y="-90"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HxcLEFdVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HxcLEVdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxcyIFdVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HxcLEldVEeejsLaQeGcDdg" x="-311" y="-90"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Hxi4wFdVEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Hxi4wVdVEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hxi4w1dVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Hxi4wldVEeejsLaQeGcDdg" x="-311" y="-90"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z8zk8evSEealldJ4rm6P_g" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z8zk8uvSEealldJ4rm6P_g"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_z8zk8-vSEealldJ4rm6P_g">
@@ -1204,6 +1252,66 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YHkW4ldTEeejsLaQeGcDdg" points="[-25, 0, 56, -1]$[-100, -28, -19, -29]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YIgyEFdTEeejsLaQeGcDdg" id="(0.0,0.3793103448275862)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YIgyEVdTEeejsLaQeGcDdg" id="(1.0,0.3793103448275862)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HwskMFdVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_fc1w8OwLEealldJ4rm6P_g" target="_Hwr9I1dVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HwskMVdVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HwskNVdVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HwskMldVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwskM1dVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HwskNFdVEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HwyDx1dVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dcMSYOwMEealldJ4rm6P_g" target="_HwyDw1dVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HwyDyFdVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hwyq0ldVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HwyDyVdVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hwyq0FdVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hwyq0VdVEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HxRzBFdVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_emkToO6lEeaHHP1Zcp2a0A" target="_HxRzAFdVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HxRzBVdVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxRzCVdVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HxRzBldVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxRzB1dVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxRzCFdVEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HxXSlFdVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_g5zzgO6jEeaHHP1Zcp2a0A" target="_HxXSkFdVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HxXSlVdVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxXSmVdVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HxXSlldVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxXSl1dVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxXSmFdVEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HxcyIVdVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A" target="_HxcLEFdVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HxcyIldVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HxcyJldVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HxcyI1dVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxcyJFdVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HxcyJVdVEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Hxi4xFdVEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_Z1Zb8BNKEeeQQtMBY9ly8w" target="_Hxi4wFdVEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Hxi4xVdVEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Hxi4yVdVEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hxi4xldVEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hxi4x1dVEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hxi4yFdVEeejsLaQeGcDdg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_dPewEFdMEeejsLaQeGcDdg" type="PapyrusUMLClassDiagram" name="OamSkeleton" measurementUnit="Pixel">

--- a/UML/TapiOam.notation
+++ b/UML/TapiOam.notation
@@ -4,7 +4,7 @@
     <stylesheets xmi:type="css:StyleSheetReference" xmi:id="_RfHAMMOaEeaFfJxGCRaf4A" path="/OTWG MEP Refactoring/CompartmentRestrictions.css"/>
     <stylesheets xmi:type="css:StyleSheetReference" xmi:id="_RfHAMcOaEeaFfJxGCRaf4A" path="/OTWG MEP Refactoring/NoStereotyesDiagram.css"/>
   </css:ModelStyleSheets>
-  <notation:Diagram xmi:id="_z8zk8OvSEealldJ4rm6P_g" type="PapyrusUMLClassDiagram" name="OamSkeleton" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="_z8zk8OvSEealldJ4rm6P_g" type="PapyrusUMLClassDiagram" name="OamServiceSkeleton" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_fc1w8OwLEealldJ4rm6P_g" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_fc1w8uwLEealldJ4rm6P_g" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_fc1w8-wLEealldJ4rm6P_g" type="8510">
@@ -29,83 +29,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fc73nuwLEealldJ4rm6P_g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fc1w8ewLEealldJ4rm6P_g" x="-457" y="66" width="108" height="53"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_fdIE0-wLEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_fdIE1OwLEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fdIE1uwLEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fdIE1ewLEealldJ4rm6P_g" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZUO-gOwMEealldJ4rm6P_g" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZUO-guwMEealldJ4rm6P_g" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZUO-g-wMEealldJ4rm6P_g" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZUO-hOwMEealldJ4rm6P_g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_ZUO-hewMEealldJ4rm6P_g" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_ZUO-huwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_ZUO-h-wMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_ZUO-iOwMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZUO-iewMEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_ZUO-iuwMEealldJ4rm6P_g" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_ZUO-i-wMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_ZUO-jOwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_ZUO-jewMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZUO-juwMEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_ZUO-j-wMEealldJ4rm6P_g" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_ZUO-kOwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_ZUO-kewMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_ZUO-kuwMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZUO-k-wMEealldJ4rm6P_g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZUO-gewMEealldJ4rm6P_g" x="-407" y="-175" width="132" height="61"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ZUbL2-wMEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_ZUbL3OwMEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZUbL3uwMEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZUbL3ewMEealldJ4rm6P_g" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_a0jhwOwMEealldJ4rm6P_g" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_a0jhwuwMEealldJ4rm6P_g" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_a0jhw-wMEealldJ4rm6P_g" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_a0jhxOwMEealldJ4rm6P_g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a0jhxewMEealldJ4rm6P_g" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a0jhxuwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a0jhx-wMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a0jhyOwMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a0jhyewMEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a0jhyuwMEealldJ4rm6P_g" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a0jhy-wMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a0jhzOwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a0jhzewMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a0jhzuwMEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_a0jhz-wMEealldJ4rm6P_g" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_a0jh0OwMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_a0jh0ewMEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_a0jh0uwMEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a0jh0-wMEealldJ4rm6P_g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a0jhwewMEealldJ4rm6P_g" x="-398" y="-56" height="63"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_a011o-wMEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_a011pOwMEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_a011puwMEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a011pewMEealldJ4rm6P_g" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fc1w8ewLEealldJ4rm6P_g" x="-543" y="-116" width="108" height="53"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dcMSYOwMEealldJ4rm6P_g" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_dcMSYuwMEealldJ4rm6P_g" type="5029"/>
@@ -131,15 +55,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dcMSc-wMEealldJ4rm6P_g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dcMSYewMEealldJ4rm6P_g" x="-338" y="64" width="114" height="58"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_dcYfq-wMEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_dcYfrOwMEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dcYfruwMEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dcYfrewMEealldJ4rm6P_g" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dcMSYewMEealldJ4rm6P_g" x="-427" y="-117" width="114" height="52"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JiUvg-wNEealldJ4rm6P_g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_JiUvhOwNEealldJ4rm6P_g" showTitle="true"/>
@@ -190,22 +106,6 @@
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ko7yRuwNEealldJ4rm6P_g" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ko7yRewNEealldJ4rm6P_g" x="802" y="80"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_MXovw-wNEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MXovxOwNEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXovxuwNEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MXovxewNEealldJ4rm6P_g" x="676" y="-47"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_MvhEQ-wNEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_MvhEROwNEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MvhERuwNEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MvhERewNEealldJ4rm6P_g" x="681" y="-182"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_NkGi4-wNEealldJ4rm6P_g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_NkGi5OwNEealldJ4rm6P_g" showTitle="true"/>
@@ -273,40 +173,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1qwSzewNEealldJ4rm6P_g" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_QuX0kOwPEealldJ4rm6P_g" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_QuX0kuwPEealldJ4rm6P_g" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_QuX0k-wPEealldJ4rm6P_g" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QuX0lOwPEealldJ4rm6P_g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QuX0lewPEealldJ4rm6P_g" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QuX0luwPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QuX0l-wPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QuX0mOwPEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuX0mewPEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QuX0muwPEealldJ4rm6P_g" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QuX0m-wPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QuX0nOwPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QuX0newPEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuX0nuwPEealldJ4rm6P_g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_QuX0n-wPEealldJ4rm6P_g" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_QuX0oOwPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_QuX0oewPEealldJ4rm6P_g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_QuX0ouwPEealldJ4rm6P_g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuX0o-wPEealldJ4rm6P_g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuX0kewPEealldJ4rm6P_g" x="329" y="-52" height="53"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_QuwPE-wPEealldJ4rm6P_g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_QuwPFOwPEealldJ4rm6P_g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QuwPFuwPEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QuwPFewPEealldJ4rm6P_g" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_Sv-f8OwPEealldJ4rm6P_g" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_Sv-f8uwPEealldJ4rm6P_g" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_Sv-f8-wPEealldJ4rm6P_g" type="8510">
@@ -331,7 +197,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sv-gA-wPEealldJ4rm6P_g"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sv-f8ewPEealldJ4rm6P_g" x="341" y="84" width="113" height="72"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sv-f8ewPEealldJ4rm6P_g" x="-251" width="113" height="72"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SwQz0-wPEealldJ4rm6P_g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_SwQz1OwPEealldJ4rm6P_g" showTitle="true"/>
@@ -399,14 +265,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qZW1JexIEeaTUPmcu3rLwA" x="320" y="-545"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_dgoONuxTEeaTUPmcu3rLwA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_dgoON-xTEeaTUPmcu3rLwA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dgoOOexTEeaTUPmcu3rLwA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dgoOOOxTEeaTUPmcu3rLwA" x="492" y="-134"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_1ajwY-xWEeaTUPmcu3rLwA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_1ajwZOxWEeaTUPmcu3rLwA" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1ajwZuxWEeaTUPmcu3rLwA" name="BASE_ELEMENT"/>
@@ -452,7 +310,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nm6xVexYEeaTUPmcu3rLwA"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nm6xQ-xYEeaTUPmcu3rLwA" x="-506" y="-304" height="66"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nm6xQ-xYEeaTUPmcu3rLwA" x="-543" y="-318" width="166" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_NnNFN-xYEeaTUPmcu3rLwA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_NnNFOOxYEeaTUPmcu3rLwA" showTitle="true"/>
@@ -476,9 +334,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9c_q4-xYEeaTUPmcu3rLwA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9c_q5OxYEeaTUPmcu3rLwA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9c_q5uxYEeaTUPmcu3rLwA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Dependency" href="TapiOam.uml#_9cCooOxYEeaTUPmcu3rLwA"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9c_q5uxYEeaTUPmcu3rLwA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9c_q5exYEeaTUPmcu3rLwA" x="49" y="-541"/>
     </children>
@@ -499,22 +355,6 @@
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8F6txuxZEeaTUPmcu3rLwA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8F6txexZEeaTUPmcu3rLwA" x="-1" y="-434"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_g7J3U-6jEeaHHP1Zcp2a0A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_g7J3VO6jEeaHHP1Zcp2a0A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g7J3Vu6jEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g7J3Ve6jEeaHHP1Zcp2a0A" x="453" y="-56"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_hoYJs-6jEeaHHP1Zcp2a0A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_hoYJtO6jEeaHHP1Zcp2a0A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hoYJtu6jEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hoYJte6jEeaHHP1Zcp2a0A" x="453" y="-56"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_emkToO6lEeaHHP1Zcp2a0A" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_emkTou6lEeaHHP1Zcp2a0A" type="5029"/>
@@ -540,15 +380,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkTs-6lEeaHHP1Zcp2a0A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-410" y="210" width="134" height="60"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_emqaW-6lEeaHHP1Zcp2a0A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_emqaXO6lEeaHHP1Zcp2a0A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emqaXu6lEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emqaXe6lEeaHHP1Zcp2a0A" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emkToe6lEeaHHP1Zcp2a0A" x="-511" y="10" width="134" height="60"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_4cL74-6nEeaHHP1Zcp2a0A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_4cL75O6nEeaHHP1Zcp2a0A" showTitle="true"/>
@@ -580,40 +412,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__y_xZe6nEeaHHP1Zcp2a0A" x="669" y="-298"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_7WyOUO6zEeaHHP1Zcp2a0A" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_7WyOUu6zEeaHHP1Zcp2a0A" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_7WyOU-6zEeaHHP1Zcp2a0A" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7WyOVO6zEeaHHP1Zcp2a0A" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_7WyOVe6zEeaHHP1Zcp2a0A" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_7WyOVu6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_7WyOV-6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_7WyOWO6zEeaHHP1Zcp2a0A"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7WyOWe6zEeaHHP1Zcp2a0A"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_7WyOWu6zEeaHHP1Zcp2a0A" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_7WyOW-6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_7WyOXO6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_7WyOXe6zEeaHHP1Zcp2a0A"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7WyOXu6zEeaHHP1Zcp2a0A"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_7W4U8O6zEeaHHP1Zcp2a0A" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_7W4U8e6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_7W4U8u6zEeaHHP1Zcp2a0A"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_7W4U8-6zEeaHHP1Zcp2a0A"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7W4U9O6zEeaHHP1Zcp2a0A"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7WyOUe6zEeaHHP1Zcp2a0A" x="334" y="-196" width="117" height="61"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7XQvi-6zEeaHHP1Zcp2a0A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7XQvjO6zEeaHHP1Zcp2a0A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7XQvju6zEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7XQvje6zEeaHHP1Zcp2a0A" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_R7ysU-60EeaHHP1Zcp2a0A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_R7ysVO60EeaHHP1Zcp2a0A" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_R7ysVu60EeaHHP1Zcp2a0A" name="BASE_ELEMENT">
@@ -621,14 +419,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R7ysVe60EeaHHP1Zcp2a0A" x="771" y="-295"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Y79jc-60EeaHHP1Zcp2a0A" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Y79jdO60EeaHHP1Zcp2a0A" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Y79jdu60EeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y79jde60EeaHHP1Zcp2a0A" x="654" y="-168"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_f3yaABM7Eee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_f3yaAhM7Eee0L_IMWjydgQ" type="5029"/>
@@ -672,48 +462,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_u2X5NRM7Eee0L_IMWjydgQ" x="329" y="-547"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_e_oFIxNKEeeQQtMBY9ly8w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_e_oFJBNKEeeQQtMBY9ly8w" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_oFJhNKEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e_oFJRNKEeeQQtMBY9ly8w" x="464" y="-165"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_PBp_YBO0EeeuwKj8ylAa1g" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_PBsboBO0EeeuwKj8ylAa1g" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PBtCsBO0EeeuwKj8ylAa1g" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PBtCsRO0EeeuwKj8ylAa1g" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_PBtpwBO0EeeuwKj8ylAa1g" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_PBtpwRO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_PBtpwhO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_PBtpwxO0EeeuwKj8ylAa1g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PBtpxBO0EeeuwKj8ylAa1g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_PBtpxRO0EeeuwKj8ylAa1g" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_PBtpxhO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_PBtpxxO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_PBtpyBO0EeeuwKj8ylAa1g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PBtpyRO0EeeuwKj8ylAa1g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_PBtpyhO0EeeuwKj8ylAa1g" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_PBtpyxO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_PBtpzBO0EeeuwKj8ylAa1g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_PBtpzRO0EeeuwKj8ylAa1g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PBtpzhO0EeeuwKj8ylAa1g"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PBp_YRO0EeeuwKj8ylAa1g" x="249" y="-320" width="136" height="62"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_PCnBoBO0EeeuwKj8ylAa1g" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_PCnBoRO0EeeuwKj8ylAa1g" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PCnosBO0EeeuwKj8ylAa1g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PCnBohO0EeeuwKj8ylAa1g" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_94EI8BP6EeepnPPr_BcZKg" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_94EI8hP6EeepnPPr_BcZKg" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_94EI8xP6EeepnPPr_BcZKg" type="8510">
@@ -738,7 +486,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_94EJAxP6EeepnPPr_BcZKg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_94EI8RP6EeepnPPr_BcZKg" x="-33" y="-58" height="56"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_94EI8RP6EeepnPPr_BcZKg" x="-33" y="-121" height="56"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_94QWPhP6EeepnPPr_BcZKg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_94QWPxP6EeepnPPr_BcZKg" showTitle="true"/>
@@ -747,14 +495,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_94QWQBP6EeepnPPr_BcZKg" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Eui4kxP7EeepnPPr_BcZKg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Eui4lBP7EeepnPPr_BcZKg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eui4lhP7EeepnPPr_BcZKg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eui4lRP7EeepnPPr_BcZKg" x="79" y="3"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W5IZsBP7EeepnPPr_BcZKg" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_W5IZshP7EeepnPPr_BcZKg" type="5029"/>
@@ -798,64 +538,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nGpKJRP7EeepnPPr_BcZKg" x="426" y="-403"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_f1_d8BoEEeeV4o0osG5stg" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_f1_d8hoEEeeV4o0osG5stg" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_f1_d8xoEEeeV4o0osG5stg" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_f1_d9BoEEeeV4o0osG5stg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_f1_d9RoEEeeV4o0osG5stg" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_f1_d9hoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_f1_d9xoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_f1_d-BoEEeeV4o0osG5stg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_d-RoEEeeV4o0osG5stg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_f1_d-hoEEeeV4o0osG5stg" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_f1_d-xoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_f1_d_BoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_f1_d_RoEEeeV4o0osG5stg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_d_hoEEeeV4o0osG5stg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_f1_d_xoEEeeV4o0osG5stg" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_f1_eABoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_f1_eARoEEeeV4o0osG5stg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_f1_eAhoEEeeV4o0osG5stg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_eAxoEEeeV4o0osG5stg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f1_d8RoEEeeV4o0osG5stg" x="315" y="-451" height="64"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_f2LrPhoEEeeV4o0osG5stg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_f2LrPxoEEeeV4o0osG5stg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f2LrQRoEEeeV4o0osG5stg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f2LrQBoEEeeV4o0osG5stg" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_f3Cm0xoEEeeV4o0osG5stg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_f3Cm1BoEEeeV4o0osG5stg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f3Cm1hoEEeeV4o0osG5stg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_f3Cm1RoEEeeV4o0osG5stg" x="32" y="-413"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7P8WsCBcEeeWCKlkirNtnw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7P8WsSBcEeeWCKlkirNtnw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7P8WsyBcEeeWCKlkirNtnw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7P8WsiBcEeeWCKlkirNtnw" x="454" y="-297"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__RBOYExtEeeBqfKxLidrUg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__RBOYUxtEeeBqfKxLidrUg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RBOY0xtEeeBqfKxLidrUg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__RBOYkxtEeeBqfKxLidrUg" x="449" y="-420"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="__RKYUExtEeeBqfKxLidrUg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__RKYUUxtEeeBqfKxLidrUg" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RKYU0xtEeeBqfKxLidrUg" name="BASE_ELEMENT">
@@ -872,13 +554,69 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WvGdQk8-Eeeicu4cm-7qRg" x="-46" y="-270"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_8AmJU1dLEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8AmJVFdLEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8AmwYFdLEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8AmJVVdLEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nVLQ4FdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nVLQ4VdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nVL38FdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nVLQ4ldQEeejsLaQeGcDdg" x="-257" y="3"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nVTzwFdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nVTzwVdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nVTzw1dQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nVTzwldQEeejsLaQeGcDdg" x="-138" y="1"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nWBlcFdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nWBlcVdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWBlc1dQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nWBlcldQEeejsLaQeGcDdg" x="-210" y="147"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nWF24FdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nWF24VdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWF241dQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nWF24ldQEeejsLaQeGcDdg" x="-210" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nWL9gFdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nWL9gVdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWL9g1dQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nWL9gldQEeejsLaQeGcDdg" x="-210" y="47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nWSEIFdQEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nWSEIVdQEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWSEI1dQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nWSEIldQEeejsLaQeGcDdg" x="-210" y="47"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z8zk8evSEealldJ4rm6P_g" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z8zk8uvSEealldJ4rm6P_g"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_z8zk8-vSEealldJ4rm6P_g">
       <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
-    <edges xmi:type="notation:Connector" xmi:id="_fdIE1-wLEealldJ4rm6P_g" type="StereotypeCommentLink" source="_fc1w8OwLEealldJ4rm6P_g" target="_fdIE0-wLEealldJ4rm6P_g">
+    <edges xmi:type="notation:Connector" xmi:id="_fdIE1-wLEealldJ4rm6P_g" type="StereotypeCommentLink" source="_fc1w8OwLEealldJ4rm6P_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_fdIE2OwLEealldJ4rm6P_g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_fdIE3OwLEealldJ4rm6P_g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
@@ -888,27 +626,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fdIE2uwLEealldJ4rm6P_g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fdIE2-wLEealldJ4rm6P_g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZUhSYOwMEealldJ4rm6P_g" type="StereotypeCommentLink" source="_ZUO-gOwMEealldJ4rm6P_g" target="_ZUbL2-wMEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZUhSYewMEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZUhSZewMEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZUhSYuwMEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUhSY-wMEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZUhSZOwMEealldJ4rm6P_g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_a011p-wMEealldJ4rm6P_g" type="StereotypeCommentLink" source="_a0jhwOwMEealldJ4rm6P_g" target="_a011o-wMEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_a011qOwMEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_a011rOwMEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_a011qewMEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a011quwMEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_a011q-wMEealldJ4rm6P_g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dcYfr-wMEealldJ4rm6P_g" type="StereotypeCommentLink" source="_dcMSYOwMEealldJ4rm6P_g" target="_dcYfq-wMEealldJ4rm6P_g">
+    <edges xmi:type="notation:Connector" xmi:id="_dcYfr-wMEealldJ4rm6P_g" type="StereotypeCommentLink" source="_dcMSYOwMEealldJ4rm6P_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_dcYfsOwMEealldJ4rm6P_g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dcYftOwMEealldJ4rm6P_g" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
@@ -982,111 +700,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ko7ySuwNEealldJ4rm6P_g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ko7yS-wNEealldJ4rm6P_g"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MXKOoOwNEealldJ4rm6P_g" type="4001" source="_a0jhwOwMEealldJ4rm6P_g" target="_ZUO-gOwMEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXKOo-wNEealldJ4rm6P_g" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXKOpOwNEealldJ4rm6P_g" x="-4" y="3"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXKOpewNEealldJ4rm6P_g" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXKOpuwNEealldJ4rm6P_g" x="6" y="2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXKOp-wNEealldJ4rm6P_g" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXKOqOwNEealldJ4rm6P_g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXKOqewNEealldJ4rm6P_g" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXKOquwNEealldJ4rm6P_g" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXQVQOwNEealldJ4rm6P_g" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXQVQewNEealldJ4rm6P_g" x="8" y="17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_MXQVQuwNEealldJ4rm6P_g" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_MXQVQ-wNEealldJ4rm6P_g" x="-7" y="14"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_MXKOoewNEealldJ4rm6P_g"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MXKOouwNEealldJ4rm6P_g" points="[0, 0, -5, 135]$[5, -135, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXQVROwNEealldJ4rm6P_g" id="(0.49523809523809526,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXQVRewNEealldJ4rm6P_g" id="(0.4621212121212121,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MXovx-wNEealldJ4rm6P_g" type="StereotypeCommentLink" source="_MXKOoOwNEealldJ4rm6P_g" target="_MXovw-wNEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MXovyOwNEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MXovzOwNEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MXovyewNEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXovyuwNEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MXovy-wNEealldJ4rm6P_g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MvU3AOwNEealldJ4rm6P_g" type="4001" source="_ZUO-gOwMEealldJ4rm6P_g" target="_1qqMEOwNEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9oOwNEealldJ4rm6P_g" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9oewNEealldJ4rm6P_g" x="60" y="-1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9ouwNEealldJ4rm6P_g" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9o-wNEealldJ4rm6P_g" x="78" y="-8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9pOwNEealldJ4rm6P_g" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9pewNEealldJ4rm6P_g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9puwNEealldJ4rm6P_g" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9p-wNEealldJ4rm6P_g" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9qOwNEealldJ4rm6P_g" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9qewNEealldJ4rm6P_g" x="10" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Mva9quwNEealldJ4rm6P_g" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Mva9q-wNEealldJ4rm6P_g" x="-8" y="13"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_MvU3AewNEealldJ4rm6P_g"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MvU3AuwNEealldJ4rm6P_g" points="[0, -1, -23, 198]$[23, -199, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mva9rOwNEealldJ4rm6P_g" id="(0.4015151515151515,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Mva9rewNEealldJ4rm6P_g" id="(0.08396946564885496,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MvhER-wNEealldJ4rm6P_g" type="StereotypeCommentLink" source="_MvU3AOwNEealldJ4rm6P_g" target="_MvhEQ-wNEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MvhESOwNEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MvhETOwNEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MvhESewNEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MvhESuwNEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MvhES-wNEealldJ4rm6P_g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_O1ddEOwNEealldJ4rm6P_g" type="4001" source="_ZUO-gOwMEealldJ4rm6P_g" target="_NkS1sOxFEeaTUPmcu3rLwA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddE-wNEealldJ4rm6P_g" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddFOwNEealldJ4rm6P_g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddFewNEealldJ4rm6P_g" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddFuwNEealldJ4rm6P_g" x="13" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddF-wNEealldJ4rm6P_g" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddGOwNEealldJ4rm6P_g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddGewNEealldJ4rm6P_g" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddGuwNEealldJ4rm6P_g" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddG-wNEealldJ4rm6P_g" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddHOwNEealldJ4rm6P_g" x="10" y="15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_O1ddHewNEealldJ4rm6P_g" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O1ddHuwNEealldJ4rm6P_g" x="-9" y="15"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_O1ddEewNEealldJ4rm6P_g"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O1ddEuwNEealldJ4rm6P_g" points="[40, 0, -86, -4]$[125, 3, -1, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1ddH-wNEealldJ4rm6P_g" id="(0.7954545454545454,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1ddIOwNEealldJ4rm6P_g" id="(0.20526315789473684,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_O1jjt-wNEealldJ4rm6P_g" type="StereotypeCommentLink" source="_O1ddEOwNEealldJ4rm6P_g" target="_O1jjs-wNEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_O1jjuOwNEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_O1jjvOwNEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O1jjuewNEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1jjuuwNEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O1jju-wNEealldJ4rm6P_g"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_1qwSz-wNEealldJ4rm6P_g" type="StereotypeCommentLink" source="_1qqMEOwNEealldJ4rm6P_g" target="_1qwSy-wNEealldJ4rm6P_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_1qwS0OwNEealldJ4rm6P_g"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1qwS1OwNEealldJ4rm6P_g" name="BASE_ELEMENT">
@@ -1096,16 +709,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1qwS0ewNEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1qwS0uwNEealldJ4rm6P_g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1qwS0-wNEealldJ4rm6P_g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_QuwPF-wPEealldJ4rm6P_g" type="StereotypeCommentLink" source="_QuX0kOwPEealldJ4rm6P_g" target="_QuwPE-wPEealldJ4rm6P_g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_QuwPGOwPEealldJ4rm6P_g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_QuwPHOwPEealldJ4rm6P_g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QuwPGewPEealldJ4rm6P_g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QuwPGuwPEealldJ4rm6P_g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QuwPG-wPEealldJ4rm6P_g"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_SwQz1-wPEealldJ4rm6P_g" type="StereotypeCommentLink" source="_Sv-f8OwPEealldJ4rm6P_g" target="_SwQz0-wPEealldJ4rm6P_g">
       <styles xmi:type="notation:FontStyle" xmi:id="_SwQz2OwPEealldJ4rm6P_g"/>
@@ -1129,10 +732,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qYmAIOxIEeaTUPmcu3rLwA" type="4001" source="_1qqMEOwNEealldJ4rm6P_g" target="_NkS1sOxFEeaTUPmcu3rLwA">
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAI-xIEeaTUPmcu3rLwA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJOxIEeaTUPmcu3rLwA" x="7" y="9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJOxIEeaTUPmcu3rLwA" x="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAJexIEeaTUPmcu3rLwA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJuxIEeaTUPmcu3rLwA" x="-10" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAJuxIEeaTUPmcu3rLwA" x="-8" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmAJ-xIEeaTUPmcu3rLwA" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmAKOxIEeaTUPmcu3rLwA" y="-20"/>
@@ -1144,13 +747,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmALOxIEeaTUPmcu3rLwA" x="7" y="17"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_qYmALexIEeaTUPmcu3rLwA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmALuxIEeaTUPmcu3rLwA" x="1" y="-2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qYmALuxIEeaTUPmcu3rLwA" x="-10" y="19"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_qYmAIexIEeaTUPmcu3rLwA"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qYmAIuxIEeaTUPmcu3rLwA" points="[0, -1, -3, -66]$[1, 41, -2, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIOxIEeaTUPmcu3rLwA" id="(0.8702290076335878,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIexIEeaTUPmcu3rLwA" id="(0.4789473684210526,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIOxIEeaTUPmcu3rLwA" id="(0.7099236641221374,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qbMBIexIEeaTUPmcu3rLwA" id="(0.3631578947368421,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qZW1J-xIEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_qYmAIOxIEeaTUPmcu3rLwA" target="_qZW1I-xIEeaTUPmcu3rLwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_qZW1KOxIEeaTUPmcu3rLwA"/>
@@ -1161,44 +764,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qZW1KexIEeaTUPmcu3rLwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZW1KuxIEeaTUPmcu3rLwA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZW1K-xIEeaTUPmcu3rLwA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dgV6UOxTEeaTUPmcu3rLwA" type="4001" source="_Sv-f8OwPEealldJ4rm6P_g" target="_QuX0kOwPEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA8OxTEeaTUPmcu3rLwA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA8exTEeaTUPmcu3rLwA" x="-6" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA8uxTEeaTUPmcu3rLwA" type="6002">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WMNIBPiEeepnPPr_BcZKg" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WM0MBPiEeepnPPr_BcZKg" key="visible" value="true"/>
-        </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA8-xTEeaTUPmcu3rLwA" x="8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA9OxTEeaTUPmcu3rLwA" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA9exTEeaTUPmcu3rLwA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA9uxTEeaTUPmcu3rLwA" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA9-xTEeaTUPmcu3rLwA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA-OxTEeaTUPmcu3rLwA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA-exTEeaTUPmcu3rLwA" x="11" y="22"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dgcA-uxTEeaTUPmcu3rLwA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dgcA--xTEeaTUPmcu3rLwA" x="-12" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_dgV6UexTEeaTUPmcu3rLwA"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dgV6UuxTEeaTUPmcu3rLwA" points="[-12, -40, 12, 41]$[-24, -81, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dgcA_OxTEeaTUPmcu3rLwA" id="(0.4194690265486726,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dgcA_exTEeaTUPmcu3rLwA" id="(0.45,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dgoOOuxTEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_dgV6UOxTEeaTUPmcu3rLwA" target="_dgoONuxTEeaTUPmcu3rLwA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dgoOO-xTEeaTUPmcu3rLwA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dgoOP-xTEeaTUPmcu3rLwA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dgoOPOxTEeaTUPmcu3rLwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dgoOPexTEeaTUPmcu3rLwA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dgoOPuxTEeaTUPmcu3rLwA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NnNFO-xYEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_Nm6xQuxYEeaTUPmcu3rLwA" target="_NnNFN-xYEeaTUPmcu3rLwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_NnNFPOxYEeaTUPmcu3rLwA"/>
@@ -1225,29 +790,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_izgq2exYEeaTUPmcu3rLwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_izgq2uxYEeaTUPmcu3rLwA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_izgq2-xYEeaTUPmcu3rLwA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9cCoouxYEeaTUPmcu3rLwA" type="4008" source="_Nm6xQuxYEeaTUPmcu3rLwA" target="_1qqMEOwNEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_9cCopexYEeaTUPmcu3rLwA" type="6026">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9cCopuxYEeaTUPmcu3rLwA" x="-72"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_9cCop-xYEeaTUPmcu3rLwA" type="6027">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9cCoqOxYEeaTUPmcu3rLwA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_9cCoo-xYEeaTUPmcu3rLwA"/>
-      <element xmi:type="uml:Dependency" href="TapiOam.uml#_9cCooOxYEeaTUPmcu3rLwA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9cCopOxYEeaTUPmcu3rLwA" points="[0, 0, -81, 106]$[0, -106, -81, 0]$[81, -106, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoOxYEeaTUPmcu3rLwA" id="(0.4838709677419355,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9eVHoexYEeaTUPmcu3rLwA" id="(0.0,0.6911764705882353)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_9c_q5-xYEeaTUPmcu3rLwA" type="StereotypeCommentLink" source="_9cCoouxYEeaTUPmcu3rLwA" target="_9c_q4-xYEeaTUPmcu3rLwA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_9c_q6OxYEeaTUPmcu3rLwA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9c_q7OxYEeaTUPmcu3rLwA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Dependency" href="TapiOam.uml#_9cCooOxYEeaTUPmcu3rLwA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9c_q6exYEeaTUPmcu3rLwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9c_q6uxYEeaTUPmcu3rLwA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9c_q6-xYEeaTUPmcu3rLwA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QdCNV-xZEeaTUPmcu3rLwA" type="StereotypeCommentLink" target="_QdCNU-xZEeaTUPmcu3rLwA">
       <styles xmi:type="notation:FontStyle" xmi:id="_QdCNWOxZEeaTUPmcu3rLwA"/>
@@ -1278,7 +820,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhO6jEeaHHP1Zcp2a0A" x="-9" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_g5zzhe6jEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhu6jEeaHHP1Zcp2a0A" x="11" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zzhu6jEeaHHP1Zcp2a0A" x="5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_g5zzh-6jEeaHHP1Zcp2a0A" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_g5zziO6jEeaHHP1Zcp2a0A" y="-20"/>
@@ -1295,10 +837,10 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_g5zzge6jEeaHHP1Zcp2a0A"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g5zzgu6jEeaHHP1Zcp2a0A" points="[-12, -26, 31, 71]$[-43, -98, 0, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svcO6jEeaHHP1Zcp2a0A" id="(0.1417910447761194,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svce6jEeaHHP1Zcp2a0A" id="(0.6203703703703703,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svcO6jEeaHHP1Zcp2a0A" id="(0.11194029850746269,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g8svce6jEeaHHP1Zcp2a0A" id="(0.4351851851851852,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_g7J3V-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_g5zzgO6jEeaHHP1Zcp2a0A" target="_g7J3U-6jEeaHHP1Zcp2a0A">
+    <edges xmi:type="notation:Connector" xmi:id="_g7J3V-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_g5zzgO6jEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_g7J3WO6jEeaHHP1Zcp2a0A"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g7J3XO6jEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
@@ -1310,10 +852,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hm478O6jEeaHHP1Zcp2a0A" type="4001" source="_emkToO6lEeaHHP1Zcp2a0A" target="_dcMSYOwMEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_CkO6jEeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cke6jEeaHHP1Zcp2a0A" x="-5" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cke6jEeaHHP1Zcp2a0A" x="-12" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_Cku6jEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Ck-6jEeaHHP1Zcp2a0A" x="14" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Ck-6jEeaHHP1Zcp2a0A" x="5" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hm_ClO6jEeaHHP1Zcp2a0A" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hm_Cle6jEeaHHP1Zcp2a0A" y="-20"/>
@@ -1330,10 +872,10 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_hm478e6jEeaHHP1Zcp2a0A"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hm478u6jEeaHHP1Zcp2a0A" points="[2, -1, -262, 83]$[266, -85, 2, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.8432835820895522,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_se6jEeaHHP1Zcp2a0A" id="(0.35964912280701755,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_sO6jEeaHHP1Zcp2a0A" id="(0.8582089552238806,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hru_se6jEeaHHP1Zcp2a0A" id="(0.2719298245614035,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_hoYJt-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A" target="_hoYJs-6jEeaHHP1Zcp2a0A">
+    <edges xmi:type="notation:Connector" xmi:id="_hoYJt-6jEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_hoYJuO6jEeaHHP1Zcp2a0A"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_hoYJvO6jEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
@@ -1343,7 +885,7 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hoYJuu6jEeaHHP1Zcp2a0A"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hoYJu-6jEeaHHP1Zcp2a0A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_emqaX-6lEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_emkToO6lEeaHHP1Zcp2a0A" target="_emqaW-6lEeaHHP1Zcp2a0A">
+    <edges xmi:type="notation:Connector" xmi:id="_emqaX-6lEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_emkToO6lEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_emqaYO6lEeaHHP1Zcp2a0A"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emqaZO6lEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
@@ -1352,41 +894,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emqaYe6lEeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emqaYu6lEeaHHP1Zcp2a0A"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emqaY-6lEeaHHP1Zcp2a0A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4cF1QO6nEeaHHP1Zcp2a0A" type="4001" source="_a0jhwOwMEealldJ4rm6P_g" target="_dcMSYOwMEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1Q-6nEeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1RO6nEeaHHP1Zcp2a0A" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1Re6nEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1Ru6nEeaHHP1Zcp2a0A" x="1" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1R-6nEeaHHP1Zcp2a0A" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1SO6nEeaHHP1Zcp2a0A" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1Se6nEeaHHP1Zcp2a0A" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1Su6nEeaHHP1Zcp2a0A" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1S-6nEeaHHP1Zcp2a0A" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1TO6nEeaHHP1Zcp2a0A" x="16" y="13"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cF1Te6nEeaHHP1Zcp2a0A" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4cF1Tu6nEeaHHP1Zcp2a0A" x="-12" y="14"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_4cF1Qe6nEeaHHP1Zcp2a0A"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4cF1Qu6nEeaHHP1Zcp2a0A" points="[-1, -1, -107, -17]$[105, 15, -1, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4cF1T-6nEeaHHP1Zcp2a0A" id="(0.8457142857142858,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4cF1UO6nEeaHHP1Zcp2a0A" id="(0.24561403508771928,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4cL75-6nEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_4cF1QO6nEeaHHP1Zcp2a0A" target="_4cL74-6nEeaHHP1Zcp2a0A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_4cL76O6nEeaHHP1Zcp2a0A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4cL77O6nEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4cL76e6nEeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4cL76u6nEeaHHP1Zcp2a0A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4cL76-6nEeaHHP1Zcp2a0A"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_5bfcx-6nEeaHHP1Zcp2a0A" type="StereotypeCommentLink" target="_5bfcw-6nEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="_5bfcyO6nEeaHHP1Zcp2a0A"/>
@@ -1398,41 +905,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5bfcyu6nEeaHHP1Zcp2a0A"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5bfcy-6nEeaHHP1Zcp2a0A"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6JEUcO6nEeaHHP1Zcp2a0A" type="4001" source="_fc1w8OwLEealldJ4rm6P_g" target="_a0jhwOwMEealldJ4rm6P_g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUc-6nEeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUdO6nEeaHHP1Zcp2a0A" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUde6nEeaHHP1Zcp2a0A" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUdu6nEeaHHP1Zcp2a0A" x="1" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUd-6nEeaHHP1Zcp2a0A" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUeO6nEeaHHP1Zcp2a0A" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUee6nEeaHHP1Zcp2a0A" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUeu6nEeaHHP1Zcp2a0A" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUe-6nEeaHHP1Zcp2a0A" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUfO6nEeaHHP1Zcp2a0A" x="15" y="12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_6JEUfe6nEeaHHP1Zcp2a0A" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_6JEUfu6nEeaHHP1Zcp2a0A" x="-10" y="9"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_6JEUce6nEeaHHP1Zcp2a0A"/>
-      <element xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6JEUcu6nEeaHHP1Zcp2a0A" points="[27, 0, -315, 6]$[342, -6, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6JEUf-6nEeaHHP1Zcp2a0A" id="(0.6388888888888888,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6JEUgO6nEeaHHP1Zcp2a0A" id="(0.09523809523809523,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_6JEUiO6nEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_6JEUcO6nEeaHHP1Zcp2a0A" target="_6JEUhO6nEeaHHP1Zcp2a0A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_6JEUie6nEeaHHP1Zcp2a0A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6JEUje6nEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6JEUiu6nEeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6JEUi-6nEeaHHP1Zcp2a0A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6JEUjO6nEeaHHP1Zcp2a0A"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="__y_xZ-6nEeaHHP1Zcp2a0A" type="StereotypeCommentLink" target="__y_xY-6nEeaHHP1Zcp2a0A">
       <styles xmi:type="notation:FontStyle" xmi:id="__y_xaO6nEeaHHP1Zcp2a0A"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="__y_xbO6nEeaHHP1Zcp2a0A" name="BASE_ELEMENT"/>
@@ -1440,54 +912,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__y_xae6nEeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__y_xau6nEeaHHP1Zcp2a0A"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__y_xa-6nEeaHHP1Zcp2a0A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7XQvj-6zEeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_7WyOUO6zEeaHHP1Zcp2a0A" target="_7XQvi-6zEeaHHP1Zcp2a0A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7XQvkO6zEeaHHP1Zcp2a0A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7XQvlO6zEeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7XQvke6zEeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7XQvku6zEeaHHP1Zcp2a0A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7XQvk-6zEeaHHP1Zcp2a0A"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Y7lI8O60EeaHHP1Zcp2a0A" type="4001" source="_QuX0kOwPEealldJ4rm6P_g" target="_7WyOUO6zEeaHHP1Zcp2a0A">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI8-60EeaHHP1Zcp2a0A" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI9O60EeaHHP1Zcp2a0A" x="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI9e60EeaHHP1Zcp2a0A" type="6002">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2t248BPiEeepnPPr_BcZKg" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2t248RPiEeepnPPr_BcZKg" key="visible" value="true"/>
-        </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI9u60EeaHHP1Zcp2a0A" x="14" y="1"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI9-60EeaHHP1Zcp2a0A" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI-O60EeaHHP1Zcp2a0A" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI-e60EeaHHP1Zcp2a0A" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI-u60EeaHHP1Zcp2a0A" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI--60EeaHHP1Zcp2a0A" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI_O60EeaHHP1Zcp2a0A" x="11" y="21"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Y7lI_e60EeaHHP1Zcp2a0A" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Y7lI_u60EeaHHP1Zcp2a0A" x="-10" y="20"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Y7lI8e60EeaHHP1Zcp2a0A"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y7lI8u60EeaHHP1Zcp2a0A" points="[0, 0, 43, 55]$[-43, -55, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y7lI_-60EeaHHP1Zcp2a0A" id="(0.4318181818181818,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y7lJAO60EeaHHP1Zcp2a0A" id="(0.4444444444444444,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Y79jd-60EeaHHP1Zcp2a0A" type="StereotypeCommentLink" source="_Y7lI8O60EeaHHP1Zcp2a0A" target="_Y79jc-60EeaHHP1Zcp2a0A">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Y79jeO60EeaHHP1Zcp2a0A"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Y79jfO60EeaHHP1Zcp2a0A" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y79jee60EeaHHP1Zcp2a0A" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y79jeu60EeaHHP1Zcp2a0A"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y79je-60EeaHHP1Zcp2a0A"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_f3-nRxM7Eee0L_IMWjydgQ" type="StereotypeCommentLink" source="_f3yaABM7Eee0L_IMWjydgQ" target="_f3-nQxM7Eee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_f3-nSBM7Eee0L_IMWjydgQ"/>
@@ -1507,7 +931,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_pW0gRRM7Eee0L_IMWjydgQ" x="5" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_pW0gRhM7Eee0L_IMWjydgQ" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pW0gRxM7Eee0L_IMWjydgQ" x="2" y="3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pW0gRxM7Eee0L_IMWjydgQ" x="3" y="9"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_pW0gQhM7Eee0L_IMWjydgQ"/>
       <element xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
@@ -1527,18 +951,18 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Z1Zb8BNKEeeQQtMBY9ly8w" type="4006" source="_emkToO6lEeaHHP1Zcp2a0A" target="_Sv-f8OwPEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_Z1Zb8xNKEeeQQtMBY9ly8w" type="6014">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1Zb9BNKEeeQQtMBY9ly8w" x="-25" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1Zb9BNKEeeQQtMBY9ly8w" x="-1" y="-13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Z1Zb9RNKEeeQQtMBY9ly8w" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1Zb9hNKEeeQQtMBY9ly8w" x="-34" y="14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z1Zb9hNKEeeQQtMBY9ly8w" x="-11" y="3"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Z1Zb8RNKEeeQQtMBY9ly8w"/>
       <element xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[0, 0, -668, 81]$[668, 0, 0, 81]$[668, -81, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8BNKEeeQQtMBY9ly8w" id="(1.0,0.45)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8RNKEeeQQtMBY9ly8w" id="(0.45132743362831856,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z1Zb8hNKEeeQQtMBY9ly8w" points="[-1, 0, -120, -34]$[75, 20, -44, -14]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8BNKEeeQQtMBY9ly8w" id="(1.0,0.46)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z27F8RNKEeeQQtMBY9ly8w" id="(0.0,0.5222222222222223)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_e_oFJxNKEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_Z1Zb8BNKEeeQQtMBY9ly8w" target="_e_oFIxNKEeeQQtMBY9ly8w">
+    <edges xmi:type="notation:Connector" xmi:id="_e_oFJxNKEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_Z1Zb8BNKEeeQQtMBY9ly8w">
       <styles xmi:type="notation:FontStyle" xmi:id="_e_oFKBNKEeeQQtMBY9ly8w"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e_oFLBNKEeeQQtMBY9ly8w" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
@@ -1547,44 +971,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e_oFKRNKEeeQQtMBY9ly8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_oFKhNKEeeQQtMBY9ly8w"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e_oFKxNKEeeQQtMBY9ly8w"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PCoPwBO0EeeuwKj8ylAa1g" type="StereotypeCommentLink" source="_PBp_YBO0EeeuwKj8ylAa1g" target="_PCnBoBO0EeeuwKj8ylAa1g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_PCoPwRO0EeeuwKj8ylAa1g"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_PCoPxRO0EeeuwKj8ylAa1g" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PCoPwhO0EeeuwKj8ylAa1g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PCoPwxO0EeeuwKj8ylAa1g"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PCoPxBO0EeeuwKj8ylAa1g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_PFUXYBO0EeeuwKj8ylAa1g" type="4001" source="_7WyOUO6zEeaHHP1Zcp2a0A" target="_PBp_YBO0EeeuwKj8ylAa1g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFUXYxO0EeeuwKj8ylAa1g" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFUXZBO0EeeuwKj8ylAa1g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFUXZRO0EeeuwKj8ylAa1g" type="6002">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_07QS4BPiEeepnPPr_BcZKg" source="PapyrusCSSForceValue">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_07QS4RPiEeepnPPr_BcZKg" key="visible" value="true"/>
-        </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFUXZhO0EeeuwKj8ylAa1g" x="5" y="-22"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFU-cBO0EeeuwKj8ylAa1g" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFU-cRO0EeeuwKj8ylAa1g" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFU-chO0EeeuwKj8ylAa1g" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFU-cxO0EeeuwKj8ylAa1g" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFU-dBO0EeeuwKj8ylAa1g" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFU-dRO0EeeuwKj8ylAa1g" x="9" y="22"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_PFU-dhO0EeeuwKj8ylAa1g" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_PFU-dxO0EeeuwKj8ylAa1g" x="-10" y="24"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_PFUXYRO0EeeuwKj8ylAa1g"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PFUXYhO0EeeuwKj8ylAa1g" points="[52, 88, -70, -118]$[122, 206, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFWMkBO0EeeuwKj8ylAa1g" id="(0.08547008547008547,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PFWMkRO0EeeuwKj8ylAa1g" id="(0.6985294117647058,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_94QWQhP6EeepnPPr_BcZKg" type="StereotypeCommentLink" source="_94EI8BP6EeepnPPr_BcZKg" target="_94QWPhP6EeepnPPr_BcZKg">
       <styles xmi:type="notation:FontStyle" xmi:id="_94QWQxP6EeepnPPr_BcZKg"/>
@@ -1595,41 +981,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_94QWRBP6EeepnPPr_BcZKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_94Wc0BP6EeepnPPr_BcZKg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_94Wc0RP6EeepnPPr_BcZKg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EuWrUBP7EeepnPPr_BcZKg" type="4001" source="_Sv-f8OwPEealldJ4rm6P_g" target="_94EI8BP6EeepnPPr_BcZKg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrUxP7EeepnPPr_BcZKg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrVBP7EeepnPPr_BcZKg" x="105" y="30"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrVRP7EeepnPPr_BcZKg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrVhP7EeepnPPr_BcZKg" x="109" y="48"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrVxP7EeepnPPr_BcZKg" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrWBP7EeepnPPr_BcZKg" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrWRP7EeepnPPr_BcZKg" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrWhP7EeepnPPr_BcZKg" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrWxP7EeepnPPr_BcZKg" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrXBP7EeepnPPr_BcZKg" x="14" y="15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_EuWrXRP7EeepnPPr_BcZKg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_EuWrXhP7EeepnPPr_BcZKg" x="-11" y="17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_EuWrURP7EeepnPPr_BcZKg"/>
-      <element xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EuWrUhP7EeepnPPr_BcZKg" points="[-1, 0, 314, 102]$[-315, 0, 0, 102]$[-315, -103, 0, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EuWrXxP7EeepnPPr_BcZKg" id="(0.0,0.23333333333333334)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EuWrYBP7EeepnPPr_BcZKg" id="(0.44661654135338347,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Eui4lxP7EeepnPPr_BcZKg" type="StereotypeCommentLink" source="_EuWrUBP7EeepnPPr_BcZKg" target="_Eui4kxP7EeepnPPr_BcZKg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Eui4mBP7EeepnPPr_BcZKg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Eui4nBP7EeepnPPr_BcZKg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Eui4mRP7EeepnPPr_BcZKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eui4mhP7EeepnPPr_BcZKg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Eui4mxP7EeepnPPr_BcZKg"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_W5JA0hP7EeepnPPr_BcZKg" type="StereotypeCommentLink" source="_W5IZsBP7EeepnPPr_BcZKg" target="_W5JAzhP7EeepnPPr_BcZKg">
       <styles xmi:type="notation:FontStyle" xmi:id="_W5JA0xP7EeepnPPr_BcZKg"/>
@@ -1643,7 +994,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_btNzwBP7EeepnPPr_BcZKg" type="4001" source="_NkS1sOxFEeaTUPmcu3rLwA" target="_W5IZsBP7EeepnPPr_BcZKg">
       <children xmi:type="notation:DecorationNode" xmi:id="_btNzwxP7EeepnPPr_BcZKg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzxBP7EeepnPPr_BcZKg" x="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzxBP7EeepnPPr_BcZKg" x="14"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_btNzxRP7EeepnPPr_BcZKg" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzxhP7EeepnPPr_BcZKg" y="1"/>
@@ -1658,7 +1009,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzzBP7EeepnPPr_BcZKg" x="8" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_btNzzRP7EeepnPPr_BcZKg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzzhP7EeepnPPr_BcZKg" x="-11" y="10"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_btNzzhP7EeepnPPr_BcZKg" x="-10" y="20"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_btNzwRP7EeepnPPr_BcZKg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
@@ -1681,7 +1032,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_uhpjIRP7EeepnPPr_BcZKg" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_uhpjIhP7EeepnPPr_BcZKg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_uhpjIxP7EeepnPPr_BcZKg" x="35" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uhpjIxP7EeepnPPr_BcZKg" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_uhpjJBP7EeepnPPr_BcZKg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_uhpjJRP7EeepnPPr_BcZKg" y="-20"/>
@@ -1697,74 +1048,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_uhjcgRP7EeepnPPr_BcZKg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_uW9WEBP7EeepnPPr_BcZKg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uhjcghP7EeepnPPr_BcZKg" points="[0, 0, -124, -84]$[0, 84, -124, 0]$[124, 84, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkBP7EeepnPPr_BcZKg" id="(0.6691729323308271,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkRP7EeepnPPr_BcZKg" id="(0.0,0.5357142857142857)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_f2LrQhoEEeeV4o0osG5stg" type="StereotypeCommentLink" source="_f1_d8BoEEeeV4o0osG5stg" target="_f2LrPhoEEeeV4o0osG5stg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_f2LrQxoEEeeV4o0osG5stg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f2LrRxoEEeeV4o0osG5stg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f2LrRBoEEeeV4o0osG5stg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f2LrRRoEEeeV4o0osG5stg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f2LrRhoEEeeV4o0osG5stg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_f22ZkBoEEeeV4o0osG5stg" type="4008" source="_f1_d8BoEEeeV4o0osG5stg" target="_f3yaABM7Eee0L_IMWjydgQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_f22ZkxoEEeeV4o0osG5stg" type="6026">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_f22ZlBoEEeeV4o0osG5stg" x="-5" y="10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_f22ZlRoEEeeV4o0osG5stg" type="6027">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_f22ZlhoEEeeV4o0osG5stg" x="-8" y="-11"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_f22ZkRoEEeeV4o0osG5stg"/>
-      <element xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f22ZkhoEEeeV4o0osG5stg" points="[-1, 0, 198, -12]$[-200, 12, -1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f22ZlxoEEeeV4o0osG5stg" id="(0.0,0.515625)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f22ZmBoEEeeV4o0osG5stg" id="(1.0,0.45666666666666667)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_f3Cm1xoEEeeV4o0osG5stg" type="StereotypeCommentLink" source="_f22ZkBoEEeeV4o0osG5stg" target="_f3Cm0xoEEeeV4o0osG5stg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_f3Cm2BoEEeeV4o0osG5stg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_f3Cm3BoEEeeV4o0osG5stg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_f3Cm2RoEEeeV4o0osG5stg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f3Cm2hoEEeeV4o0osG5stg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f3Cm2xoEEeeV4o0osG5stg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zcI-IBoEEeeV4o0osG5stg" type="4001" source="_PBp_YBO0EeeuwKj8ylAa1g" target="_f1_d8BoEEeeV4o0osG5stg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-IxoEEeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JBoEEeeV4o0osG5stg" x="-7" y="-8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-JRoEEeeV4o0osG5stg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-JhoEEeeV4o0osG5stg" x="8" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-JxoEEeeV4o0osG5stg" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-KBoEEeeV4o0osG5stg" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-KRoEEeeV4o0osG5stg" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-KhoEEeeV4o0osG5stg" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-KxoEEeeV4o0osG5stg" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-LBoEEeeV4o0osG5stg" x="9" y="10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zcI-LRoEEeeV4o0osG5stg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zcI-LhoEEeeV4o0osG5stg" x="-8" y="13"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_zcI-IRoEEeeV4o0osG5stg"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zcI-IhoEEeeV4o0osG5stg" points="[21, -40, -26, 46]$[47, -86, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zcPEwBoEEeeV4o0osG5stg" id="(0.5808823529411765,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zcPEwRoEEeeV4o0osG5stg" id="(0.1,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uhjcghP7EeepnPPr_BcZKg" points="[0, -1, -126, -21]$[0, 20, -126, 0]$[125, 20, -1, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkBP7EeepnPPr_BcZKg" id="(0.6586466165413534,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ujFtkRP7EeepnPPr_BcZKg" id="(0.0,0.5178571428571429)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_OM4K0BoHEeeV4o0osG5stg" type="4001" source="_94EI8BP6EeepnPPr_BcZKg" target="_f3yaABM7Eee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K0xoHEeeV4o0osG5stg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1BoHEeeV4o0osG5stg" x="102" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1BoHEeeV4o0osG5stg" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K1RoHEeeV4o0osG5stg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1hoHEeeV4o0osG5stg" x="120" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K1hoHEeeV4o0osG5stg" x="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K1xoHEeeV4o0osG5stg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K2BoHEeeV4o0osG5stg" y="-20"/>
@@ -1776,58 +1069,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K3BoHEeeV4o0osG5stg" x="12" y="21"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_OM4K3RoHEeeV4o0osG5stg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K3hoHEeeV4o0osG5stg" x="-12" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_OM4K3hoHEeeV4o0osG5stg" x="-3" y="13"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_OM4K0RoHEeeV4o0osG5stg"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OM4K0hoHEeeV4o0osG5stg" points="[0, 0, 121, 473]$[-102, -398, 19, 75]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K3xoHEeeV4o0osG5stg" id="(0.39849624060150374,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OM4K4BoHEeeV4o0osG5stg" id="(0.5698324022346368,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BYrsACBcEeeWCKlkirNtnw" type="4001" source="_7WyOUO6zEeaHHP1Zcp2a0A" target="_f1_d8BoEEeeV4o0osG5stg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsAyBcEeeWCKlkirNtnw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsBCBcEeeWCKlkirNtnw" x="40" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsBSBcEeeWCKlkirNtnw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsBiBcEeeWCKlkirNtnw" x="53" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsByBcEeeWCKlkirNtnw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsCCBcEeeWCKlkirNtnw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsCSBcEeeWCKlkirNtnw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsCiBcEeeWCKlkirNtnw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsCyBcEeeWCKlkirNtnw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsDCBcEeeWCKlkirNtnw" x="9" y="12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BYrsDSBcEeeWCKlkirNtnw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BYrsDiBcEeeWCKlkirNtnw" x="-13" y="12"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BYrsASBcEeeWCKlkirNtnw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BYrsAiBcEeeWCKlkirNtnw" points="[0, -1, -5, 180]$[5, -182, 0, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BYrsDyBcEeeWCKlkirNtnw" id="(0.7692307692307693,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BYrsECBcEeeWCKlkirNtnw" id="(0.8384615384615385,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7P8WtCBcEeeWCKlkirNtnw" type="StereotypeCommentLink" source="_BYrsACBcEeeWCKlkirNtnw" target="_7P8WsCBcEeeWCKlkirNtnw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7P8WtSBcEeeWCKlkirNtnw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7P8WuSBcEeeWCKlkirNtnw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7P8WtiBcEeeWCKlkirNtnw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7P8WtyBcEeeWCKlkirNtnw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7P8WuCBcEeeWCKlkirNtnw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__RBOZExtEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_zcI-IBoEEeeV4o0osG5stg" target="__RBOYExtEeeBqfKxLidrUg">
-      <styles xmi:type="notation:FontStyle" xmi:id="__RBOZUxtEeeBqfKxLidrUg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__RBOaUxtEeeBqfKxLidrUg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__RBOZkxtEeeBqfKxLidrUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RBOZ0xtEeeBqfKxLidrUg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__RBOaExtEeeBqfKxLidrUg"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__RKYVExtEeeBqfKxLidrUg" type="StereotypeCommentLink" source="_OM4K0BoHEeeV4o0osG5stg" target="__RKYUExtEeeBqfKxLidrUg">
       <styles xmi:type="notation:FontStyle" xmi:id="__RKYVUxtEeeBqfKxLidrUg"/>
@@ -1841,10 +1089,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0qX7AE86Eeeicu4cm-7qRg" type="4001" source="_W5IZsBP7EeepnPPr_BcZKg" target="_Sv-f8OwPEealldJ4rm6P_g">
       <children xmi:type="notation:DecorationNode" xmi:id="_0qX7A086Eeeicu4cm-7qRg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEE86Eeeicu4cm-7qRg" x="-151" y="-149"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEE86Eeeicu4cm-7qRg" x="4" y="-7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0qYiEU86Eeeicu4cm-7qRg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEk86Eeeicu4cm-7qRg" x="-156" y="-166"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiEk86Eeeicu4cm-7qRg" x="-6" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0qYiE086Eeeicu4cm-7qRg" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiFE86Eeeicu4cm-7qRg" y="-20"/>
@@ -1856,13 +1104,13 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiGE86Eeeicu4cm-7qRg" x="9" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0qYiGU86Eeeicu4cm-7qRg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiGk86Eeeicu4cm-7qRg" x="-10" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0qYiGk86Eeeicu4cm-7qRg" x="-11" y="21"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_0qX7AU86Eeeicu4cm-7qRg"/>
       <element xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0qX7Ak86Eeeicu4cm-7qRg" points="[0, 0, -549, -244]$[0, 244, -549, 0]$[549, 244, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AME86Eeeicu4cm-7qRg" id="(0.2857142857142857,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AMU86Eeeicu4cm-7qRg" id="(0.0,0.6666666666666666)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0qX7Ak86Eeeicu4cm-7qRg" points="[0, -1, 52, -119]$[-47, 104, 5, -14]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AME86Eeeicu4cm-7qRg" id="(0.26165413533834586,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s2AMU86Eeeicu4cm-7qRg" id="(0.35929203539823007,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WvGdRE8-Eeeicu4cm-7qRg" type="StereotypeCommentLink" source="_0qX7AE86Eeeicu4cm-7qRg" target="_WvGdQE8-Eeeicu4cm-7qRg">
       <styles xmi:type="notation:FontStyle" xmi:id="_WvGdRU8-Eeeicu4cm-7qRg"/>
@@ -1873,6 +1121,1996 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvGdRk8-Eeeicu4cm-7qRg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvGdR08-Eeeicu4cm-7qRg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvGdSE8-Eeeicu4cm-7qRg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8AmwYVdLEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_8AmJU1dLEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8AmwYldLEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8AnXcFdLEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8AmwY1dLEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8AmwZFdLEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8AmwZVdLEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nVL38VdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_fc1w8OwLEealldJ4rm6P_g" target="_nVLQ4FdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nVL38ldQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nVL39ldQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nVL381dQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVL39FdQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVL39VdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nVTzxFdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dcMSYOwMEealldJ4rm6P_g" target="_nVTzwFdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nVTzxVdQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nVTzyVdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nVTzxldQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVTzx1dQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVTzyFdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nWBldFdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_emkToO6lEeaHHP1Zcp2a0A" target="_nWBlcFdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nWBldVdQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWBleVdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nWBldldQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWBld1dQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWBleFdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nWF25FdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_g5zzgO6jEeaHHP1Zcp2a0A" target="_nWF24FdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nWF25VdQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWF26VdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nWF25ldQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWF251dQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWF26FdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nWL9hFdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_hm478O6jEeaHHP1Zcp2a0A" target="_nWL9gFdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nWL9hVdQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWL9iVdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nWL9hldQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWL9h1dQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWL9iFdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nWSEJFdQEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_Z1Zb8BNKEeeQQtMBY9ly8w" target="_nWSEIFdQEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nWSEJVdQEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nWSEKVdQEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nWSEJldQEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWSEJ1dQEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nWSEKFdQEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YHkW4FdTEeejsLaQeGcDdg" type="4003" source="_NkS1sOxFEeaTUPmcu3rLwA" target="_Nm6xQuxYEeaTUPmcu3rLwA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_YHkW41dTEeejsLaQeGcDdg" type="6008">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YHkW5FdTEeejsLaQeGcDdg" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_YHkW5VdTEeejsLaQeGcDdg" type="6009">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YHkW5ldTEeejsLaQeGcDdg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_YHkW4VdTEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:InterfaceRealization" href="TapiOam.uml#_YHEnoFdTEeejsLaQeGcDdg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YHkW4ldTEeejsLaQeGcDdg" points="[-25, 0, 56, -1]$[-100, -28, -19, -29]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YIgyEFdTEeejsLaQeGcDdg" id="(0.0,0.3793103448275862)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YIgyEVdTEeejsLaQeGcDdg" id="(1.0,0.3793103448275862)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_dPewEFdMEeejsLaQeGcDdg" type="PapyrusUMLClassDiagram" name="OamSkeleton" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_dPewEVdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewEldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewE1dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPewFFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewFVdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewFldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewF1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewGFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewGVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewGldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewG1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewHFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewHVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewHldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewH1dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewIFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewIVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewIldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewI1dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewOldMEeejsLaQeGcDdg" x="-457" y="66" width="108" height="53"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPewO1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPewPFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPewPVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewTldMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPewT1dMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewUFdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewUVdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPewUldMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewU1dMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewVFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewVVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewVldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewV1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewWFdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewWVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewWldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewW1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewXFdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewXVdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewXldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewX1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewYFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewYVdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeweFdMEeejsLaQeGcDdg" x="-407" y="-175" width="132" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeweVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeweldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPewe1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewjFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPewjVdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewjldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewj1dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPewkFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewkVdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewkldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewk1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewlFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewlVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewlldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewl1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewmFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewmVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewmldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewm1dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPewnFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPewnVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPewnldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewn1dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewtldMEeejsLaQeGcDdg" x="-398" y="-56" height="63"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPewt1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPewuFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPewuVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPewyldMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPewy1dMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewzFdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPewzVdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPewzldMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPewz1dMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPew0FdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPew0VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPew0ldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPew01dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPew1FdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPew1VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPew1ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPew11dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPew2FdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPew2VdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPew2ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPew21dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPew3FdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPew3VdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPew9FdMEeejsLaQeGcDdg" x="-338" y="64" width="114" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPew9VdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPew9ldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPew91dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexCFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexCVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexCldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexC1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexDFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexDVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexDldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexD1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexEFdMEeejsLaQeGcDdg" x="588" y="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexEVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexEldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexE1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_nPXJwLxAEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexFFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexFVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexFldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexF1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_iGK1UOfGEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexGFdMEeejsLaQeGcDdg" x="431" y="-1"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexGVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexGldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexG1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_82r5QLzJEeSmrtWG5D-wKA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexHFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexHVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexHldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexH1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_LgIfwOfKEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexIFdMEeejsLaQeGcDdg" x="656" y="45"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexIVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexIldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexI1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexJFdMEeejsLaQeGcDdg" x="802" y="80"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexJVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexJldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexJ1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexOFdMEeejsLaQeGcDdg" x="676" y="-47"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexOVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexOldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexO1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexTFdMEeejsLaQeGcDdg" x="681" y="-182"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexTVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexTldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexT1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_AYu0cMOiEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexUFdMEeejsLaQeGcDdg" x="591" y="193"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexUVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexUldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexU1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_Fk5XUMOiEeaFfJxGCRaf4A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexVFdMEeejsLaQeGcDdg" x="726" y="142"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexVVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexVldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexV1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_RlnSwLxDEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexWFdMEeejsLaQeGcDdg" x="588" y="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexWVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexWldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexW1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexXFdMEeejsLaQeGcDdg" x="681" y="-182"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexXVdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPexXldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPexX1dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPexYFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexYVdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexYldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexY1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexZFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexZVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexZldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexZ1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexaFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexaVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexaldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexa1dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexbFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexbVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexbldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexb1dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexhldMEeejsLaQeGcDdg" x="-365" y="-457" width="131" height="68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexh1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexiFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexiVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexmldMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexm1dMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPexnFdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPexnVdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPexnldMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexn1dMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexoFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexoVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexoldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexo1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexpFdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexpVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexpldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexp1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexqFdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPexqVdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPexqldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPexq1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPexrFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexrVdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPexxFdMEeejsLaQeGcDdg" x="329" y="-52" height="53"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPexxVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPexxldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPexx1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPex2FdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPex2VdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPex2ldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPex21dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPex3FdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPex3VdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPex3ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPex31dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPex4FdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPex4VdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPex4ldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPex41dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPex5FdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPex5VdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPex5ldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPex51dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPex6FdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPex6VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPex6ldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPex61dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyAldMEeejsLaQeGcDdg" x="341" y="84" width="113" height="72"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyA1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyBFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyBVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyFldMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyF1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyGFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyGVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_iGK1UOfGEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyGldMEeejsLaQeGcDdg" x="347" y="134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyG1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyHFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyHVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_LgIfwOfKEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyHldMEeejsLaQeGcDdg" x="349" y="2"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyH1dMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPeyIFdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPeyIVdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPeyIldMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPeyI1dMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyJFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPeyJVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPeyJldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyJ1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPeyKFdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyKVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPeyKldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPeyK1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyLFdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPeyLVdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyLldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPeyL1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPeyMFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyMVdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeySFdMEeejsLaQeGcDdg" x="-341" y="-318" width="190" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeySVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeySldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyS1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyXFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyXVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyXldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyX1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeycFdMEeejsLaQeGcDdg" x="320" y="-545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeycVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeycldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyc1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyhFdMEeejsLaQeGcDdg" x="492" y="-134"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyhVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyhldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyh1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyiFdMEeejsLaQeGcDdg" x="577" y="-546"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyiVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyildMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyi1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeyjFdMEeejsLaQeGcDdg" x="189" y="-294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeyjVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPeyjldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPeyj1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeykFdMEeejsLaQeGcDdg" x="320" y="-545"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPeykVdMEeejsLaQeGcDdg" type="2004">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPeykldMEeejsLaQeGcDdg" type="5011"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPeyk1dMEeejsLaQeGcDdg" type="8507">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPeylFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPeylVdMEeejsLaQeGcDdg" type="7006">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPeylldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPeyl1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPeymFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPeymVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPeymldMEeejsLaQeGcDdg" visible="false" type="7007">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dPeym1dMEeejsLaQeGcDdg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dPfXIFdMEeejsLaQeGcDdg" key="visible" value="true"/>
+        </eAnnotations>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXIVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfXIldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfXI1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXJFdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfXJVdMEeejsLaQeGcDdg" visible="false" type="7008">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXJldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfXJ1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfXKFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXKVdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXQFdMEeejsLaQeGcDdg" x="-504" y="-318" width="134" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXQVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXQldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXQ1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXVFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXVVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXVldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXV1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXWFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXWVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXWldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXW1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXXFdMEeejsLaQeGcDdg" x="113" y="-402"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXXVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXXldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXX1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXYFdMEeejsLaQeGcDdg" x="49" y="-541"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXYVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXYldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXY1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXZFdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXZVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXZldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXZ1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXaFdMEeejsLaQeGcDdg" x="91" y="-419"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXaVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXaldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXa1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXbFdMEeejsLaQeGcDdg" x="-1" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXbVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXbldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXb1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXgFdMEeejsLaQeGcDdg" x="453" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXgVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXgldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXg1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXlFdMEeejsLaQeGcDdg" x="453" y="-56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXlVdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfXlldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfXl1dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfXmFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfXmVdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXmldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfXm1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfXnFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXnVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfXnldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXn1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfXoFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfXoVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXoldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfXo1dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXpFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfXpVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfXpldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXp1dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfXvldMEeejsLaQeGcDdg" x="-410" y="210" width="134" height="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfXv1dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfXwFdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfXwVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX0ldMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfX01dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX1FdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfX1VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX1ldMEeejsLaQeGcDdg" x="463" y="-299"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfX11dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX2FdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfX2VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX2ldMEeejsLaQeGcDdg" x="463" y="-299"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfX21dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX3FdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfX3VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX3ldMEeejsLaQeGcDdg" x="189" y="-294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfX31dMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX4FdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfX4VdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX4ldMEeejsLaQeGcDdg" x="669" y="-298"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfX41dMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfX5FdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfX5VdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfX5ldMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfX51dMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX6FdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfX6VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfX6ldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX61dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfX7FdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX7VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfX7ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfX71dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX8FdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfX8VdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfX8ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfX81dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfX9FdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfX9VdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYDFdMEeejsLaQeGcDdg" x="334" y="-196" width="117" height="61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYDVdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYDldMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfYD1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYEFdMEeejsLaQeGcDdg" x="771" y="-295"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYEVdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfYEldMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfYE1dMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfYFFdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYFVdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYFldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYF1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYGFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYGVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYGldMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYG1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYHFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYHVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYHldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYH1dMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYIFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYIVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYIldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYI1dMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYUVdMEeejsLaQeGcDdg" x="-82" y="-447" height="60"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYUldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYU1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfYVFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYeVdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYeldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYe1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfYfFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYkVdMEeejsLaQeGcDdg" x="329" y="-547"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYkldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYk1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfYlFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYqVdMEeejsLaQeGcDdg" x="464" y="-165"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfYqldMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfYq1dMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfYrFdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfYrVdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYrldMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYr1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYsFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYsVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYsldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYs1dMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYtFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYtVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYtldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYt1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfYuFdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfYuVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfYuldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfYu1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfYvFdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfY01dMEeejsLaQeGcDdg" x="-33" y="-58" height="56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfY1FdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfY1VdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfY1ldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfY51dMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfY6FdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfY6VdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfY6ldMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfY61dMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfY7FdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfY7VdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfY7ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfY71dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfY8FdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfY8VdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfY8ldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfY81dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfY9FdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfY9VdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfY9ldMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfY91dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfY-FdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfY-VdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfY-ldMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZEVdMEeejsLaQeGcDdg" x="249" y="-320" width="136" height="62"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfZEldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZE1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfZFFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZJVdMEeejsLaQeGcDdg" x="79" y="3"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfZJldMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfZJ1dMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPfZKFdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPfZKVdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfZKldMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZK1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfZLFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfZLVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZLldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfZL1dMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZMFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfZMVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfZMldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZM1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPfZNFdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZNVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPfZNldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPfZN1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZOFdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZT1dMEeejsLaQeGcDdg" x="-246" y="-170" height="58"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfZUFdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZUVdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfZUldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZY1dMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfZZFdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZZVdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfZZldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPfZd1dMEeejsLaQeGcDdg" x="426" y="-403"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPfZeFdMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPfZeVdMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPfZeldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-NVdMEeejsLaQeGcDdg" x="167" y="-158"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-NldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-N1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-OFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-SVdMEeejsLaQeGcDdg" x="-46" y="-270"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-SldMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf-S1dMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf-TFdMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf-TVdMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-TldMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-T1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-UFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-UVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-UldMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-U1dMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-VFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-VVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-VldMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-V1dMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-WFdMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-WVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-WldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-W1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-XFdMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-c1dMEeejsLaQeGcDdg" x="493" y="-55" width="121" height="56"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-dFdMEeejsLaQeGcDdg" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf-dVdMEeejsLaQeGcDdg" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf-dldMEeejsLaQeGcDdg" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf-d1dMEeejsLaQeGcDdg" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-eFdMEeejsLaQeGcDdg" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-eVdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-eldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-e1dMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-fFdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-fVdMEeejsLaQeGcDdg" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-fldMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-f1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-gFdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-gVdMEeejsLaQeGcDdg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_dPf-gldMEeejsLaQeGcDdg" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-g1dMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_dPf-hFdMEeejsLaQeGcDdg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_dPf-hVdMEeejsLaQeGcDdg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-hldMEeejsLaQeGcDdg"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-nVdMEeejsLaQeGcDdg" x="315" y="-451" height="64"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-nldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-n1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-oFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-sVdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-sldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-s1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-tFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-xVdMEeejsLaQeGcDdg" x="541" y="-16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_dPf-xldMEeejsLaQeGcDdg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_dPf-x1dMEeejsLaQeGcDdg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-yFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dPf-2VdMEeejsLaQeGcDdg" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_dPf-2ldMEeejsLaQeGcDdg" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_dPf-21dMEeejsLaQeGcDdg"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_dPf-3FdMEeejsLaQeGcDdg">
+      <owner xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiOam.uml#_XQfKcOvSEealldJ4rm6P_g"/>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf-3VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewEVdMEeejsLaQeGcDdg" target="_dPewO1dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-3ldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-31dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-4FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-4VdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-4ldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf-41dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPeweVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-5FdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-5VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_zR-agMbLEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-5ldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-51dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-6FdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf-6VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewt1dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-6ldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-61dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_iE9fcMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-7FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-7VdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-7ldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf-71dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPewy1dMEeejsLaQeGcDdg" target="_dPew9VdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-8FdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-8VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-8ldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-81dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-9FdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf-9VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexCVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-9ldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-91dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf--FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf--VdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf--ldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf--1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexDVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf-_FdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf-_VdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf-_ldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf-_1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_AFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_AVdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexEVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_AldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_A1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_nPXJwLxAEeSpn78DYJKtkA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_BFdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_BVdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_BldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_B1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexFVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_CFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_CVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_iGK1UOfGEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_CldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_C1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_DFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_DVdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexGVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_DldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_D1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_82r5QLzJEeSmrtWG5D-wKA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_EFdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_EVdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_EldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_E1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexHVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_FFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_FVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_LgIfwOfKEea2-taDQDzvGg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_FldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_F1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_GFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_GVdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPexIVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_GldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_G1dMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_HFdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_HVdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_HldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_H1dMEeejsLaQeGcDdg" type="4001" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewT1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_IFdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_IVdMEeejsLaQeGcDdg" x="-4" y="3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_IldMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_I1dMEeejsLaQeGcDdg" x="6" y="2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_JFdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_JVdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_JldMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_J1dMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_KFdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_KVdMEeejsLaQeGcDdg" x="8" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_KldMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_K1dMEeejsLaQeGcDdg" x="-7" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_LFdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_MFdMEeejsLaQeGcDdg" points="[0, 0, -5, 135]$[5, -135, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_MVdMEeejsLaQeGcDdg" id="(0.49523809523809526,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_MldMEeejsLaQeGcDdg" id="(0.4621212121212121,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_M1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_H1dMEeejsLaQeGcDdg" target="_dPexJVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_NFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_NVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_kho9QMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_NldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_N1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_OFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_OVdMEeejsLaQeGcDdg" type="4001" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPexXVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_OldMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_O1dMEeejsLaQeGcDdg" x="60" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_PFdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_PVdMEeejsLaQeGcDdg" x="78" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_PldMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_P1dMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_QFdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_QVdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_QldMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_Q1dMEeejsLaQeGcDdg" x="10" y="14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_RFdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_RVdMEeejsLaQeGcDdg" x="-8" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_RldMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_SldMEeejsLaQeGcDdg" points="[0, -1, -23, 198]$[23, -199, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_S1dMEeejsLaQeGcDdg" id="(0.4015151515151515,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_TFdMEeejsLaQeGcDdg" id="(0.08396946564885496,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_TVdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_OVdMEeejsLaQeGcDdg" target="_dPexOVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_TldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_T1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_1i2mEMbNEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_UFdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_UVdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_UldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_U1dMEeejsLaQeGcDdg" type="4001" source="_dPewT1dMEeejsLaQeGcDdg" target="_dPeyH1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_VFdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_VVdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_VldMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_V1dMEeejsLaQeGcDdg" x="13" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_WFdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_WVdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_WldMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_W1dMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_XFdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_XVdMEeejsLaQeGcDdg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_XldMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_X1dMEeejsLaQeGcDdg" x="-9" y="15"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_YFdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_YVdMEeejsLaQeGcDdg" points="[40, 0, -86, -4]$[125, 3, -1, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_YldMEeejsLaQeGcDdg" id="(0.7954545454545454,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_Y1dMEeejsLaQeGcDdg" id="(0.20526315789473684,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_ZFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_U1dMEeejsLaQeGcDdg" target="_dPexWVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_ZVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_ZldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#__nuEoNzDEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_Z1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_aFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_aVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_aldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPexXVdMEeejsLaQeGcDdg" target="_dPexh1dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_a1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_bFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_1qX4MOwNEealldJ4rm6P_g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_bVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_bldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_b1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_cFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPexm1dMEeejsLaQeGcDdg" target="_dPexxVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_cVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_cldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_c1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_dFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_dVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_dldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPex2VdMEeejsLaQeGcDdg" target="_dPeyA1dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_d1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_eFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_eVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_eldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_e1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_fFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPeyH1dMEeejsLaQeGcDdg" target="_dPeySVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_fVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_fldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_NgYmEOxFEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_f1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_gFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_gVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_gldMEeejsLaQeGcDdg" type="4001" source="_dPexXVdMEeejsLaQeGcDdg" target="_dPeyH1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_g1dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_hFdMEeejsLaQeGcDdg" x="7" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_hVdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_hldMEeejsLaQeGcDdg" x="-10" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_h1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_iFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_iVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_ildMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_i1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_jFdMEeejsLaQeGcDdg" x="7" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_jVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_jldMEeejsLaQeGcDdg" x="1" y="-2"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_j1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_k1dMEeejsLaQeGcDdg" points="[0, -1, -3, -66]$[1, 41, -2, -24]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_lFdMEeejsLaQeGcDdg" id="(0.8702290076335878,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_lVdMEeejsLaQeGcDdg" id="(0.4789473684210526,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_lldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_gldMEeejsLaQeGcDdg" target="_dPeyXVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_l1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_mFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_qXvEgOxIEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_mVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_mldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_m1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_nFdMEeejsLaQeGcDdg" type="4001" source="_dPex2VdMEeejsLaQeGcDdg" target="_dPexm1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_nVdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_nldMEeejsLaQeGcDdg" x="-6" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_n1dMEeejsLaQeGcDdg" type="6002">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dPf_oFdMEeejsLaQeGcDdg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dPf_oVdMEeejsLaQeGcDdg" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_oldMEeejsLaQeGcDdg" x="8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_o1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_pFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_pVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_pldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_p1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_qFdMEeejsLaQeGcDdg" x="11" y="22"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_qVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_qldMEeejsLaQeGcDdg" x="-12" y="16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_q1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_r1dMEeejsLaQeGcDdg" points="[-12, -40, 12, 41]$[-24, -81, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_sFdMEeejsLaQeGcDdg" id="(0.4194690265486726,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_sVdMEeejsLaQeGcDdg" id="(0.45,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_sldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_nFdMEeejsLaQeGcDdg" target="_dPeycVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_s1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_tFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_tVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_tldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_t1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_uFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPeykVdMEeejsLaQeGcDdg" target="_dPfXQVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_uVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_uldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Interface" href="TapiOam.uml#_Nm0qoOxYEeaTUPmcu3rLwA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_u1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_vFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_vVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_vldMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfXVVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_v1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_wFdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_wVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_wldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_w1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_xFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfXWVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_xVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_xldMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_x1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_yFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_yVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_yldMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfXYVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_y1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_zFdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_zVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_zldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_z1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_0FdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfXZVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_0VdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_0ldMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_01dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_1FdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_1VdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_1ldMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfXaVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_11dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_2FdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_2VdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_2ldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_21dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_3FdMEeejsLaQeGcDdg" type="4001" source="_dPfXlVdMEeejsLaQeGcDdg" target="_dPewEVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_3VdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_3ldMEeejsLaQeGcDdg" x="-9" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_31dMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_4FdMEeejsLaQeGcDdg" x="11" y="2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_4VdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_4ldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_41dMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_5FdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_5VdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_5ldMEeejsLaQeGcDdg" x="10" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_51dMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_6FdMEeejsLaQeGcDdg" x="-14" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_6VdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_7VdMEeejsLaQeGcDdg" points="[-12, -26, 31, 71]$[-43, -98, 0, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_7ldMEeejsLaQeGcDdg" id="(0.1417910447761194,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_71dMEeejsLaQeGcDdg" id="(0.6203703703703703,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_8FdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_3FdMEeejsLaQeGcDdg" target="_dPfXbVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPf_8VdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPf_8ldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_g408EO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPf_81dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_9FdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPf_9VdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPf_9ldMEeejsLaQeGcDdg" type="4001" source="_dPfXlVdMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_91dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_-FdMEeejsLaQeGcDdg" x="-5" y="7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_-VdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf_-ldMEeejsLaQeGcDdg" x="14" y="2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf_-1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf__FdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf__VdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPf__ldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPf__1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAAFdMEeejsLaQeGcDdg" x="10" y="-12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAAVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAAldMEeejsLaQeGcDdg" x="-12" y="-13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAA1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAB1dMEeejsLaQeGcDdg" points="[2, -1, -262, 83]$[266, -85, 2, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgACFdMEeejsLaQeGcDdg" id="(0.8432835820895522,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgACVdMEeejsLaQeGcDdg" id="(0.35964912280701755,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgACldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf_9ldMEeejsLaQeGcDdg" target="_dPfXgVdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAC1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgADFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_hl75sO6jEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgADVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgADldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAD1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAEFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfXlVdMEeejsLaQeGcDdg" target="_dPfXv1dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAEVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAEldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_emeNAO6lEeaHHP1Zcp2a0A"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAE1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAFFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAFVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAFldMEeejsLaQeGcDdg" type="4001" source="_dPewjVdMEeejsLaQeGcDdg" target="_dPewy1dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAF1dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAGFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAGVdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAGldMEeejsLaQeGcDdg" x="1" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAG1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAHFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAHVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAHldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAH1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAIFdMEeejsLaQeGcDdg" x="16" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAIVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAIldMEeejsLaQeGcDdg" x="-12" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAI1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAJFdMEeejsLaQeGcDdg" points="[-1, -1, -107, -17]$[105, 15, -1, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAJVdMEeejsLaQeGcDdg" id="(0.8457142857142858,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAJldMEeejsLaQeGcDdg" id="(0.24561403508771928,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAJ1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAFldMEeejsLaQeGcDdg" target="_dPfX01dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAKFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAKVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAKldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAK1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgALFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgALVdMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfX11dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgALldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAL1dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_ysrVENzEEeaMV83ubDcSig"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAMFdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAMVdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAMldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAM1dMEeejsLaQeGcDdg" type="4001" source="_dPewEVdMEeejsLaQeGcDdg" target="_dPewjVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgANFdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgANVdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgANldMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAN1dMEeejsLaQeGcDdg" x="1" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAOFdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAOVdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAOldMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAO1dMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAPFdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAPVdMEeejsLaQeGcDdg" x="15" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAPldMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAP1dMEeejsLaQeGcDdg" x="-10" y="9"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAQFdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAQVdMEeejsLaQeGcDdg" points="[27, 0, -315, 6]$[342, -6, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAQldMEeejsLaQeGcDdg" id="(0.6388888888888888,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAQ1dMEeejsLaQeGcDdg" id="(0.09523809523809523,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgARFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAM1dMEeejsLaQeGcDdg" target="_dPfX21dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgARVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgARldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_-eN0AMbMEeaVKq30FmMykA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAR1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgASFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgASVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgASldMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPfX31dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAS1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgATFdMEeejsLaQeGcDdg" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgATVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgATldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAT1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAUFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfX41dMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAUVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAUldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAU1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAVFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAVVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAVldMEeejsLaQeGcDdg" type="4001" source="_dPexm1dMEeejsLaQeGcDdg" target="_dPfX41dMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAV1dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAWFdMEeejsLaQeGcDdg" x="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAWVdMEeejsLaQeGcDdg" type="6002">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dPgAWldMEeejsLaQeGcDdg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dPgAW1dMEeejsLaQeGcDdg" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAXFdMEeejsLaQeGcDdg" x="14" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAXVdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAXldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAX1dMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAYFdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAYVdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAYldMEeejsLaQeGcDdg" x="11" y="21"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAY1dMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAZFdMEeejsLaQeGcDdg" x="-10" y="20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAZVdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAaVdMEeejsLaQeGcDdg" points="[0, 0, 43, 55]$[-43, -55, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAaldMEeejsLaQeGcDdg" id="(0.4318181818181818,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAa1dMEeejsLaQeGcDdg" id="(0.4444444444444444,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAbFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAVldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAbVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAbldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAb1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAcFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAcVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAcldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfYEVdMEeejsLaQeGcDdg" target="_dPfYUldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAc1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAdFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAdVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAdldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAd1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAeFdMEeejsLaQeGcDdg" type="4006" source="_dPexXVdMEeejsLaQeGcDdg" target="_dPfYEVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAeVdMEeejsLaQeGcDdg" type="6014">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dPgAeldMEeejsLaQeGcDdg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dPgAe1dMEeejsLaQeGcDdg" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAfFdMEeejsLaQeGcDdg" x="5" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAfVdMEeejsLaQeGcDdg" type="6015">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAfldMEeejsLaQeGcDdg" x="2" y="3"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAf1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAg1dMEeejsLaQeGcDdg" points="[-28, 2, 127, -14]$[-139, 10, 16, -6]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAhFdMEeejsLaQeGcDdg" id="(1.0,0.6323529411764706)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAhVdMEeejsLaQeGcDdg" id="(0.0,0.55)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAhldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAeFdMEeejsLaQeGcDdg" target="_dPfYeldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAh1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAiFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_pW0gQBM7Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAiVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAildMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAi1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAjFdMEeejsLaQeGcDdg" type="4006" source="_dPfXlVdMEeejsLaQeGcDdg" target="_dPex2VdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAjVdMEeejsLaQeGcDdg" type="6014">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAjldMEeejsLaQeGcDdg" x="-25" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAj1dMEeejsLaQeGcDdg" type="6015">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAkFdMEeejsLaQeGcDdg" x="-34" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAkVdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAlVdMEeejsLaQeGcDdg" points="[-1, -1, -669, 80]$[668, 0, 0, 81]$[668, -81, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAlldMEeejsLaQeGcDdg" id="(1.0,0.45)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAl1dMEeejsLaQeGcDdg" id="(0.45132743362831856,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAmFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAjFdMEeejsLaQeGcDdg" target="_dPfYkldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAmVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAmldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOam.uml#_Zz0HkBNKEeeQQtMBY9ly8w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAm1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAnFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAnVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAnldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfY6FdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAn1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAoFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAoVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAoldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAo1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgApFdMEeejsLaQeGcDdg" type="4001" source="_dPfX41dMEeejsLaQeGcDdg" target="_dPfY6FdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgApVdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgApldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAp1dMEeejsLaQeGcDdg" type="6002">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dPgAqFdMEeejsLaQeGcDdg" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dPgAqVdMEeejsLaQeGcDdg" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAqldMEeejsLaQeGcDdg" x="5" y="-22"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAq1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgArFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgArVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgArldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAr1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAsFdMEeejsLaQeGcDdg" x="9" y="22"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAsVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAsldMEeejsLaQeGcDdg" x="-10" y="24"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAs1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAtFdMEeejsLaQeGcDdg" points="[52, 88, -70, -118]$[122, 206, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAtVdMEeejsLaQeGcDdg" id="(0.08547008547008547,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAtldMEeejsLaQeGcDdg" id="(0.6985294117647058,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAt1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfYqldMEeejsLaQeGcDdg" target="_dPfY1FdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAuFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgAuVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAuldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAu1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAvFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgAvVdMEeejsLaQeGcDdg" type="4001" source="_dPex2VdMEeejsLaQeGcDdg" target="_dPfYqldMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAvldMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAv1dMEeejsLaQeGcDdg" x="105" y="30"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAwFdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAwVdMEeejsLaQeGcDdg" x="109" y="48"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAwldMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAw1dMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAxFdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAxVdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAxldMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAx1dMEeejsLaQeGcDdg" x="14" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgAyFdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgAyVdMEeejsLaQeGcDdg" x="-11" y="17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgAyldMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgAzldMEeejsLaQeGcDdg" points="[-1, 0, 314, 102]$[-315, 0, 0, 102]$[-315, -103, 0, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgAz1dMEeejsLaQeGcDdg" id="(0.0,0.23333333333333334)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA0FdMEeejsLaQeGcDdg" id="(0.44661654135338347,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgA0VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgAvVdMEeejsLaQeGcDdg" target="_dPfZEldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgA0ldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgA01dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgA1FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA1VdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA1ldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgA11dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPfZUFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgA2FdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgA2VdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOam.uml#_W48McBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgA2ldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA21dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA3FdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgA3VdMEeejsLaQeGcDdg" type="4001" source="_dPeyH1dMEeejsLaQeGcDdg" target="_dPfZJldMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA3ldMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA31dMEeejsLaQeGcDdg" x="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA4FdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA4VdMEeejsLaQeGcDdg" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA4ldMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA41dMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA5FdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA5VdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA5ldMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA51dMEeejsLaQeGcDdg" x="8" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA6FdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA6VdMEeejsLaQeGcDdg" x="-11" y="10"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgA6ldMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgA7ldMEeejsLaQeGcDdg" points="[43, -1, -226, -1]$[215, -1, -54, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA71dMEeejsLaQeGcDdg" id="(0.8515789473684211,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA8FdMEeejsLaQeGcDdg" id="(0.49624060150375937,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgA8VdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgA3VdMEeejsLaQeGcDdg" target="_dPfZZFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgA8ldMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgA81dMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_bsgCEBP7EeepnPPr_BcZKg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgA9FdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA9VdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgA9ldMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgA91dMEeejsLaQeGcDdg" type="4001" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPfYqldMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA-FdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA-VdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA-ldMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA-1dMEeejsLaQeGcDdg" x="35" y="-12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA_FdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA_VdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgA_ldMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgA_1dMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBAFdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBAVdMEeejsLaQeGcDdg" x="7" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBAldMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBA1dMEeejsLaQeGcDdg" x="-12" y="16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBBFdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_uW9WEBP7EeepnPPr_BcZKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBBVdMEeejsLaQeGcDdg" points="[0, 0, -124, -84]$[0, 84, -124, 0]$[124, 84, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBBldMEeejsLaQeGcDdg" id="(0.6691729323308271,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBB1dMEeejsLaQeGcDdg" id="(0.0,0.5357142857142857)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBCFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf-dFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBCVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBCldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_e4FmwMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBC1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBDFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBDVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBDldMEeejsLaQeGcDdg" type="4008" source="_dPf-dFdMEeejsLaQeGcDdg" target="_dPfYEVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBD1dMEeejsLaQeGcDdg" type="6026">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBEFdMEeejsLaQeGcDdg" x="-5" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBEVdMEeejsLaQeGcDdg" type="6027">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBEldMEeejsLaQeGcDdg" x="-8" y="-11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBE1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBF1dMEeejsLaQeGcDdg" points="[-1, 0, 198, -12]$[-200, 12, -1, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBGFdMEeejsLaQeGcDdg" id="(0.0,0.515625)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBGVdMEeejsLaQeGcDdg" id="(1.0,0.45666666666666667)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBGldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBDldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBG1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBHFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_Ju5pkBM2Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBHVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBHldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBH1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBIFdMEeejsLaQeGcDdg" type="4001" source="_dPfY6FdMEeejsLaQeGcDdg" target="_dPf-dFdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBIVdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBIldMEeejsLaQeGcDdg" x="-7" y="-8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBI1dMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBJFdMEeejsLaQeGcDdg" x="8" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBJVdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBJldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBJ1dMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBKFdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBKVdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBKldMEeejsLaQeGcDdg" x="9" y="10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBK1dMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBLFdMEeejsLaQeGcDdg" x="-8" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBLVdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBMVdMEeejsLaQeGcDdg" points="[21, -40, -26, 46]$[47, -86, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBMldMEeejsLaQeGcDdg" id="(0.5808823529411765,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBM1dMEeejsLaQeGcDdg" id="(0.1,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBNFdMEeejsLaQeGcDdg" type="4001" source="_dPfYqldMEeejsLaQeGcDdg" target="_dPfYEVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBNVdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBNldMEeejsLaQeGcDdg" x="102" y="1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBN1dMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBOFdMEeejsLaQeGcDdg" x="120" y="-4"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBOVdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBOldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBO1dMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBPFdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBPVdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBPldMEeejsLaQeGcDdg" x="12" y="21"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBP1dMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBQFdMEeejsLaQeGcDdg" x="-12" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBQVdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBRVdMEeejsLaQeGcDdg" points="[0, 0, 121, 473]$[-102, -398, 19, 75]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBRldMEeejsLaQeGcDdg" id="(0.39849624060150374,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBR1dMEeejsLaQeGcDdg" id="(0.5698324022346368,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBSFdMEeejsLaQeGcDdg" type="4001" source="_dPfX41dMEeejsLaQeGcDdg" target="_dPf-dFdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBSVdMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBSldMEeejsLaQeGcDdg" x="40" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBS1dMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBTFdMEeejsLaQeGcDdg" x="53" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBTVdMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBTldMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBT1dMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBUFdMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBUVdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBUldMEeejsLaQeGcDdg" x="9" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBU1dMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBVFdMEeejsLaQeGcDdg" x="-13" y="12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBVVdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBWVdMEeejsLaQeGcDdg" points="[0, -1, -5, 180]$[5, -182, 0, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBWldMEeejsLaQeGcDdg" id="(0.7692307692307693,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBW1dMEeejsLaQeGcDdg" id="(0.8384615384615385,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBXFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBSFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBXVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBXldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_mvBt0MhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBX1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBYFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBYVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBYldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBIFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBY1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBZFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_l5X4MMhsEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBZVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBZldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBZ1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBaFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBNFdMEeejsLaQeGcDdg" target="_dPfZeFdMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBaVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBaldMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBa1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBbFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBbVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBbldMEeejsLaQeGcDdg" type="4001" source="_dPfZJldMEeejsLaQeGcDdg" target="_dPex2VdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBb1dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBcFdMEeejsLaQeGcDdg" x="-151" y="-149"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBcVdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBcldMEeejsLaQeGcDdg" x="-156" y="-166"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBc1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBdFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBdVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBdldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBd1dMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBeFdMEeejsLaQeGcDdg" x="9" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBeVdMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBeldMEeejsLaQeGcDdg" x="-10" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBe1dMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBf1dMEeejsLaQeGcDdg" points="[0, 0, -549, -244]$[0, 244, -549, 0]$[549, 244, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBgFdMEeejsLaQeGcDdg" id="(0.2857142857142857,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBgVdMEeejsLaQeGcDdg" id="(0.0,0.6666666666666666)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBgldMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBbldMEeejsLaQeGcDdg" target="_dPf-NldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBg1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBhFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOam.uml#_0WKlkE86Eeeicu4cm-7qRg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBhVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBhldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBh1dMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBiFdMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPf-SldMEeejsLaQeGcDdg" target="_dPf-nldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPgBiVdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPgBildMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPgBi1dMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBjFdMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPgBjVdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPgBjldMEeejsLaQeGcDdg" type="4001" source="_dPex2VdMEeejsLaQeGcDdg" target="_dPf-SldMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBj1dMEeejsLaQeGcDdg" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBkFdMEeejsLaQeGcDdg" x="57" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBkVdMEeejsLaQeGcDdg" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBkldMEeejsLaQeGcDdg" x="68"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBk1dMEeejsLaQeGcDdg" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBlFdMEeejsLaQeGcDdg" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPgBlVdMEeejsLaQeGcDdg" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPgBlldMEeejsLaQeGcDdg" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPglQFdMEeejsLaQeGcDdg" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPglQVdMEeejsLaQeGcDdg" x="14" y="15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPglQldMEeejsLaQeGcDdg" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPglQ1dMEeejsLaQeGcDdg" x="-12" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPglRFdMEeejsLaQeGcDdg"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPglSFdMEeejsLaQeGcDdg" points="[-1, 0, -101, 115]$[100, 0, 0, 115]$[100, -116, 0, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglSVdMEeejsLaQeGcDdg" id="(1.0,0.4444444444444444)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglSldMEeejsLaQeGcDdg" id="(0.5085714285714286,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPglS1dMEeejsLaQeGcDdg" type="StereotypeCommentLink" source="_dPgBjldMEeejsLaQeGcDdg" target="_dPf-sldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPglTFdMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPglTVdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPglTldMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglT1dMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglUFdMEeejsLaQeGcDdg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPglUVdMEeejsLaQeGcDdg" type="4003" source="_dPexXVdMEeejsLaQeGcDdg" target="_dPeykVdMEeejsLaQeGcDdg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPglUldMEeejsLaQeGcDdg" type="6008">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPglU1dMEeejsLaQeGcDdg" y="40"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_dPglVFdMEeejsLaQeGcDdg" type="6009">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dPglVVdMEeejsLaQeGcDdg" x="9" y="-10"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPglVldMEeejsLaQeGcDdg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPglV1dMEeejsLaQeGcDdg" points="[-1, 0, 81, -110]$[-82, 0, 0, -110]$[-83, 109, -1, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglWFdMEeejsLaQeGcDdg" id="(0.0,0.4264705882352941)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglWVdMEeejsLaQeGcDdg" id="(0.4298507462686567,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dPglWldMEeejsLaQeGcDdg" type="StereotypeCommentLink" target="_dPf-xldMEeejsLaQeGcDdg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dPglW1dMEeejsLaQeGcDdg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dPglXFdMEeejsLaQeGcDdg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dPglXVdMEeejsLaQeGcDdg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglXldMEeejsLaQeGcDdg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dPglX1dMEeejsLaQeGcDdg"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -368,7 +368,7 @@
   <OpenModel_Profile:OpenModelAttribute xmi:id="_mJof4fLsEeaAIfPpmDwI5Q" base_StructuralFeature="_mJof4PLsEeaAIfPpmDwI5Q"/>
   <OpenModel_Profile:PassedByReference xmi:id="_vOnwMBMyEee0L_IMWjydgQ" base_Property="__n5DwNzDEeaMV83ubDcSig"/>
   <OpenModel_Profile:Specify xmi:id="_u2Lr8BM7Eee0L_IMWjydgQ" base_Abstraction="_pW0gQBM7Eee0L_IMWjydgQ" target="/TapiCommon:Context:_context"/>
-  <OpenModel_Profile:Specify xmi:id="_e_h-gBNKEeeQQtMBY9ly8w" base_Abstraction="_Zz0HkBNKEeeQQtMBY9ly8w" target="/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connection/TapiConnectivity:Connection:_connectionEndPoint/TapiConnectivity:ConnectionEndPoint:_layerProtocol"/>
+  <OpenModel_Profile:Specify xmi:id="_e_h-gBNKEeeQQtMBY9ly8w" base_Abstraction="_Zz0HkBNKEeeQQtMBY9ly8w" target="/TapiCommon:Context:_context/TapiOam:OamContext:_oamService/TapiOam:OamService:_endPoint/TapiOam:OamServiceEndPoint:_layerProtocol"/>
   <OpenModel_Profile:StrictComposite xmi:id="_b7lzgBPmEeepnPPr_BcZKg" base_Association="_kho9QMbMEeaVKq30FmMykA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_W48McRP7EeepnPPr_BcZKg" base_Class="_W48McBP7EeepnPPr_BcZKg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_bsmItBP7EeepnPPr_BcZKg" base_StructuralFeature="_bsmIshP7EeepnPPr_BcZKg"/>

--- a/UML/TapiOam.uml
+++ b/UML/TapiOam.uml
@@ -110,9 +110,10 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DlVJsNzEEeaMV83ubDcSig" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_bsmIshP7EeepnPPr_BcZKg" name="_endPoint" type="_W48McBP7EeepnPPr_BcZKg" aggregation="composite" association="_bsgCEBP7EeepnPPr_BcZKg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="2"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kW8CoBP7EeepnPPr_BcZKg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kXCJQBP7EeepnPPr_BcZKg" value="*"/>
         </ownedAttribute>
+        <interfaceRealization xmi:type="uml:InterfaceRealization" xmi:id="_YHEnoFdTEeejsLaQeGcDdg" client="_NgYmEOxFEeaTUPmcu3rLwA" supplier="_Nm0qoOxYEeaTUPmcu3rLwA" contract="_Nm0qoOxYEeaTUPmcu3rLwA"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_1qX4MOwNEealldJ4rm6P_g" name="OamContext">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_qX1LIuxIEeaTUPmcu3rLwA" name="_oamService" type="_NgYmEOxFEeaTUPmcu3rLwA" aggregation="composite" association="_qXvEgOxIEeaTUPmcu3rLwA">
@@ -124,7 +125,7 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_61UlQMbNEeaVKq30FmMykA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_emeNAO6lEeaHHP1Zcp2a0A" name="MepMipReference">
+      <packagedElement xmi:type="uml:Class" xmi:id="_emeNAO6lEeaHHP1Zcp2a0A" name="OamLpSpec">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hl75tO6jEeaHHP1Zcp2a0A" name="_mip" type="_k-OoENzEEeaMV83ubDcSig" isReadOnly="true" aggregation="composite" association="_hl75sO6jEeaHHP1Zcp2a0A">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_psLBAO6jEeaHHP1Zcp2a0A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_psRHoO6jEeaHHP1Zcp2a0A" value="*"/>
@@ -242,7 +243,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_qX7RwexIEeaTUPmcu3rLwA" name="oamcontext" type="_1qX4MOwNEealldJ4rm6P_g" association="_qXvEgOxIEeaTUPmcu3rLwA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Dependency" xmi:id="_9cCooOxYEeaTUPmcu3rLwA" name="OperatesOn" client="_XQfKcOvSEealldJ4rm6P_g" supplier="_XQfKcOvSEealldJ4rm6P_g"/>
       <packagedElement xmi:type="uml:Association" xmi:id="_g408EO6jEeaHHP1Zcp2a0A" name="LpContainsMep" memberEnd="_g43YUO6jEeaHHP1Zcp2a0A _g450kO6jEeaHHP1Zcp2a0A">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g41jIO6jEeaHHP1Zcp2a0A" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_g42KMO6jEeaHHP1Zcp2a0A" key="nature" value="UML_Nature"/>
@@ -264,7 +264,7 @@
         </ownedComment>
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Zz0HkBNKEeeQQtMBY9ly8w" name="MepMipRefAugmentsLp" client="_emeNAO6lEeaHHP1Zcp2a0A">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Zz0HkBNKEeeQQtMBY9ly8w" name="OamSpecAugmentsLp" client="_emeNAO6lEeaHHP1Zcp2a0A">
         <supplier xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_bsgCEBP7EeepnPPr_BcZKg" name="OamServiceHasSEPs" memberEnd="_bsmIshP7EeepnPPr_BcZKg _bssPUBP7EeepnPPr_BcZKg">


### PR DESCRIPTION
As per discussion on 06/22/17 IMP call on OamService semantics
 - cleaned-up and added OamServiceSkeleton diagram 
 - added _OamLpSpec_ (MepMipReferences) augment association to _OamServiceEndPoint_ which represents the "intent" part of Oam request. Thus it is possible to specify intended MEP/MIP setup information in the _OamService_ request. Since _OamServiceEndPoint_ also holds references to the _ServiceInterfacePoint_ with specific _role_ and _directionality_ for this specific request, it is possible for the TAPI provider/controller to instantiate/provision _MEPs/MIPs_ on appropriate _ConnectionEndPoints/NodeEdgePoints_