### PR TITLE
Fixes to ODU model to enable proper yang generation

### DIFF
--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -179,11 +179,11 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/termination-spec/": {
+        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
             "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_termination-spec_termination-spec",
+                "summary": "Retrieve odu-pool-property-spec",
+                "description": "Retrieve operation of resource: odu-pool-property-spec",
+                "operationId": "retrieve_context_service-interface-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
                 "produces": [
                     "application/json"
                 ],
@@ -210,129 +210,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/termination-spec/deg-thr/": {
-            "get": {
-                "summary": "Retrieve deg-thr",
-                "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_termination-spec_deg-thr_deg-thr",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                            "$ref": "#/definitions/deg-thr"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/adapter-and-connection-point-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/nominal-bit-rate-and-tolerance/": {
-            "get": {
-                "summary": "Retrieve nominal-bit-rate-and-tolerance",
-                "description": "Retrieve operation of resource: nominal-bit-rate-and-tolerance",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_nominal-bit-rate-and-tolerance_nominal-bit-rate-and-tolerance",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                            "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
+                            "$ref": "#/definitions/odu-pool-property-pac"
                         }
                     },
                     "400": {
@@ -565,11 +443,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/termination-spec/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
             "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_termination-spec_termination-spec",
+                "summary": "Retrieve odu-pool-property-spec",
+                "description": "Retrieve operation of resource: odu-pool-property-spec",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
                 "produces": [
                     "application/json"
                 ],
@@ -610,171 +488,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/termination-spec/deg-thr/": {
-            "get": {
-                "summary": "Retrieve deg-thr",
-                "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_termination-spec_deg-thr_deg-thr",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                            "$ref": "#/definitions/deg-thr"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/adapter-and-connection-point-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/nominal-bit-rate-and-tolerance/": {
-            "get": {
-                "summary": "Retrieve nominal-bit-rate-and-tolerance",
-                "description": "Retrieve operation of resource: nominal-bit-rate-and-tolerance",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_nominal-bit-rate-and-tolerance_nominal-bit-rate-and-tolerance",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                            "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
+                            "$ref": "#/definitions/odu-pool-property-pac"
                         }
                     },
                     "400": {
@@ -979,11 +693,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/termination-spec/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/odu-pool-property-spec/": {
             "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_termination-spec_termination-spec",
+                "summary": "Retrieve odu-pool-property-spec",
+                "description": "Retrieve operation of resource: odu-pool-property-spec",
+                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
                 "produces": [
                     "application/json"
                 ],
@@ -1017,150 +731,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/termination-spec/deg-thr/": {
-            "get": {
-                "summary": "Retrieve deg-thr",
-                "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_termination-spec_deg-thr_deg-thr",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                            "$ref": "#/definitions/deg-thr"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/adapter-and-connection-point-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/nominal-bit-rate-and-tolerance/": {
-            "get": {
-                "summary": "Retrieve nominal-bit-rate-and-tolerance",
-                "description": "Retrieve operation of resource: nominal-bit-rate-and-tolerance",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_nominal-bit-rate-and-tolerance_nominal-bit-rate-and-tolerance",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                            "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
+                            "$ref": "#/definitions/odu-pool-property-pac"
                         }
                     },
                     "400": {
@@ -1365,201 +936,58 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/termination-spec/": {
-            "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_termination-spec_termination-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/termination-spec/deg-thr/": {
-            "get": {
-                "summary": "Retrieve deg-thr",
-                "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_termination-spec_deg-thr_deg-thr",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                            "$ref": "#/definitions/deg-thr"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/adapter-and-connection-point-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/nominal-bit-rate-and-tolerance/": {
-            "get": {
-                "summary": "Retrieve nominal-bit-rate-and-tolerance",
-                "description": "Retrieve operation of resource: nominal-bit-rate-and-tolerance",
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_adapter-spec_nominal-bit-rate-and-tolerance_nominal-bit-rate-and-tolerance",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                            "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
+        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
             "get": {
                 "summary": "Retrieve odu-pool-property-spec",
                 "description": "Retrieve operation of resource: odu-pool-property-spec",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-pool-property-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/ctp-pac/": {
+            "get": {
+                "summary": "Retrieve ctp-pac",
+                "description": "Retrieve operation of resource: ctp-pac",
+                "operationId": "retrieve_context_service-interface-point_layer-protocol_ctp-pac_ctp-pac",
                 "produces": [
                     "application/json"
                 ],
@@ -1586,7 +1014,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/pool-property-pac"
+                            "$ref": "#/definitions/odu-ctp-pac"
                         }
                     },
                     "400": {
@@ -1595,11 +1023,132 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
+        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/termination-pac/": {
             "get": {
-                "summary": "Retrieve odu-pool-property-spec",
-                "description": "Retrieve operation of resource: odu-pool-property-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
+                "summary": "Retrieve termination-pac",
+                "description": "Retrieve operation of resource: termination-pac",
+                "operationId": "retrieve_context_service-interface-point_layer-protocol_termination-pac_termination-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-pac/": {
+            "get": {
+                "summary": "Retrieve adapter-pac",
+                "description": "Retrieve operation of resource: adapter-pac",
+                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-pac_adapter-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-pac/accepted-payload-type/": {
+            "get": {
+                "summary": "Retrieve accepted-payload-type",
+                "description": "Retrieve operation of resource: accepted-payload-type",
+                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-pac_accepted-payload-type_accepted-payload-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/ctp-pac/": {
+            "get": {
+                "summary": "Retrieve ctp-pac",
+                "description": "Retrieve operation of resource: ctp-pac",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_ctp-pac_ctp-pac",
                 "produces": [
                     "application/json"
                 ],
@@ -1640,7 +1189,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/pool-property-pac"
+                            "$ref": "#/definitions/odu-ctp-pac"
                         }
                     },
                     "400": {
@@ -1649,11 +1198,174 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/odu-pool-property-spec/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/termination-pac/": {
             "get": {
-                "summary": "Retrieve odu-pool-property-spec",
-                "description": "Retrieve operation of resource: odu-pool-property-spec",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
+                "summary": "Retrieve termination-pac",
+                "description": "Retrieve operation of resource: termination-pac",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_termination-pac_termination-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-pac/": {
+            "get": {
+                "summary": "Retrieve adapter-pac",
+                "description": "Retrieve operation of resource: adapter-pac",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-pac_adapter-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-pac/accepted-payload-type/": {
+            "get": {
+                "summary": "Retrieve accepted-payload-type",
+                "description": "Retrieve operation of resource: accepted-payload-type",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-pac_accepted-payload-type_accepted-payload-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/ctp-pac/": {
+            "get": {
+                "summary": "Retrieve ctp-pac",
+                "description": "Retrieve operation of resource: ctp-pac",
+                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_ctp-pac_ctp-pac",
                 "produces": [
                     "application/json"
                 ],
@@ -1687,7 +1399,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/pool-property-pac"
+                            "$ref": "#/definitions/odu-ctp-pac"
                         }
                     },
                     "400": {
@@ -1696,11 +1408,153 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/odu-pool-property-spec/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/termination-pac/": {
             "get": {
-                "summary": "Retrieve odu-pool-property-spec",
-                "description": "Retrieve operation of resource: odu-pool-property-spec",
-                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_odu-pool-property-spec_odu-pool-property-spec",
+                "summary": "Retrieve termination-pac",
+                "description": "Retrieve operation of resource: termination-pac",
+                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_termination-pac_termination-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-pac/": {
+            "get": {
+                "summary": "Retrieve adapter-pac",
+                "description": "Retrieve operation of resource: adapter-pac",
+                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-pac_adapter-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-pac/accepted-payload-type/": {
+            "get": {
+                "summary": "Retrieve accepted-payload-type",
+                "description": "Retrieve operation of resource: accepted-payload-type",
+                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-pac_accepted-payload-type_accepted-payload-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/ctp-pac/": {
+            "get": {
+                "summary": "Retrieve ctp-pac",
+                "description": "Retrieve operation of resource: ctp-pac",
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_ctp-pac_ctp-pac",
                 "produces": [
                     "application/json"
                 ],
@@ -1734,7 +1588,149 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/pool-property-pac"
+                            "$ref": "#/definitions/odu-ctp-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/termination-pac/": {
+            "get": {
+                "summary": "Retrieve termination-pac",
+                "description": "Retrieve operation of resource: termination-pac",
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_termination-pac_termination-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-pac/": {
+            "get": {
+                "summary": "Retrieve adapter-pac",
+                "description": "Retrieve operation of resource: adapter-pac",
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_adapter-pac_adapter-pac",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/odu-client-adaptation-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connection/{uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-pac/accepted-payload-type/": {
+            "get": {
+                "summary": "Retrieve accepted-payload-type",
+                "description": "Retrieve operation of resource: accepted-payload-type",
+                "operationId": "retrieve_context_connection_connection-end-point_layer-protocol_adapter-pac_accepted-payload-type_accepted-payload-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
                         }
                     },
                     "400": {
@@ -1745,163 +1741,82 @@
         }
     },
     "definitions": {
-        "adapter-and-connection-point-pac": {
+        "odu-client-adaptation-pac": {
+            "description": "This Pac contains the attributes associated with the client adaptation function of the server layer TTP\nIt is present only if the CEP contains a TTP",
             "properties": {
-                "adaptation-active": {
-                    "type": "boolean",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point."
-                },
-                "aps-enable": {
-                    "type": "boolean",
-                    "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
-                },
-                "aps-level": {
-                    "type": "string",
-                    "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
-                },
-                "k": {
+                "opu-tributary-slot-size": {
                     "type": "string",
                     "enum": [
-                        "1.25-g",
-                        "2.5-g",
-                        "10-g",
-                        "10-g-2-e",
-                        "40-g",
-                        "100-g",
-                        "flex-cbr",
-                        "flex-gfp"
+                        "1-g-25",
+                        "2-g-5"
                     ],
-                    "description": "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.\nWhen the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.\n"
-                },
-                "odu-type-and-rate": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G"
-                },
-                "position-seq": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.\nThe order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.\nWithin the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.\nThe syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.\nThe order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).\nIf a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.\n"
-                    }
-                },
-                "tributary-slot-list": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
-                    }
-                },
-                "applicable-problems": {
-                    "type": "string",
-                    "enum": [
-                        "plm",
-                        "msim",
-                        "lof-lom",
-                        "loomfi"
-                    ],
-                    "description": "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList."
-                },
-                "expected-m-si": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. "
-                },
-                "accepted-m-si": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
-                },
-                "accepted-payload-type": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. "
-                },
-                "transmitted-m-si": {
-                    "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function."
+                    "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
                 },
                 "auto-payload-type": {
                     "type": "boolean",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
+                    "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
                 },
-                "inserted-payload-type": {
+                "configured-client-type": {
                     "type": "string",
-                    "description": "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. "
+                    "description": "This attribute configures the type of the client CTP of the server ODU TTP."
                 },
-                "current-number-of-tributary-slots": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. \nThe upper bound of this attribute is dependent on the HO-ODUk server layer. \nWhen the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):\n- After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)\n- After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)\nThis attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n"
-                    }
-                },
-                "nominal-bit-rate-and-tolerance": {
-                    "description": "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-                    "$ref": "#/definitions/oduk-h-nominal-bit-rate-and-tolerance"
-                }
-            }
-        },
-        "termination-pac": {
-            "properties": {
-                "rate": {
-                    "type": "string",
-                    "description": "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).\n"
-                },
-                "dm-source": {
-                    "type": "boolean",
-                    "description": "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue."
-                },
-                "dm-value": {
-                    "type": "boolean",
-                    "description": "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1."
-                },
-                "acti": {
-                    "type": "string",
-                    "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail."
-                },
-                "deg-m": {
-                    "type": "string",
-                    "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected."
-                },
-                "deg-thr": {
-                    "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
-                    "$ref": "#/definitions/deg-thr"
-                },
-                "ex-dapi": {
-                    "type": "string",
-                    "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
-                },
-                "ex-sapi": {
-                    "type": "string",
-                    "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
-                },
-                "tim-act-disabled": {
-                    "type": "boolean",
-                    "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled."
-                },
-                "tim-det-mode": {
+                "configured-mapping-type": {
                     "type": "string",
                     "enum": [
-                        "dapi",
-                        "sapi",
-                        "both"
+                        "amp",
+                        "bmp",
+                        "gfp-f",
+                        "gmp",
+                        "ttp-gfp-bmp",
+                        "null"
                     ],
-                    "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI"
+                    "description": "This attributes indicates the configured mapping type."
                 },
-                "txti": {
-                    "type": "string",
-                    "description": "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission."
+                "accepted-payload-type": {
+                    "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                    "$ref": "#/definitions/odu-payload-type"
                 }
             }
         },
-        "connection-end-point-lp-spec": {
+        "odu-termination-pac": {
+            "description": "This Pac contains the attributes associated with the termination function of the TTP\nIt is present only if the CEP contains a TTP"
+        },
+        "odu-connection-end-point-lp-spec": {
             "properties": {
-                "termination-spec": {
-                    "$ref": "#/definitions/termination-pac"
+                "odu-type": {
+                    "type": "string",
+                    "enum": [
+                        "odu-0",
+                        "odu-1",
+                        "odu-2",
+                        "odu-2-e",
+                        "odu-3",
+                        "odu-4",
+                        "odu-flex",
+                        "odu-cn"
+                    ],
+                    "description": "This attribute specifies the type of the ODU termination point."
                 },
-                "adapter-spec": {
-                    "$ref": "#/definitions/adapter-and-connection-point-pac"
+                "odu-rate": {
+                    "type": "string",
+                    "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
+                },
+                "odu-rate-tolerance": {
+                    "type": "string",
+                    "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
+                },
+                "ctp-pac": {
+                    "$ref": "#/definitions/odu-ctp-pac"
+                },
+                "termination-pac": {
+                    "$ref": "#/definitions/odu-termination-pac"
+                },
+                "adapter-pac": {
+                    "$ref": "#/definitions/odu-client-adaptation-pac"
                 }
             }
         },
-        "pool-property-pac": {
+        "odu-pool-property-pac": {
             "properties": {
                 "client-capacity": {
                     "type": "string"
@@ -1914,39 +1829,98 @@
                 }
             }
         },
-        "node-edge-point-lp-spec": {
+        "odu-node-edge-point-lp-spec": {
             "properties": {
                 "odu-pool-property-spec": {
-                    "$ref": "#/definitions/pool-property-pac"
+                    "$ref": "#/definitions/odu-pool-property-pac"
                 }
             }
         },
-        "deg-thr": {
-            "description": "Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. \ndegThrValue when type is PERCENTAGE:\npercentageGranularity is used to indicate the number of decimal points\nSo if percentageGranularity is 0 a value of 1 in degThrValue would indicate 1%, a value of 10 = 10%, a value of 100 = 100%\nSo if percentageGranularity is 3 (thousandths) a value of 1 in degThrValue would indicate 0.001%, a value of 1000 = 1%, a value of 1000000 = 100%\ndegThrValue when type is NUMBER_ERROR_BLOCKS:\nNumber of Errored Blocks is captured in an integer value.",
+        "odu-ctp-pac": {
+            "description": "This Pac contains the attributes associated with the CTP\nIt is present only if the CEP contains a CTP",
             "properties": {
-                "deg-thr-value": {
-                    "type": "string",
-                    "description": "Percentage of detected errored blocks"
+                "tributary-slot-list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \nThis attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. \nIt will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). \nThe upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). \nThus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
+                    }
                 },
-                "deg-thr-type": {
+                "tributary-port-number": {
                     "type": "string",
-                    "description": "Number of errored blocks"
+                    "description": "This attribute identifies the tributary port number that is associated with the ODU CTP.\nrange of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.\nIn case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.\nIn case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.\nIn case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.\nIn case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\n"
                 },
-                "percentage-granularity": {
+                "accepted-m-si": {
+                    "type": "string",
+                    "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
+                }
+            }
+        },
+        "odu-mep-spec": {
+            "properties": {
+                "acti": {
+                    "type": "string",
+                    "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail."
+                },
+                "deg-m": {
+                    "type": "string",
+                    "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected."
+                },
+                "deg-thr": {
+                    "type": "string",
+                    "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer."
+                },
+                "ex-dapi": {
+                    "type": "string",
+                    "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
+                },
+                "ex-sapi": {
+                    "type": "string",
+                    "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.\n"
+                },
+                "tim-act-disabled": {
+                    "type": "boolean",
+                    "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink."
+                },
+                "tim-det-mode": {
+                    "type": "string",
+                    "enum": [
+                        "dapi",
+                        "sapi",
+                        "both",
+                        "off"
+                    ],
+                    "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI"
+                },
+                "txti": {
+                    "type": "string",
+                    "description": "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.\n"
+                }
+            }
+        },
+        "protection-spec": {
+            "properties": {
+                "aps-enable": {
+                    "type": "boolean",
+                    "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
+                },
+                "aps-level": {
+                    "type": "string",
+                    "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
+                }
+            }
+        },
+        "odu-payload-type": {
+            "properties": {
+                "named-payload-type": {
+                    "type": "string",
+                    "enum": [
+                        "unknown",
+                        "uninterpretable"
+                    ]
+                },
+                "hex-payload-type": {
                     "type": "string"
-                }
-            }
-        },
-        "oduk-h-nominal-bit-rate-and-tolerance": {
-            "description": "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.",
-            "properties": {
-                "tolerance": {
-                    "type": "string",
-                    "description": "tolerance in ppm"
-                },
-                "frequency": {
-                    "type": "string",
-                    "description": "frequency in kilohertz"
                 }
             }
         },
@@ -2306,639 +2280,40 @@
                             },
                             "x-key": "value-name"
                         },
-                        "odu-pool-property-spec": {
-                            "$ref": "#/definitions/pool-property-pac"
+                        "odu-type": {
+                            "type": "string",
+                            "enum": [
+                                "odu-0",
+                                "odu-1",
+                                "odu-2",
+                                "odu-2-e",
+                                "odu-3",
+                                "odu-4",
+                                "odu-flex",
+                                "odu-cn"
+                            ],
+                            "description": "This attribute specifies the type of the ODU termination point."
+                        },
+                        "odu-rate": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
+                        },
+                        "odu-rate-tolerance": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
+                        },
+                        "ctp-pac": {
+                            "$ref": "#/definitions/odu-ctp-pac"
+                        },
+                        "termination-pac": {
+                            "$ref": "#/definitions/odu-termination-pac"
+                        },
+                        "adapter-pac": {
+                            "$ref": "#/definitions/odu-client-adaptation-pac"
                         }
                     }
                 }
             ]
-        },
-        "connection": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connection-end-point"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "lower-connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
-                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
-                            }
-                        },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
-                        "route": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/route"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "switch-control": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch-control"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ]
-                        },
-                        "layer-protocol-name": {
-                            "type": "string"
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connection-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "client-node-edge-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "connection-port-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "connection-port-role": {
-                            "type": "string",
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ],
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
-        },
-        "connectivity-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-type": {
-                            "type": "string",
-                            "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
-                            ]
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "cost-characteristic": {
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "x-key": "cost-name cost-value cost-algorithm"
-                        },
-                        "latency-characteristic": {
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "x-key": "traffic-property-name traffic-property-queing-latency"
-                        },
-                        "coroute-inclusion": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                        },
-                        "diversity-exclusion": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                            }
-                        },
-                        "schedule": {
-                            "$ref": "#/definitions/time-range"
-                        }
-                    }
-                }
-            ]
-        },
-        "connectivity-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "end-point": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service-end-point"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
-                            }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
-                            ]
-                        },
-                        "layer-protocol-name": {
-                            "type": "string"
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connectivity-service-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "role": {
-                            "type": "string",
-                            "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ],
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
-        },
-        "route": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        }
-                    }
-                }
-            ],
-            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
-        },
-        "connectivity-context": {
-            "properties": {
-                "connectivity-service": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    },
-                    "x-key": "uuid"
-                },
-                "connection": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connection"
-                    },
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "switch": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "selected-connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "selected-route": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
-                            }
-                        },
-                        "selection-control": {
-                            "type": "string",
-                            "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
-                            ],
-                            "description": "Degree of administrative control applied to the switch selection."
-                        },
-                        "selection-reason": {
-                            "type": "string",
-                            "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
-                            ],
-                            "description": "The reason for the current switch selection."
-                        },
-                        "switch-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
-                            ],
-                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
-                        }
-                    }
-                }
-            ],
-            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
-        },
-        "switch-control": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "sub-switch-control": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
-                            }
-                        },
-                        "switch": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/control-parameters-pac"
-                        }
-                    }
-                }
-            ],
-            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
-        },
-        "control-parameters-pac": {
-            "description": "A list of control parameters to apply to a switch.",
-            "properties": {
-                "switch-type": {
-                    "type": "string",
-                    "enum": [
-                        "linear-1-plus-1",
-                        "linear-1-for-1"
-                    ],
-                    "description": "Indicates the protection scheme that is used for the ProtectionGroup."
-                },
-                "reversion-mode": {
-                    "type": "string",
-                    "enum": [
-                        "revertive",
-                        "non-revertive"
-                    ],
-                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                },
-                "wait-to-revert-time": {
-                    "type": "string",
-                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                },
-                "hold-off-time": {
-                    "type": "string",
-                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                },
-                "is-lock-out": {
-                    "type": "boolean",
-                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                },
-                "is-frozen": {
-                    "type": "boolean",
-                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                },
-                "is-coordinated-switching-both-ends": {
-                    "type": "boolean",
-                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                }
-            }
-        },
-        "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        "get-connection-detailsRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                },
-                "connection-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-connection-detailsRPC_output_schema": {
-            "properties": {
-                "connection": {
-                    "$ref": "#/definitions/connection"
-                }
-            }
-        },
-        "get-connectivity-service-listRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    }
-                }
-            }
-        },
-        "get-connectivity-service-detailsRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-connectivity-service-detailsRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "create-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "end-point": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service-end-point"
-                    }
-                },
-                "conn-constraint": {
-                    "$ref": "#/definitions/connectivity-constraint"
-                },
-                "topo-constraint": {
-                    "$ref": "#/definitions/topology-constraint"
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
-        "create-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "update-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                },
-                "end-point": {
-                    "$ref": "#/definitions/connectivity-service-end-point"
-                },
-                "conn-constraint": {
-                    "$ref": "#/definitions/connectivity-constraint"
-                },
-                "topo-constraint": {
-                    "$ref": "#/definitions/topology-constraint"
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
-        "update-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "delete-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "delete-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
         },
         "link": {
             "allOf": [
@@ -3474,6 +2849,604 @@
                     "description": "Quality of validation (i.e. how likely is the stated validation to be invalid)"
                 }
             }
