### PR TITLE
FIX: duplicated local-id in layer-protocol & switch

### DIFF
--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -9677,7 +9677,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/"
+                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{layer-protocol_local-id}/"
                             },
                             "type": "array"
                         }
@@ -9688,7 +9688,7 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{layer-protocol_local-id}/": {
             "post": {
                 "summary": "Create layer-protocol by ID",
                 "description": "Create operation of resource: layer-protocol",
@@ -9716,7 +9716,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -9767,7 +9767,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -9812,7 +9812,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -9863,7 +9863,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -9879,7 +9879,7 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{layer-protocol_local-id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -9907,7 +9907,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -9919,7 +9919,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{layer-protocol_local-id}/name/{value-name}/"
                             },
                             "type": "array"
                         }
@@ -9930,7 +9930,7 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/": {
+        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{layer-protocol_local-id}/name/{value-name}/": {
             "post": {
                 "summary": "Create name by ID",
                 "description": "Create operation of resource: name",
@@ -9958,7 +9958,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -10016,7 +10016,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -10068,7 +10068,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -10126,7 +10126,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "layer-protocol_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -13092,7 +13092,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/switch/{local-id}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/switch/{switch_local-id}/"
                             },
                             "type": "array"
                         }
@@ -13103,7 +13103,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{local-id}/": {
+        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{switch_local-id}/": {
             "get": {
                 "summary": "Retrieve switch by ID",
                 "description": "Retrieve operation of resource: switch",
@@ -13131,7 +13131,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "switch_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -13150,7 +13150,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{local-id}/name/": {
+        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{switch_local-id}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
@@ -13178,7 +13178,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "switch_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"
@@ -13190,7 +13190,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/switch/{local-id}/name/{value-name}/"
+                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/switch/{switch_local-id}/name/{value-name}/"
                             },
                             "type": "array"
                         }
@@ -13201,7 +13201,7 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{local-id}/name/{value-name}/": {
+        "/config/context/connection/{uuid}/switch-control/{local-id}/switch/{switch_local-id}/name/{value-name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
@@ -13229,7 +13229,7 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
+                        "name": "switch_local-id",
                         "description": "ID of local-id",
                         "required": true,
                         "type": "string"


### PR DESCRIPTION
The swagger does not work because file has duplicated local-ids in layer-protocol and switch fields.