+        },
+        "get-topology-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-topology-detailsRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "$ref": "#/definitions/topology"
+                }
+            }
+        },
+        "get-node-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-detailsRPC_output_schema": {
+            "properties": {
+                "node": {
+                    "$ref": "#/definitions/node"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                },
+                "ep-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_output_schema": {
+            "properties": {
+                "node-edge-point": {
+                    "$ref": "#/definitions/node-edge-point"
+                }
+            }
+        },
+        "get-link-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "link-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-link-detailsRPC_output_schema": {
+            "properties": {
+                "link": {
+                    "$ref": "#/definitions/link"
+                }
+            }
+        },
+        "get-topology-listRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    }
+                }
+            }
+        },
+        "connection": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection-end-point"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "lower-connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
+                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
+                            }
+                        },
+                        "supported-link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
+                            }
+                        },
+                        "container-node": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                        },
+                        "route": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/route"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "switch-control": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch-control"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connection-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "layer-protocol": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "client-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                            }
+                        },
+                        "server-node-edge-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                        },
+                        "peer-connection-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "connection-port-direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "connection-port-role": {
+                            "type": "string",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "trunk",
+                                "unknown"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        }
+                    }
+                }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "connectivity-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-type": {
+                            "type": "string",
+                            "enum": [
+                                "point-to-point-connectivity",
+                                "point-to-multipoint-connectivity",
+                                "multipoint-connectivity",
+                                "rooted-multipoint-connectivity"
+                            ]
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name cost-value cost-algorithm"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name traffic-property-queing-latency"
+                        },
+                        "coroute-inclusion": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                        },
+                        "diversity-exclusion": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                            }
+                        },
+                        "schedule": {
+                            "$ref": "#/definitions/time-range"
+                        }
+                    }
+                }
+            ]
+        },
+        "connectivity-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+                            }
+                        },
+                        "conn-constraint": {
+                            "$ref": "#/definitions/connectivity-constraint"
+                        },
+                        "topo-constraint": {
+                            "$ref": "#/definitions/topology-constraint"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "unidirectional",
+                                "undefined-or-unknown"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connectivity-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "layer-protocol": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/layer-protocol"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "capacity": {
+                            "$ref": "#/definitions/capacity-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": [
+                                "symmetric",
+                                "root",
+                                "leaf",
+                                "trunk",
+                                "unknown"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "route": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
+        },
+        "connectivity-context": {
+            "properties": {
+                "connectivity-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connectivity-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "connection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "switch": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "selected-connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "selected-route": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                            }
+                        },
+                        "selection-control": {
+                            "type": "string",
+                            "enum": [
+                                "lock-out",
+                                "normal",
+                                "manual",
+                                "forced"
+                            ],
+                            "description": "Degree of administrative control applied to the switch selection."
+                        },
+                        "selection-reason": {
+                            "type": "string",
+                            "enum": [
+                                "lockout",
+                                "normal",
+                                "manual",
+                                "forced",
+                                "wait-to-revert",
+                                "signal-degrade",
+                                "signal-fail"
+                            ],
+                            "description": "The reason for the current switch selection."
+                        },
+                        "switch-direction": {
+                            "type": "string",
+                            "enum": [
+                                "bidirectional",
+                                "input",
+                                "output",
+                                "unidentified-or-unknown"
+                            ],
+                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
+                        }
+                    }
+                }
+            ],
+            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
+        },
+        "switch-control": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "sub-switch-control": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                            }
+                        },
+                        "switch": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "control-parameters": {
+                            "$ref": "#/definitions/control-parameters-pac"
+                        }
+                    }
+                }
+            ],
+            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
+        },
+        "control-parameters-pac": {
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "switch-type": {
+                    "type": "string",
+                    "enum": [
+                        "linear-1-plus-1",
+                        "linear-1-for-1"
+                    ],
+                    "description": "Indicates the protection scheme that is used for the ProtectionGroup."
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "revertive",
+                        "non-revertive"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                }
+            }
+        },
+        "topology-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "include-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        },
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        },
+                        "include-path": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                            }
+                        },
+                        "exclude-path": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                            }
+                        },
+                        "include-link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                            }
+                        },
+                        "exclude-link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                            }
+                        },
+                        "include-node": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                            }
+                        },
+                        "exclude-node": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                            }
+                        },
+                        "preferred-transport-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     }
 }

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -1545,14 +1545,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9-D-dRNIEeeQQtMBY9ly8w" x="130" y="-459"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_XkC50xNJEeeQQtMBY9ly8w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_XkC51BNJEeeQQtMBY9ly8w" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XkC51hNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_UFST8BNJEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XkC51RNJEeeQQtMBY9ly8w" x="520" y="-408"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_YmwUBBNJEeeQQtMBY9ly8w" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_YmwUBRNJEeeQQtMBY9ly8w" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YmwUBxNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
@@ -2578,6 +2570,62 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y2yzsmv0EeeuTqO16nt42g" x="129" y="-406"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zQhOkGv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zQhOkWv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zQh1oGv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zQhOkmv2EeeuTqO16nt42g" x="650" y="-96"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zRmMoGv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zRmMoWv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zRmMo2v2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zRmMomv2EeeuTqO16nt42g" x="483" y="-429"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zR7j0Gv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zR7j0Wv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zR8K4Gv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7tR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zR7j0mv2EeeuTqO16nt42g" x="483" y="-429"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zSoHYGv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zSoHYWv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zSoHY2v2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxi9R3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zSoHYmv2EeeuTqO16nt42g" x="374" y="-99"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zTJEwGv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zTJEwWv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTJEw2v2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zTJEwmv2EeeuTqO16nt42g" x="129" y="-98"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zUBOgGv2EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zUBOgWv2EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUBOg2v2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUBOgmv2EeeuTqO16nt42g" x="129" y="-406"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RNexkGv3EeeuTqO16nt42g" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RNexkWv3EeeuTqO16nt42g" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RNfYoGv3EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_Pk4cEGv3EeeuTqO16nt42g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RNexkmv3EeeuTqO16nt42g" x="483" y="-429"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
@@ -4363,29 +4411,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QguBABNJEeeQQtMBY9ly8w" id="(0.7290969899665551,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QguBARNJEeeQQtMBY9ly8w" id="(0.07829181494661921,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UFYakBNJEeeQQtMBY9ly8w" type="4006" source="_sY0nGx3BEea2UIYIpgn3Zw" target="_UuBYQENeEeajnf5I7cki4A">
-      <children xmi:type="notation:DecorationNode" xmi:id="_UFYakxNJEeeQQtMBY9ly8w" type="6014">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_UFYalBNJEeeQQtMBY9ly8w" x="10" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_UFYalRNJEeeQQtMBY9ly8w" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_UFYalhNJEeeQQtMBY9ly8w" x="-9" y="-1"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_UFYakRNJEeeQQtMBY9ly8w"/>
-      <element xmi:type="uml:Abstraction" href="TapiOdu.uml#_UFST8BNJEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UFYakhNJEeeQQtMBY9ly8w" points="[0, 0, -18, 140]$[69, -121, 51, 19]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHSfEBNJEeeQQtMBY9ly8w" id="(0.29110512129380056,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UHSfERNJEeeQQtMBY9ly8w" id="(0.9466192170818505,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_XkC51xNJEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_UFYakBNJEeeQQtMBY9ly8w" target="_XkC50xNJEeeQQtMBY9ly8w">
-      <styles xmi:type="notation:FontStyle" xmi:id="_XkC52BNJEeeQQtMBY9ly8w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XkC53BNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_UFST8BNJEeeQQtMBY9ly8w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XkC52RNJEeeQQtMBY9ly8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XkC52hNJEeeQQtMBY9ly8w"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XkC52xNJEeeQQtMBY9ly8w"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YmwUCBNJEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_QeIAABNJEeeQQtMBY9ly8w" target="_YmwUBBNJEeeQQtMBY9ly8w">
       <styles xmi:type="notation:FontStyle" xmi:id="_YmwUCRNJEeeQQtMBY9ly8w"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_YmwUDRNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
@@ -5510,6 +5535,89 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y2yztmv0EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y2yzt2v0EeeuTqO16nt42g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y2yzuGv0EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zQh1oWv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_zQhOkGv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zQh1omv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zQicsGv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zQh1o2v2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zQh1pGv2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zQh1pWv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zRmMpGv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_sZDP5x3BEea2UIYIpgn3Zw" target="_zRmMoGv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zRmMpWv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zRmMqWv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zRmMpmv2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRmMp2v2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zRmMqGv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zR8K4Wv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_sZDP-B3BEea2UIYIpgn3Zw" target="_zR7j0Gv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zR8K4mv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zR8K5mv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7tR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zR8K42v2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zR8K5Gv2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zR8K5Wv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zSoHZGv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_sY0nTR3BEea2UIYIpgn3Zw" target="_zSoHYGv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zSoHZWv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zSoHaWv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxi9R3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zSoHZmv2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zSoHZ2v2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zSoHaGv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zTJExGv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_zTJEwGv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zTJExWv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zTJEyWv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zTJExmv2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTJEx2v2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zTJEyGv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zUBOhGv2EeeuTqO16nt42g" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA" target="_zUBOgGv2EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zUBOhWv2EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUB1kGv2EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUBOhmv2EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUBOh2v2EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUBOiGv2EeeuTqO16nt42g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Po3kMGv3EeeuTqO16nt42g" type="4006" source="_sY0nGx3BEea2UIYIpgn3Zw" target="_UuBYQENeEeajnf5I7cki4A">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Po6ngGv3EeeuTqO16nt42g" type="6014">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Po6ngWv3EeeuTqO16nt42g" x="6" y="-6"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Po7OkGv3EeeuTqO16nt42g" type="6015">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Po7OkWv3EeeuTqO16nt42g" x="-8" y="-1"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Po3kMWv3EeeuTqO16nt42g"/>
+      <element xmi:type="uml:Abstraction" href="TapiOdu.uml#_Pk4cEGv3EeeuTqO16nt42g"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Po3kMmv3EeeuTqO16nt42g" points="[-1, -7, 3, 109]$[11, -107, 15, 9]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PtiBwGv3EeeuTqO16nt42g" id="(0.1725067385444744,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PtiBwWv3EeeuTqO16nt42g" id="(0.7900355871886121,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RNfYoWv3EeeuTqO16nt42g" type="StereotypeCommentLink" source="_Po3kMGv3EeeuTqO16nt42g" target="_RNexkGv3EeeuTqO16nt42g">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RNfYomv3EeeuTqO16nt42g"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RNfYpmv3EeeuTqO16nt42g" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiOdu.uml#_Pk4cEGv3EeeuTqO16nt42g"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RNfYo2v3EeeuTqO16nt42g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RNfYpGv3EeeuTqO16nt42g"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RNfYpWv3EeeuTqO16nt42g"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9g30gEeNEeetffGEmR5xrg" type="PapyrusUMLClassDiagram" name="OduOamProtectionSpecs" measurementUnit="Pixel">

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -20,11 +20,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_cOYiRzIOEeaBg9FoTfINnA" name="_lpSpec" type="_Um-Q8EKhEea-2Meh9kw1kA" association="_cOYiQDIOEeaBg9FoTfINnA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_UFST8BNJEeeQQtMBY9ly8w" name="CepLpSpecAugmentsLp" client="_sYw7vx3BEea2UIYIpgn3Zw _sYxjIR3BEea2UIYIpgn3Zw" supplier="_sYw7vx3BEea2UIYIpgn3Zw">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_BFH1EBiAEeeaw_DVk4Yi2w" annotatedElement="_UFST8BNJEeeQQtMBY9ly8w">
-          <body>Augments the base LayerProtocol information in ConnectionEndPoint with ODU-specific information</body>
-        </ownedComment>
-      </packagedElement>
       <packagedElement xmi:type="uml:Abstraction" xmi:id="_QeB5YBNJEeeQQtMBY9ly8w" name="NepLpSpecAugmentsLp" client="_Um-Q8EKhEea-2Meh9kw1kA" supplier="_sYw7vx3BEea2UIYIpgn3Zw">
         <ownedComment xmi:type="uml:Comment" xmi:id="_EKfqkBiAEeeaw_DVk4Yi2w" annotatedElement="_QeB5YBNJEeeQQtMBY9ly8w">
           <body>Augments the base LayerProtocol information in NodeEdgePoint with ODU-specific information</body>
@@ -35,6 +30,9 @@
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dvGW4UeLEeetffGEmR5xrg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_dvHlAUeLEeetffGEmR5xrg" name="_lpSpec" type="_sYxjIR3BEea2UIYIpgn3Zw" association="_dvFv0EeLEeetffGEmR5xrg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_Pk4cEGv3EeeuTqO16nt42g" name="CepLpSpecAugmentsLp" client="_sYxjIR3BEea2UIYIpgn3Zw">
+        <supplier xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams">
@@ -156,7 +154,7 @@ The upper bound of the integer allowed in this set is a function of the HO-ODU s
 Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).</body>
           </ownedComment>
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Pk5mALN_EeKWUbaPy23M3g" value="1"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Pk5mALN_EeKWUbaPy23M3g"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Pk60ILN_EeKWUbaPy23M3g" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Fw3b4ITaEea405q5sHuNGg" name="tributaryPortNumber" isReadOnly="true">
@@ -277,7 +275,7 @@ Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). No
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dsdDIOw_EeCjNNLZCc6mew" name="BOTH"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eoqN8BmdEeed09aaMoozsQ" name="OFF"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2ChJIITYEea405q5sHuNGg" name="Odu23SlotSize" isLeaf="true">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2ChJIITYEea405q5sHuNGg" name="OduSlotSize" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__8dCsITYEea405q5sHuNGg" name="1G25"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Bk5AIITZEea405q5sHuNGg" name="2G5"/>
       </packagedElement>
@@ -353,9 +351,6 @@ Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). No
   <OpenModel_Profile:Preliminary xmi:id="_5upIIEUHEead1bezhJG4aw" base_Element="_CJrDMDIOEeaBg9FoTfINnA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_UoKjwEKhEea-2Meh9kw1kA" base_Class="_Um-Q8EKhEea-2Meh9kw1kA"/>
   <OpenModel_Profile:Preliminary xmi:id="_8c4QAEUHEead1bezhJG4aw" base_Element="_Um-Q8EKhEea-2Meh9kw1kA"/>
-  <OpenModel_Profile:Specify xmi:id="_Xj8zMBNJEeeQQtMBY9ly8w" base_Abstraction="_UFST8BNJEeeQQtMBY9ly8w">
-    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connection/TapiConnectivity:Connection:_connectionEndPoint/TapiConnectivity:ConnectionEndPoint:_layerProtocol</target>
-  </OpenModel_Profile:Specify>
   <OpenModel_Profile:Specify xmi:id="_YmwUABNJEeeQQtMBY9ly8w" base_Abstraction="_QeB5YBNJEeeQQtMBY9ly8w">
     <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiTopology:NodeEdgePoint:_layerProtocol</target>
   </OpenModel_Profile:Specify>
@@ -447,4 +442,7 @@ Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). No
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_d_QWYWu0EeewIItFvY-NZg" base_Class="_8TUjoEeKEeetffGEmR5xrg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_d_QWYmu0EeewIItFvY-NZg" base_Class="_I7CxwEeOEeetffGEmR5xrg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_d_Q9cGu0EeewIItFvY-NZg" base_Class="_IHt9wEeWEeetffGEmR5xrg"/>
+  <OpenModel_Profile:Specify xmi:id="_RNFwAGv3EeeuTqO16nt42g" base_Abstraction="_Pk4cEGv3EeeuTqO16nt42g">
+    <target>/TapiCommon:Context:_context/TapiConnectivity:ConnectivityContext:_connection/TapiConnectivity:Connection:_connectionEndPoint/TapiConnectivity:ConnectionEndPoint:_layerProtocol</target>
+  </OpenModel_Profile:Specify>
 </xmi:XMI>

--- a/YANG/tapi-odu.tree
+++ b/YANG/tapi-odu.tree
@@ -1,41 +1,23 @@
 module: tapi-odu
-  augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
-    +--ro termination-spec
-    |  +--ro rate?               string
-    |  +--ro dm-source?          boolean
-    |  +--ro dm-value?           boolean
-    |  +--ro acti?               bit-string
-    |  +--ro deg-m?              uint64
-    |  +--ro deg-thr
-    |  |  +--ro deg-thr-value?            string
-    |  |  +--ro deg-thr-type?             string
-    |  |  +--ro percentage-granularity?   string
-    |  +--ro ex-dapi?            bit-string
-    |  +--ro ex-sapi?            bit-string
-    |  +--ro tim-act-disabled?   boolean
-    |  +--ro tim-det-mode?       tim-det-mo
-    |  +--ro txti?               bit-string
-    +--ro adapter-spec
-       +--ro adaptation-active?                   boolean
-       +--ro aps-enable?                          boolean
-       +--ro aps-level?                           uint64
-       +--ro k?                                   oduk-ctp-kbit-rate
-       +--ro odu-type-and-rate?                   uint64
-       +--ro position-seq*                        oduk-tcm-or-gcc-choice
-       +--ro tributary-slot-list*                 uint64
-       +--ro applicable-problems?                 oduk-ctp-problem-list
-       +--ro expected-m-si?                       string
-       +--ro accepted-m-si?                       string
-       +--ro accepted-payload-type?               string
-       +--ro transmitted-m-si?                    string
-       +--ro auto-payload-type?                   boolean
-       +--ro inserted-payload-type?               string
-       +--ro current-number-of-tributary-slots*   uint64
-       +--ro nominal-bit-rate-and-tolerance
-          +--ro tolerance?   uint64
-          +--ro frequency?   string
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
     +--ro odu-pool-property-spec
        +--ro client-capacity?        uint64
        +--ro max-client-instances?   uint64
        +--ro max-client-size?        uint64
+  augment /tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
+    +--ro odu-type?             odu-type
+    +--ro odu-rate?             uint64
+    +--ro odu-rate-tolerance?   uint64
+    +--ro ctp-pac
+    |  +--ro tributary-slot-list*     uint64
+    |  +--ro tributary-port-number?   uint64
+    |  +--ro accepted-m-si?           string
+    +--ro termination-pac
+    +--ro adapter-pac
+       +--ro opu-tributary-slot-size?   odu-slot-size
+       +--ro auto-payload-type?         boolean
+       +--ro configured-client-type?    string
+       +--ro configured-mapping-type?   mapping-type
+       +--ro accepted-payload-type
+          +--ro named-payload-type?   odu-named-payload-type
+          +--ro hex-payload-type?     uint64

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -21,171 +21,87 @@ module tapi-odu {
         description "TAPI SDK 2.0-alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol" {
-        uses connection-end-point-lp-spec;
-        description "Augments the base LayerProtocol information in ConnectionEndPoint with ODU-specific information";
-    }
     augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol" {
-        uses node-edge-point-lp-spec;
+        uses odu-node-edge-point-lp-spec;
         description "Augments the base LayerProtocol information in NodeEdgePoint with ODU-specific information";
+    }
+    augment "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol" {
+        uses odu-connection-end-point-lp-spec;
+        description "none";
     }
     /***********************
     * package object-classes
     **********************/ 
-        grouping adapter-and-connection-point-pac {
-            leaf adaptation-active {
-                type boolean;
+        grouping odu-client-adaptation-pac {
+            leaf opu-tributary-slot-size {
+                type odu-slot-size;
                 config false;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point.";
-            }
-            leaf aps-enable {
-                type boolean;
-                default "true";
-                description "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.";
-            }
-            leaf aps-level {
-                type uint64;
-                description "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.";
-            }
-            leaf k {
-                type oduk-ctp-kbit-rate;
-                config false;
-                description "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.
-                    When the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.
-                    When the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.
-                    ";
-            }
-            leaf odu-type-and-rate {
-                type uint64;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G";
-            }
-            leaf-list position-seq {
-                type oduk-tcm-or-gcc-choice;
-                config false;
-                description "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.
-                    The order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.
-                    Within the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.
-                    The syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.
-                    The order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).
-                    If a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.
-                    ";
-            }
-            leaf-list tributary-slot-list {
-                type uint64;
-                config false;
-                description "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).";
-            }
-            leaf applicable-problems {
-                type oduk-ctp-problem-list;
-                config false;
-                description "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList.";
-            }
-            leaf expected-m-si {
-                type string;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. ";
-            }
-            leaf accepted-m-si {
-                type string;
-                config false;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. ";
-            }
-            leaf accepted-payload-type {
-                type string;
-                config false;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. ";
-            }
-            leaf transmitted-m-si {
-                type string;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function.";
+                description "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP.";
             }
             leaf auto-payload-type {
                 type boolean;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. ";
+                config false;
+                description "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. ";
             }
-            leaf inserted-payload-type {
+            leaf configured-client-type {
                 type string;
                 config false;
-                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. ";
+                description "This attribute configures the type of the client CTP of the server ODU TTP.";
             }
-            leaf-list current-number-of-tributary-slots {
+            leaf configured-mapping-type {
+                type mapping-type;
+                description "This attributes indicates the configured mapping type.";
+            }
+            container accepted-payload-type {
+                config false;
+                uses odu-payload-type;
+                description "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. 
+                    This attribute is a 2-digit Hex code that indicates the new accepted payload type.
+                    Valid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.";
+            }
+            description "This Pac contains the attributes associated with the client adaptation function of the server layer TTP
+                It is present only if the CEP contains a TTP";
+        }
+        grouping odu-termination-pac {
+            description "This Pac contains the attributes associated with the termination function of the TTP
+                It is present only if the CEP contains a TTP";
+        }
+        grouping odu-connection-end-point-lp-spec {
+            leaf odu-type {
+                type odu-type;
+                config false;
+                description "This attribute specifies the type of the ODU termination point.";
+            }
+            leaf odu-rate {
                 type uint64;
                 config false;
-                description "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. 
-                    The upper bound of this attribute is dependent on the HO-ODUk server layer. 
-                    When the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):
-                    - After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)
-                    - After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)
-                    This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
+                description "This attribute indicates the rate of the ODU terminatino point. 
+                    This attribute is Set at create; i.e., once created it cannot be changed directly. 
+                    In case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). 
                     ";
             }
-            container nominal-bit-rate-and-tolerance {
-                uses oduk-h-nominal-bit-rate-and-tolerance;
-                description "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
-            }
-            description "none";
-        }
-        grouping termination-pac {
-            leaf rate {
-                type string;
-                config false;
-                description "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
-                    ";
-            }
-            leaf dm-source {
-                type boolean;
-                description "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue.";
-            }
-            leaf dm-value {
-                type boolean;
-                description "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1.";
-            }
-            leaf acti {
-                type bit-string;
-                config false;
-                description "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.";
-            }
-            leaf deg-m {
+            leaf odu-rate-tolerance {
                 type uint64;
-                description "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.";
+                config false;
+                description "This attribute indicates the rate tolerance of the ODU termination point. 
+                    Valid values are real value in the unit of ppm. 
+                    Standardized values are defined in Table 7-2/G.709.";
             }
-            container deg-thr {
-                uses deg-thr;
-                description "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.";
-            }
-            leaf ex-dapi {
-                type bit-string;
-                description "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
-            }
-            leaf ex-sapi {
-                type bit-string;
-                description "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
-            }
-            leaf tim-act-disabled {
-                type boolean;
-                description "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled.";
-            }
-            leaf tim-det-mode {
-                type tim-det-mo;
-                description "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI";
-            }
-            leaf txti {
-                type bit-string;
-                description "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.";
-            }
-            description "none";
-        }
-        grouping connection-end-point-lp-spec {
-            container termination-spec {
-                uses termination-pac;
+            container ctp-pac {
+                uses odu-ctp-pac;
                 description "none";
             }
-            container adapter-spec {
-                uses adapter-and-connection-point-pac;
+            container termination-pac {
+                uses odu-termination-pac;
+                description "none";
+            }
+            container adapter-pac {
+                uses odu-client-adaptation-pac;
                 description "none";
             }
             description "none";
         }
-        grouping pool-property-pac {
+        grouping odu-pool-property-pac {
             leaf client-capacity {
                 type uint64;
                 description "none";
@@ -202,10 +118,90 @@ module tapi-odu {
             }
             description "none";
         }
-        grouping node-edge-point-lp-spec {
+        grouping odu-node-edge-point-lp-spec {
             container odu-pool-property-spec {
-                uses pool-property-pac;
+                uses odu-pool-property-pac;
                 description "none";
+            }
+            description "none";
+        }
+        grouping odu-ctp-pac {
+            leaf-list tributary-slot-list {
+                type uint64;
+                config false;
+                description "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). 
+                    This attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. 
+                    It will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). 
+                    The upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). 
+                    Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).";
+            }
+            leaf tributary-port-number {
+                type uint64;
+                config false;
+                description "This attribute identifies the tributary port number that is associated with the ODU CTP.
+                    range of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.
+                    In case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.
+                    In case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.
+                    In case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.
+                    In case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.
+                    ";
+            }
+            leaf accepted-m-si {
+                type string;
+                config false;
+                description "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. ";
+            }
+            description "This Pac contains the attributes associated with the CTP
+                It is present only if the CEP contains a CTP";
+        }
+        grouping odu-mep-spec {
+            leaf acti {
+                type string;
+                config false;
+                description "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.";
+            }
+            leaf deg-m {
+                type uint64;
+                description "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.";
+            }
+            leaf deg-thr {
+                type uint64;
+                description "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.";
+            }
+            leaf ex-dapi {
+                type string;
+                description "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
+            }
+            leaf ex-sapi {
+                type string;
+                description "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.
+                    ";
+            }
+            leaf tim-act-disabled {
+                type boolean;
+                default "true";
+                description "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink.";
+            }
+            leaf tim-det-mode {
+                type tim-det-mo;
+                description "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI";
+            }
+            leaf txti {
+                type string;
+                description "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.
+                    ";
+            }
+            description "none";
+        }
+        grouping protection-spec {
+            leaf aps-enable {
+                type boolean;
+                default "true";
+                description "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.";
+            }
+            leaf aps-level {
+                type uint64;
+                description "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.";
             }
             description "none";
         }
@@ -213,65 +209,57 @@ module tapi-odu {
     /***********************
     * package type-definitions
     **********************/ 
-        typedef bit-string {
-            type string;
-            description "This primitive type defines a bit oriented string.
-                The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).
-                The semantic of each bit position will be defined in the Documentation field of the attribute.";
-        }
-        grouping deg-thr {
-            leaf deg-thr-value {
-                type string;
-                description "Percentage of detected errored blocks";
-            }
-            leaf deg-thr-type {
-                type string;
-                description "Number of errored blocks";
-            }
-            leaf percentage-granularity {
-                type string;
-                description "none";
-            }
-            description "Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. 
-                degThrValue when type is PERCENTAGE:
-                percentageGranularity is used to indicate the number of decimal points
-                So if percentageGranularity is 0 a value of 1 in degThrValue would indicate 1%, a value of 10 = 10%, a value of 100 = 100%
-                So if percentageGranularity is 3 (thousandths) a value of 1 in degThrValue would indicate 0.001%, a value of 1000 = 1%, a value of 1000000 = 100%
-                degThrValue when type is NUMBER_ERROR_BLOCKS:
-                Number of Errored Blocks is captured in an integer value.";
-        }
-        typedef oduk-ttp-kbit-rate {
+        typedef odu-type {
             type enumeration {
-                enum 1.25-g {
+                enum odu-0 {
                     description "none";
                 }
-                enum 2.5-g {
+                enum odu-1 {
                     description "none";
                 }
-                enum 10-g {
+                enum odu-2 {
                     description "none";
                 }
-                enum 10-g-2-e {
+                enum odu-2-e {
                     description "none";
                 }
-                enum 40-g {
+                enum odu-3 {
                     description "none";
                 }
-                enum 100-g {
+                enum odu-4 {
                     description "none";
                 }
-                enum flex-cbr {
-                    description "Represents ODUflex connection which carry a CBR client";
+                enum odu-flex {
+                    description "none";
                 }
-                enum flex-gfp {
-                    description "Represents ODUflex connection which carry packet traffic";
+                enum odu-cn {
+                    description "none";
                 }
             }
-            description "Provides an enumeration with the meaning of each k value.";
+            description "none";
         }
-        typedef oduk-tcm-or-gcc-choice {
-            type string;
-            description "A data type to constrain the values to particular types of ODUk CTPs.";
+        typedef mapping-type {
+            type enumeration {
+                enum amp {
+                    description "none";
+                }
+                enum bmp {
+                    description "none";
+                }
+                enum gfp-f {
+                    description "none";
+                }
+                enum gmp {
+                    description "none";
+                }
+                enum ttp-gfp-bmp {
+                    description "none";
+                }
+                enum null {
+                    description "none";
+                }
+            }
+            description "none";
         }
         typedef tim-det-mo {
             type enumeration {
@@ -284,153 +272,44 @@ module tapi-odu {
                 enum both {
                     description "none";
                 }
+                enum off {
+                    description "none";
+                }
             }
             description "List of modes for trace identifier mismatch detection.";
         }
-        typedef oduk-h-resizing-protocol-status {
+        typedef odu-slot-size {
             type enumeration {
-                enum lcr-initiated {
+                enum 1-g-25 {
                     description "none";
                 }
-                enum lcr-failed {
-                    description "none";
-                }
-                enum lcr-completed {
-                    description "none";
-                }
-                enum bwr-initiated {
-                    description "none";
-                }
-                enum bwr-completed {
-                    description "none";
-                }
-            }
-            description "The valid status' of the resizing protocol.";
-        }
-        typedef oduk-ctp-problem-list {
-            type enumeration {
-                enum plm {
-                    description "Payload Mismatch";
-                }
-                enum msim {
-                    description "MultiplexStructureIdentifier Mismatch, per time slot";
-                }
-                enum lof-lom {
-                    description "Loss of Frame, Loss of Multiframe, per time slot";
-                }
-                enum loomfi {
-                    description "Loss of OPU Multiframe Indicator";
-                }
-            }
-            description "The valid list of problems for the entity.";
-        }
-        typedef oduk-ctp-kbit-rate {
-            type enumeration {
-                enum 1.25-g {
-                    description "none";
-                }
-                enum 2.5-g {
-                    description "none";
-                }
-                enum 10-g {
-                    description "none";
-                }
-                enum 10-g-2-e {
-                    description "2e represents an approximate bit rate of 10 Gbit/s as a logical wrapper 10GBASE-R";
-                }
-                enum 40-g {
-                    description "none";
-                }
-                enum 100-g {
-                    description "none";
-                }
-                enum flex-cbr {
-                    description "Represents ODUflex connection which carry a CBR client";
-                }
-                enum flex-gfp {
-                    description "Represents ODUflex connection which carry packet traffic";
-                }
-            }
-            description "Provides an enumeration with the meaning of each k value.";
-        }
-        grouping oduk-h-nominal-bit-rate-and-tolerance {
-            leaf tolerance {
-                type uint64;
-                description "tolerance in ppm";
-            }
-            leaf frequency {
-                type string;
-                description "frequency in kilohertz";
-            }
-            description "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
-        }
-        typedef tcm-mode {
-            type enumeration {
-                enum operational {
-                    description "none";
-                }
-                enum transparent {
-                    description "none";
-                }
-                enum monitor {
-                    description "none";
-                }
-            }
-            description "List of value modes for the sink side of the tandem connection monitoring function.";
-        }
-        typedef oduk-t-tcm-extension {
-            type enumeration {
-                enum normal {
-                    description "none";
-                }
-                enum pass-through {
-                    description "none";
-                }
-                enum erase {
+                enum 2-g-5 {
                     description "none";
                 }
             }
             description "none";
         }
-        typedef oduk-t-administration-state {
-            type enumeration {
-                enum locked {
-                    description "none";
-                }
-                enum normal {
-                    description "none";
-                }
+        grouping odu-payload-type {
+            leaf named-payload-type {
+                type odu-named-payload-type;
+                description "none";
             }
-            description "The list of valid adminstration states.";
+            leaf hex-payload-type {
+                type uint64;
+                description "none";
+            }
+            description "none";
         }
-        typedef oduk-tcm-status {
+        typedef odu-named-payload-type {
             type enumeration {
-                enum no-source-tc {
-                    description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
+                enum unknown {
+                    description "none";
                 }
-                enum in-use-without-iae {
-                    description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
-                }
-                enum in-use-with-iae {
-                    description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
-                }
-                enum reserved-1 {
-                    description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
-                }
-                enum reserved-2 {
-                    description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
-                }
-                enum lck {
-                    description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODUk-LCK";
-                }
-                enum oci {
-                    description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODUk-OCI";
-                }
-                enum ais {
-                    description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODUk-AIS";
+                enum uninterpretable {
+                    description "none";
                 }
             }
-            description "See Table 15-5/G.709/Y.1331 ";
+            description "none";
         }
 
 }


### PR DESCRIPTION
To enable proper yang generation, made the following (temp) updates to the model:
- Renamed ODU_2_3_SlotSize enum to OduSlotSize
- Prefixed Odu to some class names
- Fixed undefined and unsupported types for attributes:
-- OduClientAdaptationPac::configuredClientType to String
-- OduMepSpec::acti to String
-- OduMepSpec::txti to String
-- OduMepSpec::exSapi to String
-- OduMepSpec::exDapi to String
-- OduMepSpec::degM to Integer
-- OduMepSpec::degThr to Integer
-- OduConnectionEndPointLpSpec::oduRate from Real to Integer
-- OduConnectionEndPointLpSpec::oduRateTolerance from Real to Integer

