### PR TITLE
 Changes due to folding of LayerProtocol attributes into NEP & CEP classes

### DIFF
--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -1952,45 +1517,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -2074,13 +1600,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -2103,6 +1628,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -2131,230 +1696,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2394,6 +1735,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2612,258 +2000,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2910,6 +2046,60 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/operational-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -12190,511 +11380,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/end-point/{local-id}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -17229,12 +15914,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -17260,6 +15941,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "connection-port-direction": {
                             "type": "string",
@@ -17422,12 +16106,8 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
                             }
                         },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -17819,45 +16499,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -17941,13 +16582,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -17970,6 +16610,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },
@@ -18232,12 +16900,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -18256,6 +16920,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -11,11 +11,11 @@
         "http"
     ],
     "paths": {
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/": {
             "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
+                "summary": "Retrieve owned-node-edge-point",
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point",
                 "produces": [
                     "application/json"
                 ],
@@ -27,6 +27,13 @@
                         "in": "path",
                         "name": "uuid",
                         "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -37,7 +44,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/"
                             },
                             "type": "array"
                         }
@@ -48,11 +55,11 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/": {
             "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
+                "summary": "Retrieve owned-node-edge-point by ID",
+                "description": "Retrieve operation of resource: owned-node-edge-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_owned-node-edge-point_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -69,8 +76,15 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -79,7 +93,7 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/layer-protocol_schema"
+                            "$ref": "#/definitions/owned-node-edge-point_schema"
                         }
                     },
                     "400": {
@@ -88,11 +102,105 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
+            "get": {
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name",
                 "produces": [
                     "application/json"
                 ],
@@ -109,8 +217,15 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -121,7 +236,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/"
                             },
                             "type": "array"
                         }
@@ -132,11 +247,11 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/{value-name}/": {
             "get": {
                 "summary": "Retrieve name by ID",
                 "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -153,8 +268,15 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -179,413 +301,11 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/termination-spec/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/": {
             "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_termination-spec_termination-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/ety-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/termination-spec/priority-regenerate/": {
-            "get": {
-                "summary": "Retrieve priority-regenerate",
-                "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_termination-spec_priority-regenerate_priority-regenerate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
-                            "$ref": "#/definitions/priority-mapping"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connection-point-and-adapter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/filter-config/": {
-            "get": {
-                "summary": "Retrieve filter-config",
-                "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_filter-config_filter-config",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                            "$ref": "#/definitions/control-frame-filter"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/": {
-            "get": {
-                "summary": "Retrieve traffic-shaping",
-                "description": "Retrieve operation of resource: traffic-shaping",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-shaping_traffic-shaping",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-shaping_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/queue-config-list/": {
-            "get": {
-                "summary": "Retrieve queue-config-list",
-                "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-shaping_queue-config-list_queue-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/queue-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/": {
-            "get": {
-                "summary": "Retrieve traffic-conditioning",
-                "description": "Retrieve operation of resource: traffic-conditioning",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-conditioning_traffic-conditioning",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-conditioning_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/cond-config-list/": {
-            "get": {
-                "summary": "Retrieve cond-config-list",
-                "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_adapter-spec_traffic-conditioning_cond-config-list_cond-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
+                "summary": "Retrieve connection-end-point",
+                "description": "Retrieve operation of resource: connection-end-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point",
                 "produces": [
                     "application/json"
                 ],
@@ -621,7 +341,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/"
                             },
                             "type": "array"
                         }
@@ -632,11 +352,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/": {
+            "post": {
+                "summary": "Create connection-end-point by ID",
+                "description": "Create operation of resource: connection-end-point",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -667,8 +387,66 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "connection-end-point",
+                        "schema": {
+                            "$ref": "#/definitions/connection-end-point_schema"
+                        },
+                        "description": "connection-end-pointbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve connection-end-point by ID",
+                "description": "Retrieve operation of resource: connection-end-point",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -677,7 +455,168 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/layer-protocol_schema"
+                            "$ref": "#/definitions/connection-end-point_schema"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update connection-end-point by ID",
+                "description": "Update operation of resource: connection-end-point",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "connection-end-point",
+                        "schema": {
+                            "$ref": "#/definitions/connection-end-point_schema"
+                        },
+                        "description": "connection-end-pointbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete connection-end-point by ID",
+                "description": "Delete operation of resource: connection-end-point",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
+            "get": {
+                "summary": "Retrieve state",
+                "description": "Retrieve operation of resource: state",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/operational-state-pac"
                         }
                     },
                     "400": {
@@ -686,11 +625,230 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
+            "post": {
+                "summary": "Create termination by ID",
+                "description": "Create operation of resource: termination",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update termination by ID",
+                "description": "Update operation of resource: termination",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete termination by ID",
+                "description": "Delete operation of resource: termination",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
                 "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_name_name",
                 "produces": [
                     "application/json"
                 ],
@@ -721,8 +879,8 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -733,7 +891,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/{value-name}/"
                             },
                             "type": "array"
                         }
@@ -744,11 +902,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/{value-name}/": {
+            "post": {
+                "summary": "Create name by ID",
+                "description": "Create operation of resource: name",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -779,8 +937,73 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "value-name",
+                        "description": "ID of value-name",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "namebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve name by ID",
+                "description": "Retrieve operation of resource: name",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_name_name_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -803,613 +1026,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/termination-spec/": {
-            "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_termination-spec_termination-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/ety-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/termination-spec/priority-regenerate/": {
-            "get": {
-                "summary": "Retrieve priority-regenerate",
-                "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_termination-spec_priority-regenerate_priority-regenerate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
-                            "$ref": "#/definitions/priority-mapping"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connection-point-and-adapter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/filter-config/": {
-            "get": {
-                "summary": "Retrieve filter-config",
-                "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_filter-config_filter-config",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                            "$ref": "#/definitions/control-frame-filter"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/": {
-            "get": {
-                "summary": "Retrieve traffic-shaping",
-                "description": "Retrieve operation of resource: traffic-shaping",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-shaping_traffic-shaping",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-shaping_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/queue-config-list/": {
-            "get": {
-                "summary": "Retrieve queue-config-list",
-                "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-shaping_queue-config-list_queue-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/queue-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/": {
-            "get": {
-                "summary": "Retrieve traffic-conditioning",
-                "description": "Retrieve operation of resource: traffic-conditioning",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-conditioning_traffic-conditioning",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-conditioning_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/cond-config-list/": {
-            "get": {
-                "summary": "Retrieve cond-config-list",
-                "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_adapter-spec_traffic-conditioning_cond-config-list_cond-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol_by_id",
+            },
+            "put": {
+                "summary": "Update name by ID",
+                "description": "Update operation of resource: name",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1447,30 +1068,34 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "value-name",
+                        "description": "ID of value-name",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "name",
+                        "schema": {
+                            "$ref": "#/definitions/name-and-value"
+                        },
+                        "description": "namebody object",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol_schema"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name",
+            },
+            "delete": {
+                "summary": "Delete name by ID",
+                "description": "Delete operation of resource: name",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_name_name_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1503,78 +1128,6 @@
                         "in": "path",
                         "name": "connection-end-point_uuid",
                         "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
                         "required": true,
                         "type": "string"
                     },
@@ -1588,10 +1141,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1599,11 +1149,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/termination-spec/": {
-            "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_termination-spec_termination-spec",
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-term/": {
+            "post": {
+                "summary": "Create eth-term by ID",
+                "description": "Create operation of resource: eth-term",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1640,9 +1190,60 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "eth-term",
+                        "schema": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        },
+                        "description": "eth-termbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve eth-term",
+                "description": "Retrieve operation of resource: eth-term",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1651,20 +1252,18 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/ety-termination-pac"
+                            "$ref": "#/definitions/eth-termination-pac"
                         }
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/termination-spec/priority-regenerate/": {
-            "get": {
-                "summary": "Retrieve priority-regenerate",
-                "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_termination-spec_priority-regenerate_priority-regenerate",
+            },
+            "put": {
+                "summary": "Update eth-term by ID",
+                "description": "Update operation of resource: eth-term",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1701,9 +1300,170 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "eth-term",
+                        "schema": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        },
+                        "description": "eth-termbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete eth-term by ID",
+                "description": "Delete operation of resource: eth-term",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-term/priority-regenerate/": {
+            "post": {
+                "summary": "Create priority-regenerate by ID",
+                "description": "Create operation of resource: priority-regenerate",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "priority-regenerate",
+                        "schema": {
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
+                            "$ref": "#/definitions/priority-mapping"
+                        },
+                        "description": "priority-regeneratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve priority-regenerate",
+                "description": "Retrieve operation of resource: priority-regenerate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1720,13 +1480,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_adapter-spec",
+            },
+            "put": {
+                "summary": "Update priority-regenerate by ID",
+                "description": "Update operation of resource: priority-regenerate",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1763,9 +1521,170 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "priority-regenerate",
+                        "schema": {
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
+                            "$ref": "#/definitions/priority-mapping"
+                        },
+                        "description": "priority-regeneratebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete priority-regenerate by ID",
+                "description": "Delete operation of resource: priority-regenerate",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/": {
+            "post": {
+                "summary": "Create eth-ctp by ID",
+                "description": "Create operation of resource: eth-ctp",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "eth-ctp",
+                        "schema": {
+                            "$ref": "#/definitions/eth-ctp-pac"
+                        },
+                        "description": "eth-ctpbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve eth-ctp",
+                "description": "Retrieve operation of resource: eth-ctp",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1774,20 +1693,18 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/connection-point-and-adapter-pac"
+                            "$ref": "#/definitions/eth-ctp-pac"
                         }
                     },
                     "400": {
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/filter-config/": {
-            "get": {
-                "summary": "Retrieve filter-config",
-                "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_filter-config_filter-config",
+            },
+            "put": {
+                "summary": "Update eth-ctp by ID",
+                "description": "Update operation of resource: eth-ctp",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1824,9 +1741,170 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "eth-ctp",
+                        "schema": {
+                            "$ref": "#/definitions/eth-ctp-pac"
+                        },
+                        "description": "eth-ctpbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete eth-ctp by ID",
+                "description": "Delete operation of resource: eth-ctp",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/filter-config/": {
+            "post": {
+                "summary": "Create filter-config by ID",
+                "description": "Create operation of resource: filter-config",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "filter-config",
+                        "schema": {
+                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
+                            "$ref": "#/definitions/control-frame-filter"
+                        },
+                        "description": "filter-configbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve filter-config",
+                "description": "Retrieve operation of resource: filter-config",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1843,13 +1921,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/": {
-            "get": {
-                "summary": "Retrieve traffic-shaping",
-                "description": "Retrieve operation of resource: traffic-shaping",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-shaping_traffic-shaping",
+            },
+            "put": {
+                "summary": "Update filter-config by ID",
+                "description": "Update operation of resource: filter-config",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1886,9 +1962,170 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "filter-config",
+                        "schema": {
+                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
+                            "$ref": "#/definitions/control-frame-filter"
+                        },
+                        "description": "filter-configbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete filter-config by ID",
+                "description": "Delete operation of resource: filter-config",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/": {
+            "post": {
+                "summary": "Create traffic-shaping by ID",
+                "description": "Create operation of resource: traffic-shaping",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "traffic-shaping",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-shaping-pac"
+                        },
+                        "description": "traffic-shapingbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve traffic-shaping",
+                "description": "Retrieve operation of resource: traffic-shaping",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1904,13 +2141,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-shaping_prio-config-list_prio-config-list",
+            },
+            "put": {
+                "summary": "Update traffic-shaping by ID",
+                "description": "Update operation of resource: traffic-shaping",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1947,9 +2182,111 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "traffic-shaping",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-shaping-pac"
+                        },
+                        "description": "traffic-shapingbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete traffic-shaping by ID",
+                "description": "Delete operation of resource: traffic-shaping",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/prio-config-list/": {
+            "get": {
+                "summary": "Retrieve prio-config-list",
+                "description": "Retrieve operation of resource: prio-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_prio-config-list_prio-config-list",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -1967,11 +2304,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/queue-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/queue-config-list/": {
             "get": {
                 "summary": "Retrieve queue-config-list",
                 "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-shaping_queue-config-list_queue-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_queue-config-list_queue-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -2004,13 +2341,6 @@
                         "in": "path",
                         "name": "connection-end-point_uuid",
                         "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
                         "required": true,
                         "type": "string"
                     }
@@ -2028,11 +2358,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/": {
-            "get": {
-                "summary": "Retrieve traffic-conditioning",
-                "description": "Retrieve operation of resource: traffic-conditioning",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-conditioning_traffic-conditioning",
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/": {
+            "post": {
+                "summary": "Create traffic-conditioning by ID",
+                "description": "Create operation of resource: traffic-conditioning",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2069,9 +2399,60 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "traffic-conditioning",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-conditioning-pac"
+                        },
+                        "description": "traffic-conditioningbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve traffic-conditioning",
+                "description": "Retrieve operation of resource: traffic-conditioning",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -2087,13 +2468,11 @@
                         "description": "Internal Error"
                     }
                 }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-conditioning_prio-config-list_prio-config-list",
+            },
+            "put": {
+                "summary": "Update traffic-conditioning by ID",
+                "description": "Update operation of resource: traffic-conditioning",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2130,9 +2509,111 @@
                         "type": "string"
                     },
                     {
+                        "in": "body",
+                        "name": "traffic-conditioning",
+                        "schema": {
+                            "$ref": "#/definitions/traffic-conditioning-pac"
+                        },
+                        "description": "traffic-conditioningbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete traffic-conditioning by ID",
+                "description": "Delete operation of resource: traffic-conditioning",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/prio-config-list/": {
+            "get": {
+                "summary": "Retrieve prio-config-list",
+                "description": "Retrieve operation of resource: prio-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_prio-config-list_prio-config-list",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -2150,11 +2631,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/cond-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/cond-config-list/": {
             "get": {
                 "summary": "Retrieve cond-config-list",
                 "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_adapter-spec_traffic-conditioning_cond-config-list_cond-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_cond-config-list_cond-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -2189,13 +2670,6 @@
                         "description": "ID of connection-end-point_uuid",
                         "required": true,
                         "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -2211,11 +2685,11 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/ety-term/": {
             "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol",
+                "summary": "Retrieve ety-term",
+                "description": "Retrieve operation of resource: ety-term",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_ety-term_ety-term",
                 "produces": [
                     "application/json"
                 ],
@@ -2232,211 +2706,15 @@
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
                     },
                     {
                         "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol_schema"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/termination-spec/": {
-            "get": {
-                "summary": "Retrieve termination-spec",
-                "description": "Retrieve operation of resource: termination-spec",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_termination-spec_termination-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -2446,431 +2724,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/ety-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/termination-spec/priority-regenerate/": {
-            "get": {
-                "summary": "Retrieve priority-regenerate",
-                "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_termination-spec_priority-regenerate_priority-regenerate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
-                            "$ref": "#/definitions/priority-mapping"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/": {
-            "get": {
-                "summary": "Retrieve adapter-spec",
-                "description": "Retrieve operation of resource: adapter-spec",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_adapter-spec",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connection-point-and-adapter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/filter-config/": {
-            "get": {
-                "summary": "Retrieve filter-config",
-                "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_filter-config_filter-config",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                            "$ref": "#/definitions/control-frame-filter"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/": {
-            "get": {
-                "summary": "Retrieve traffic-shaping",
-                "description": "Retrieve operation of resource: traffic-shaping",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-shaping_traffic-shaping",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-shaping_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-shaping/queue-config-list/": {
-            "get": {
-                "summary": "Retrieve queue-config-list",
-                "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-shaping_queue-config-list_queue-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/queue-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/": {
-            "get": {
-                "summary": "Retrieve traffic-conditioning",
-                "description": "Retrieve operation of resource: traffic-conditioning",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-conditioning_traffic-conditioning",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-conditioning_prio-config-list_prio-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/priority-configuration"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/adapter-spec/traffic-conditioning/cond-config-list/": {
-            "get": {
-                "summary": "Retrieve cond-config-list",
-                "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_adapter-spec_traffic-conditioning_cond-config-list_cond-config-list",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-configuration"
                         }
                     },
                     "400": {
@@ -2881,7 +2734,7 @@
         }
     },
     "definitions": {
-        "connection-point-and-adapter-pac": {
+        "eth-ctp-pac": {
             "properties": {
                 "auxiliary-function-position-sequence": {
                     "type": "array",
@@ -2976,13 +2829,13 @@
                 }
             }
         },
-        "connection-end-point-lp-spec": {
+        "eth-connection-end-point-spec": {
             "properties": {
-                "termination-spec": {
+                "eth-term": {
                     "$ref": "#/definitions/eth-termination-pac"
                 },
-                "adapter-spec": {
-                    "$ref": "#/definitions/connection-point-and-adapter-pac"
+                "eth-ctp": {
+                    "$ref": "#/definitions/eth-ctp-pac"
                 }
             }
         },
@@ -3140,9 +2993,9 @@
                 }
             }
         },
-        "node-edge-point-lp-spec": {
+        "eth-node-edge-point-spec": {
             "properties": {
-                "termination-spec": {
+                "ety-term": {
                     "$ref": "#/definitions/ety-termination-pac"
                 }
             }
@@ -3526,45 +3379,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -3648,13 +3462,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -3677,6 +3490,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },
@@ -3762,40 +3603,6 @@
                 }
             }
         },
-        "get-service-interface-point-detailsRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-service-interface-point-detailsRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "$ref": "#/definitions/service-interface-point"
-                }
-            }
-        },
-        "get-service-interface-point-listRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/service-interface-point"
-                    }
-                }
-            }
-        },
-        "update-service-interface-pointRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
         "owned-node-edge-point_schema": {
             "allOf": [
                 {
@@ -3821,6 +3628,9 @@
                                 "$ref": "#/definitions/connection-end-point"
                             },
                             "x-key": "uuid"
+                        },
+                        "ety-term": {
+                            "$ref": "#/definitions/ety-termination-pac"
                         }
                     }
                 }
@@ -4003,12 +3813,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -4027,6 +3833,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -4388,15 +4197,132 @@
                 }
             }
         },
-        "layer-protocol_schema": {
+        "get-topology-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-topology-detailsRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "$ref": "#/definitions/topology"
+                }
+            }
+        },
+        "get-node-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-detailsRPC_output_schema": {
+            "properties": {
+                "node": {
+                    "$ref": "#/definitions/node"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                },
+                "ep-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_output_schema": {
+            "properties": {
+                "node-edge-point": {
+                    "$ref": "#/definitions/node-edge-point"
+                }
+            }
+        },
+        "get-link-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "link-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-link-detailsRPC_output_schema": {
+            "properties": {
+                "link": {
+                    "$ref": "#/definitions/link"
+                }
+            }
+        },
+        "get-topology-listRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    }
+                }
+            }
+        },
+        "get-service-interface-point-detailsRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-service-interface-point-detailsRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "$ref": "#/definitions/service-interface-point"
+                }
+            }
+        },
+        "get-service-interface-point-listRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service-interface-point"
+                    }
+                }
+            }
+        },
+        "update-service-interface-pointRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "locked",
+                        "unlocked"
+                    ]
+                }
+            }
+        },
+        "connection-end-point_schema": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/layer-protocol"
+                    "$ref": "#/definitions/connection-end-point"
                 },
                 {
                     "properties": {
-                        "local-id": {
-                            "type": "string"
+                        "connection-end-point_uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
                         },
                         "name": {
                             "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
@@ -4406,8 +4332,11 @@
                             },
                             "x-key": "value-name"
                         },
-                        "termination-spec": {
-                            "$ref": "#/definitions/ety-termination-pac"
+                        "eth-term": {
+                            "$ref": "#/definitions/eth-termination-pac"
+                        },
+                        "eth-ctp": {
+                            "$ref": "#/definitions/eth-ctp-pac"
                         }
                     }
                 }
@@ -4487,12 +4416,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -4518,6 +4443,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "connection-port-direction": {
                             "type": "string",
@@ -4680,12 +4608,8 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
                             }
                         },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -5029,125 +4953,6 @@
                         "node",
                         "link"
                     ]
-                }
-            }
-        },
-        "get-connection-detailsRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                },
-                "connection-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-connection-detailsRPC_output_schema": {
-            "properties": {
-                "connection": {
-                    "$ref": "#/definitions/connection"
-                }
-            }
-        },
-        "get-connectivity-service-listRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    }
-                }
-            }
-        },
-        "get-connectivity-service-detailsRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-connectivity-service-detailsRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "create-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "end-point": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service-end-point"
-                    }
-                },
-                "conn-constraint": {
-                    "$ref": "#/definitions/connectivity-constraint"
-                },
-                "topo-constraint": {
-                    "$ref": "#/definitions/topology-constraint"
-                },
-                "resilience-constraint": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/resilience-constraint"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
-        "create-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "update-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                },
-                "end-point": {
-                    "$ref": "#/definitions/connectivity-service-end-point"
-                },
-                "conn-constraint": {
-                    "$ref": "#/definitions/connectivity-constraint"
-                },
-                "topo-constraint": {
-                    "$ref": "#/definitions/topology-constraint"
-                },
-                "resilience-constraint": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/resilience-constraint"
-                    }
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
-        "update-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
-                }
-            }
-        },
-        "delete-connectivity-serviceRPC_input_schema": {
-            "properties": {
-                "service-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "delete-connectivity-serviceRPC_output_schema": {
-            "properties": {
-                "service": {
-                    "$ref": "#/definitions/connectivity-service"
                 }
             }
         }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -4415,45 +3980,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -4537,13 +4063,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -4566,6 +4091,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -2131,230 +1696,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2394,6 +1735,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2777,258 +2165,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -3076,6 +2212,225 @@
                         "schema": {
                             "$ref": "#/definitions/operational-state-pac"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
+            "post": {
+                "summary": "Create termination by ID",
+                "description": "Create operation of resource: termination",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update termination by ID",
+                "description": "Update operation of resource: termination",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete termination by ID",
+                "description": "Delete operation of resource: termination",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -12541,511 +11896,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_connectivity-service_end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/end-point/{local-id}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -20594,45 +19444,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -20716,13 +19527,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -20745,6 +19555,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },
@@ -20904,12 +19742,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -20935,6 +19769,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "connection-port-direction": {
                             "type": "string",
@@ -21097,12 +19934,8 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
                             }
                         },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -21626,12 +20459,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -21650,6 +20479,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -102,230 +102,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -365,6 +141,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -748,258 +571,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -1047,6 +618,225 @@
                         "schema": {
                             "$ref": "#/definitions/operational-state-pac"
                         }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
+            "post": {
+                "summary": "Create termination by ID",
+                "description": "Create operation of resource: termination",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update termination by ID",
+                "description": "Update operation of resource: termination",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "termination",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
+                        },
+                        "description": "terminationbody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete termination by ID",
+                "description": "Delete operation of resource: termination",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
                     },
                     "400": {
                         "description": "Internal Error"
@@ -3179,45 +2969,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -3301,13 +3052,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -3330,6 +3080,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },
@@ -3639,12 +3417,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -3663,6 +3437,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -4263,12 +4040,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -4294,6 +4067,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "connection-port-direction": {
                             "type": "string",
@@ -4456,12 +4232,8 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
                             }
                         },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -116,258 +116,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -414,6 +162,60 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/operational-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "connection-end-point_uuid",
+                        "description": "ID of connection-end-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -1174,230 +976,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -1437,6 +1015,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2017,45 +1642,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -2139,13 +1725,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -2168,6 +1753,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },
@@ -2529,12 +2142,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -2553,6 +2162,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -3023,12 +2635,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -3054,6 +2662,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/operational-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "connection-port-direction": {
                             "type": "string",
@@ -3216,12 +2827,8 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
                             }
                         },
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -2131,230 +1696,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2394,6 +1735,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -11825,12 +11213,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -11849,6 +11233,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -12227,45 +11614,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -12349,13 +11697,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -12378,6 +11725,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -2131,230 +1696,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2394,6 +1735,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -8814,12 +8202,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -8838,6 +8222,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -9244,45 +8631,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -9366,13 +8714,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -9395,6 +8742,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -279,441 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/": {
-            "post": {
-                "summary": "Create layer-protocol by ID",
-                "description": "Create operation of resource: layer-protocol",
-                "operationId": "create_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update layer-protocol by ID",
-                "description": "Update operation of resource: layer-protocol",
-                "operationId": "update_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "layer-protocol",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        },
-                        "description": "layer-protocolbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete layer-protocol by ID",
-                "description": "Delete operation of resource: layer-protocol",
-                "operationId": "delete_context_service-interface-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_service-interface-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/state/": {
             "post": {
                 "summary": "Create state by ID",
@@ -2131,230 +1696,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/": {
-            "get": {
-                "summary": "Retrieve layer-protocol",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/": {
-            "get": {
-                "summary": "Retrieve layer-protocol by ID",
-                "description": "Retrieve operation of resource: layer-protocol",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_layer-protocol_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/layer-protocol/{local-id}/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_layer-protocol_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
             "get": {
                 "summary": "Retrieve state",
@@ -2394,6 +1735,53 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/admin-state-pac"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
+            "get": {
+                "summary": "Retrieve termination",
+                "description": "Retrieve operation of resource: termination",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "owned-node-edge-point_uuid",
+                        "description": "ID of owned-node-edge-point_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -11905,12 +11293,8 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                        "layer-protocol-name": {
+                            "type": "string"
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -11929,6 +11313,9 @@
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
+                        },
+                        "termination": {
+                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -12307,45 +11694,6 @@
                 }
             }
         },
-        "layer-protocol": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "description": "Indicate the specific layer-protocol described by the LayerProtocol entity."
-                        },
-                        "termination-direction": {
-                            "type": "string",
-                            "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
-                            ],
-                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
-                        },
-                        "termination-state": {
-                            "type": "string",
-                            "enum": [
-                                "lp-can-never-terminate",
-                                "lt-not-terminated",
-                                "terminated-server-to-client-flow",
-                                "terminated-client-to-server-flow",
-                                "terminated-bidirectional",
-                                "lt-permenantly-terminated",
-                                "termination-state-unknown"
-                            ],
-                            "description": "Indicates whether the layer is terminated and if so how."
-                        }
-                    }
-                }
-            ],
-            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. "
-        },
         "lifecycle-state-pac": {
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
@@ -12429,13 +11777,12 @@
                 },
                 {
                     "properties": {
-                        "layer-protocol": {
-                            "description": "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental",
+                        "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/layer-protocol"
-                            },
-                            "x-key": "local-id"
+                                "type": "string",
+                                "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
+                            }
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -12458,6 +11805,34 @@
                 "available-capacity": {
                     "description": "Capacity available to be assigned.",
                     "$ref": "#/definitions/capacity"
+                }
+            }
+        },
+        "termination-pac": {
+            "description": "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. \nIt can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. \nWhere the client \u2013 server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ",
+            "properties": {
+                "termination-direction": {
+                    "type": "string",
+                    "enum": [
+                        "bidirectional",
+                        "sink",
+                        "source",
+                        "undefined-or-unknown"
+                    ],
+                    "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                },
+                "termination-state": {
+                    "type": "string",
+                    "enum": [
+                        "lp-can-never-terminate",
+                        "lt-not-terminated",
+                        "terminated-server-to-client-flow",
+                        "terminated-client-to-server-flow",
+                        "terminated-bidirectional",
+                        "lt-permenantly-terminated",
+                        "termination-state-unknown"
+                    ],
+                    "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
         },

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -130,7 +130,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9tz_gzA_Eea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9tz_ljA_Eea4fKwSGMr6CA" x="753" y="27"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9tz_ljA_Eea4fKwSGMr6CA" x="533" y="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9tz_lzA_Eea4fKwSGMr6CA" type="2006">
       <children xmi:type="notation:DecorationNode" xmi:id="_9tz_mDA_Eea4fKwSGMr6CA" type="5023"/>
@@ -232,7 +232,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9tz_9TA_Eea4fKwSGMr6CA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiCommon.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9t0ACDA_Eea4fKwSGMr6CA" x="533" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9t0ACDA_Eea4fKwSGMr6CA" x="746" y="15"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9t0ACTA_Eea4fKwSGMr6CA" type="2006">
       <children xmi:type="notation:DecorationNode" xmi:id="_9t0ACjA_Eea4fKwSGMr6CA" type="5023"/>
@@ -895,25 +895,25 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8aKmYFqtEeexvMtO2oNM9g" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8aLNcFqtEeexvMtO2oNM9g" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_9Gm1oFqtEeexvMtO2oNM9g" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_aFAUM9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9Gm1oVqtEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9Gm1olqtEeexvMtO2oNM9g" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9Gm1o1qtEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9GncsFqtEeexvMtO2oNM9g" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_AFxHsEwDEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9GncsVqtEeexvMtO2oNM9g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_9GncslqtEeexvMtO2oNM9g" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_j5oL4Kg1EeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9Gncs1qtEeexvMtO2oNM9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j5oL4ag1EeeAVfY3jqnvAA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_9GnctFqtEeexvMtO2oNM9g" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_j5paAKg1EeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_9GnctVqtEeexvMtO2oNM9g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j5paAag1EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_k5EPoKg1EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_NMt2sKeTEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_k5EPoag1EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_k5E2sKg1EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_k5E2sag1EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_k5FdwKg1EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_AFxHsEwDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_k5Fdwag1EeeAVfY3jqnvAA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_OAvhFshqEeaVlemTikmRHw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_OAvhF8hqEeaVlemTikmRHw"/>
@@ -933,7 +933,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OAvhI8hqEeaVlemTikmRHw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OAvhEchqEeaVlemTikmRHw" x="52" y="200" width="264" height="123"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OAvhEchqEeaVlemTikmRHw" x="28" y="185" width="288" height="123"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_OA1ny8hqEeaVlemTikmRHw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_OA1nzMhqEeaVlemTikmRHw" showTitle="true"/>
@@ -1155,7 +1155,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYh7OVqtEeexvMtO2oNM9g"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiCommon.uml#_JSfMgHrqEeavcODnuX7FyA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYgtEVqtEeexvMtO2oNM9g" x="405" y="-10" width="212" height="111"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mYgtEVqtEeexvMtO2oNM9g" x="405" y="-17" width="212" height="111"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_mYv9oFqtEeexvMtO2oNM9g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_mYv9oVqtEeexvMtO2oNM9g" showTitle="true"/>
@@ -1365,6 +1365,84 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3xz2ko5zEeeyZasfnNSonw" x="214" y="-116"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_JUFqMKeREeeBGPv_1DT5og" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JUFqMaeREeeBGPv_1DT5og" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JUFqM6eREeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JUFqMqeREeeBGPv_1DT5og" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RaFHoKeWEeeBGPv_1DT5og" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RaFHoaeWEeeBGPv_1DT5og" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RaFHo6eWEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RaFHoqeWEeeBGPv_1DT5og" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CsqQsKg1EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CsqQsag1EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CsqQs6g1EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CsqQsqg1EeeAVfY3jqnvAA" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_36LJEKg1EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_36LJEag1EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_36LJE6g1EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_36LJEqg1EeeAVfY3jqnvAA" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xmhu0Kg3EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_xmhu0ag3EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xmhu06g3EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xmhu0qg3EeeAVfY3jqnvAA" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C3S0Kg3EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1C3S0ag3EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1C3S06g3EeeAVfY3jqnvAA" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C3S0qg3EeeAVfY3jqnvAA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_qsiiwKg4EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qsiiwag4EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qsiiw6g4EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsiiwqg4EeeAVfY3jqnvAA" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_kD-c0MZUEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_kD-c0cZUEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kD-c08ZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kD-c0sZUEeeAD9H5zOiMUQ" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_6UlegMZcEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_6UlegcZcEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6Uleg8ZcEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6UlegsZcEeeAD9H5zOiMUQ" x="214" y="-116"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_y3HDgMZgEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_y3HDgcZgEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y3HDg8ZgEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3HDgsZgEeeAD9H5zOiMUQ" x="214" y="-116"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_iE1Wsz3fEea-1_BGg-qcjQ">
@@ -1409,10 +1487,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_O3-EAMhqEeaVlemTikmRHw" type="4001" source="_jiNToD3fEea-1_BGg-qcjQ" target="_OAvhEMhqEeaVlemTikmRHw">
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EA8hqEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBMhqEeaVlemTikmRHw" x="-8" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBMhqEeaVlemTikmRHw" x="1" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EBchqEeaVlemTikmRHw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBshqEeaVlemTikmRHw" x="-19" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-EBshqEeaVlemTikmRHw" x="-11" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_O3-EB8hqEeaVlemTikmRHw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_O3-ECMhqEeaVlemTikmRHw" y="-20"/>
@@ -1429,8 +1507,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_O3-EAchqEeaVlemTikmRHw"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_O3-EAshqEeaVlemTikmRHw" points="[100, 23, -116, -28]$[213, 51, -3, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4oyYMhqEeaVlemTikmRHw" id="(0.43968268996439236,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4oyYchqEeaVlemTikmRHw" id="(0.39067478590367394,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4oyYMhqEeaVlemTikmRHw" id="(0.4638475098208674,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O4oyYchqEeaVlemTikmRHw" id="(0.46838559254339734,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_O4EKp8hqEeaVlemTikmRHw" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw">
       <styles xmi:type="notation:FontStyle" xmi:id="_O4EKqMhqEeaVlemTikmRHw"/>
@@ -1662,8 +1740,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_rOb6MVqtEeexvMtO2oNM9g"/>
       <element xmi:type="uml:InterfaceRealization" href="TapiCommon.uml#_rOMpoFqtEeexvMtO2oNM9g"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rOb6MlqtEeexvMtO2oNM9g" points="[19, 42, -37, -80]$[53, 117, -3, -5]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO7pcFqtEeexvMtO2oNM9g" id="(1.0,0.4273950145844537)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO7pcVqtEeexvMtO2oNM9g" id="(0.0,0.4051945520201247)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO7pcFqtEeexvMtO2oNM9g" id="(1.0,0.4192640846327467)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rO7pcVqtEeexvMtO2oNM9g" id="(0.0,0.3938579803721556)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_1cD05FrmEeexvMtO2oNM9g" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_1cD04FrmEeexvMtO2oNM9g">
       <styles xmi:type="notation:FontStyle" xmi:id="_1cD05VrmEeexvMtO2oNM9g"/>
@@ -1915,6 +1993,104 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3x0dpI5zEeeyZasfnNSonw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3x0dpY5zEeeyZasfnNSonw"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JUFqNKeREeeBGPv_1DT5og" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_JUFqMKeREeeBGPv_1DT5og">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JUFqNaeREeeBGPv_1DT5og"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JUFqOaeREeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUFqNqeREeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUFqN6eREeeBGPv_1DT5og"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUFqOKeREeeBGPv_1DT5og"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RaFusKeWEeeBGPv_1DT5og" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_RaFHoKeWEeeBGPv_1DT5og">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RaFusaeWEeeBGPv_1DT5og"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RaFutaeWEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RaFusqeWEeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RaFus6eWEeeBGPv_1DT5og"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RaFutKeWEeeBGPv_1DT5og"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CsqQtKg1EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_CsqQsKg1EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CsqQtag1EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Csq3wqg1EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CsqQtqg1EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Csq3wKg1EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Csq3wag1EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_36LwIKg1EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_36LJEKg1EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_36LwIag1EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_36LwJag1EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_36LwIqg1EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_36LwI6g1EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_36LwJKg1EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xmhu1Kg3EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_xmhu0Kg3EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_xmhu1ag3EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xmhu2ag3EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xmhu1qg3EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xmhu16g3EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xmhu2Kg3EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C3S1Kg3EeeAVfY3jqnvAA" type="StereotypeCommentLink" target="_1C3S0Kg3EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C3S1ag3EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1C3S2ag3EeeAVfY3jqnvAA" name="BASE_ELEMENT"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C3S1qg3EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C3S16g3EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C3S2Kg3EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qsiixKg4EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_qsiiwKg4EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qsiixag4EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qsiiyag4EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qsiixqg4EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qsiix6g4EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qsiiyKg4EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_kD-c1MZUEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_kD-c0MZUEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_kD-c1cZUEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kD-c2cZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kD-c1sZUEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kD-c18ZUEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kD-c2MZUEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6UlehMZcEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_6UlegMZcEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_6UlehcZcEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_6UleicZcEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6UlehsZcEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6Uleh8ZcEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6UleiMZcEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_y3HDhMZgEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_y3HDgMZgEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_y3HDhcZgEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y3HDicZgEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_y3HDhsZgEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3HDh8ZgEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3HDiMZgEeeAD9H5zOiMUQ"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="__w77UE0WEeaqn4OIuRCwEg" type="2008">
@@ -1923,25 +2099,25 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__w77VE0WEeaqn4OIuRCwEg" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__w77VU0WEeaqn4OIuRCwEg" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_RgJT4EwDEeewALXL7BvPYw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_aFAUM9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJT4UwDEeewALXL7BvPYw"/>
+        <children xmi:type="notation:Shape" xmi:id="_SUhGoKhGEeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_NMt2sKeTEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SUhGoahGEeeAVfY3jqnvAA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RgJ68EwDEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_SUhtsKhGEeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJ68UwDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SUhtsahGEeeAVfY3jqnvAA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RgJ68kwDEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_SUiUwKhGEeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_AFxHsEwDEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgJ680wDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SUiUwahGEeeAVfY3jqnvAA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RgKiAEwDEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_SUiUwqhGEeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgKiAUwDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SUiUw6hGEeeAVfY3jqnvAA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RgKiAkwDEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_SUiUxKhGEeeAVfY3jqnvAA" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RgKiA0wDEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_SUiUxahGEeeAVfY3jqnvAA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__w77Vk0WEeaqn4OIuRCwEg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__w77V00WEeaqn4OIuRCwEg"/>
@@ -1987,75 +2163,11 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aQiKPU0YEeaqn4OIuRCwEg" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_dEL9gE0YEeaqn4OIuRCwEg" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dEL9gk0YEeaqn4OIuRCwEg" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dEL9g00YEeaqn4OIuRCwEg" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dEL9hE0YEeaqn4OIuRCwEg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dEL9hU0YEeaqn4OIuRCwEg" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_7FIBkE0YEeaqn4OIuRCwEg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pE76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7FIBkU0YEeaqn4OIuRCwEg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_7FIBkk0YEeaqn4OIuRCwEg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pH76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7FIBk00YEeaqn4OIuRCwEg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_7FIBlE0YEeaqn4OIuRCwEg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pI76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7FIBlU0YEeaqn4OIuRCwEg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_KCWH0BMnEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KCWH0RMnEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_KCWH0hMnEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_KCWH0xMnEee0L_IMWjydgQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dEL9hk0YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dEL9h00YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dEL9iE0YEeaqn4OIuRCwEg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9iU0YEeaqn4OIuRCwEg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dEL9ik0YEeaqn4OIuRCwEg" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dEL9i00YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dEL9jE0YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dEL9jU0YEeaqn4OIuRCwEg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9jk0YEeaqn4OIuRCwEg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_dEL9j00YEeaqn4OIuRCwEg" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_dEL9kE0YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_dEL9kU0YEeaqn4OIuRCwEg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_dEL9kk0YEeaqn4OIuRCwEg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9k00YEeaqn4OIuRCwEg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEL9gU0YEeaqn4OIuRCwEg" x="484" y="241" height="124"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_dEVum00YEeaqn4OIuRCwEg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_dEVunE0YEeaqn4OIuRCwEg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dEVunk0YEeaqn4OIuRCwEg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dEVunU0YEeaqn4OIuRCwEg" x="200"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_lxE_s00ZEeaqn4OIuRCwEg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_lxE_tE0ZEeaqn4OIuRCwEg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lxE_tk0ZEeaqn4OIuRCwEg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Generalization" href="TapiCommon.uml#_D65isN8sEeWT9tG0gGLRFw"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_lxE_tk0ZEeaqn4OIuRCwEg" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lxE_tU0ZEeaqn4OIuRCwEg" x="799" y="146"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="__581chMeEee0L_IMWjydgQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__581cxMeEee0L_IMWjydgQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__581dRMeEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__581dBMeEee0L_IMWjydgQ" x="684" y="141"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__6JCfBMeEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__6JCfRMeEee0L_IMWjydgQ" showTitle="true"/>
@@ -2097,7 +2209,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lF6wUwCEeewALXL7BvPYw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lEFgUwCEeewALXL7BvPYw" x="26" y="388" height="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9lEFgUwCEeewALXL7BvPYw" x="34" y="388" height="91"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9lSvAEwCEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9lSvAUwCEeewALXL7BvPYw" showTitle="true"/>
@@ -2159,7 +2271,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lv95DmJFEeek3OrhDuslYQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lv9R8WJFEeek3OrhDuslYQ" x="483" y="121" height="99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lv9R8WJFEeek3OrhDuslYQ" x="466" y="175" height="99"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_lwIREGJFEeek3OrhDuslYQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_lwIREWJFEeek3OrhDuslYQ" showTitle="true"/>
@@ -2195,41 +2307,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aQiKQk0YEeaqn4OIuRCwEg"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aQiKQ00YEeaqn4OIuRCwEg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dEVun00YEeaqn4OIuRCwEg" type="StereotypeCommentLink" source="_dEL9gE0YEeaqn4OIuRCwEg" target="_dEVum00YEeaqn4OIuRCwEg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dEVuoE0YEeaqn4OIuRCwEg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_dEVupE0YEeaqn4OIuRCwEg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dEVuoU0YEeaqn4OIuRCwEg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dEVuok0YEeaqn4OIuRCwEg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dEVuo00YEeaqn4OIuRCwEg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dE7kYE0YEeaqn4OIuRCwEg" type="4001" source="_dEL9gE0YEeaqn4OIuRCwEg" target="__w77UE0WEeaqn4OIuRCwEg">
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7kY00YEeaqn4OIuRCwEg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kZE0YEeaqn4OIuRCwEg" x="2" y="-9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7kZU0YEeaqn4OIuRCwEg" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kZk0YEeaqn4OIuRCwEg" x="8" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7kZ00YEeaqn4OIuRCwEg" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kaE0YEeaqn4OIuRCwEg" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7kaU0YEeaqn4OIuRCwEg" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kak0YEeaqn4OIuRCwEg" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7ka00YEeaqn4OIuRCwEg" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kbE0YEeaqn4OIuRCwEg" x="23" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_dE7kbU0YEeaqn4OIuRCwEg" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_dE7kbk0YEeaqn4OIuRCwEg" x="-9" y="17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_dE7kYU0YEeaqn4OIuRCwEg"/>
-      <element xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dE7kYk0YEeaqn4OIuRCwEg" points="[0, 0, 244, -2]$[-244, 2, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dE7kb00YEeaqn4OIuRCwEg" id="(0.0,0.28225806451612906)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dE7kcE0YEeaqn4OIuRCwEg" id="(1.0,0.8865248226950354)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_dwhfEE0YEeaqn4OIuRCwEg" type="4001" source="_lv9R8GJFEeek3OrhDuslYQ" target="__w77UE0WEeaqn4OIuRCwEg">
       <children xmi:type="notation:DecorationNode" xmi:id="_dwhfE00YEeaqn4OIuRCwEg" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_dwhfFE0YEeaqn4OIuRCwEg" y="-13"/>
@@ -2253,17 +2330,7 @@
       <element xmi:type="uml:Association" href="TapiCommon.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dwhfEk0YEeaqn4OIuRCwEg" points="[0, 0, -22, -179]$[22, 179, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfH00YEeaqn4OIuRCwEg" id="(0.0,0.5252525252525253)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfIE0YEeaqn4OIuRCwEg" id="(1.0,0.15602836879432624)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__581dhMeEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_dE7kYE0YEeaqn4OIuRCwEg" target="__581chMeEee0L_IMWjydgQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="__581dxMeEee0L_IMWjydgQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__581exMeEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__581eBMeEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__581eRMeEee0L_IMWjydgQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__581ehMeEee0L_IMWjydgQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dwhfIE0YEeaqn4OIuRCwEg" id="(1.0,0.5390070921985816)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__6JCgBMeEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_dwhfEE0YEeaqn4OIuRCwEg" target="__6JCfBMeEee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="__6JCgRMeEee0L_IMWjydgQ"/>
@@ -2287,10 +2354,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_AGncQEwDEeewALXL7BvPYw" type="4001" source="__w77UE0WEeaqn4OIuRCwEg" target="_9lEFgEwCEeewALXL7BvPYw">
       <children xmi:type="notation:DecorationNode" xmi:id="_AGoDUEwDEeewALXL7BvPYw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDUUwDEeewALXL7BvPYw"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDUUwDEeewALXL7BvPYw" x="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_AGoDUkwDEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDU0wDEeewALXL7BvPYw" x="-16" y="8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDU0wDEeewALXL7BvPYw" x="-13" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_AGoDVEwDEeewALXL7BvPYw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_AGoDVUwDEeewALXL7BvPYw" y="-20"/>
@@ -2307,8 +2374,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_AGncQUwDEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiCommon.uml#_AFtdUEwDEeewALXL7BvPYw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AGncQkwDEeewALXL7BvPYw" points="[71, 141, -57, -110]$[121, 235, -7, -16]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQEwDEeewALXL7BvPYw" id="(0.5529953917050692,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQUwDEeewALXL7BvPYw" id="(0.5248868778280543,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQEwDEeewALXL7BvPYw" id="(0.5108695652173914,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AH1kQUwDEeewALXL7BvPYw" id="(0.5222672064777328,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JvxH0UwDEeewALXL7BvPYw" type="StereotypeCommentLink" source="_AGncQEwDEeewALXL7BvPYw" target="_Jvwgw0wDEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_JvxH0kwDEeewALXL7BvPYw"/>
@@ -2339,6 +2406,274 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lwIRFmJFEeek3OrhDuslYQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwIRF2JFEeek3OrhDuslYQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwIRGGJFEeek3OrhDuslYQ"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_vmLIQKeVEeeBGPv_1DT5og" type="PapyrusUMLClassDiagram" name="CommonPacs" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_whVwAKeVEeeBGPv_1DT5og" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_whWXEKeVEeeBGPv_1DT5og" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_whWXEaeVEeeBGPv_1DT5og" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_whWXEqeVEeeBGPv_1DT5og" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_whWXE6eVEeeBGPv_1DT5og" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_xmSl4KeVEeeBGPv_1DT5og" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_4ZaA0N78EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xmSl4aeVEeeBGPv_1DT5og"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_xmT0AKeVEeeBGPv_1DT5og" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_BY3PIN79EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xmT0AaeVEeeBGPv_1DT5og"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_xmUbEKeVEeeBGPv_1DT5og" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_ER7uAN79EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_xmUbEaeVEeeBGPv_1DT5og"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_whWXFKeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_whWXFaeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_whWXFqeVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whWXF6eVEeeBGPv_1DT5og"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_whWXGKeVEeeBGPv_1DT5og" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_whWXGaeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_whWXGqeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_whWXG6eVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whWXHKeVEeeBGPv_1DT5og"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_whWXHaeVEeeBGPv_1DT5og" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_whWXHqeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_whWXH6eVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_whWXIKeVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whWXIaeVEeeBGPv_1DT5og"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whVwAaeVEeeBGPv_1DT5og" x="582" y="31" height="96"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_whfhA6eVEeeBGPv_1DT5og" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_whfhBKeVEeeBGPv_1DT5og" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_whfhBqeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whfhBaeVEeeBGPv_1DT5og" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ysqYEKeVEeeBGPv_1DT5og" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ysqYEqeVEeeBGPv_1DT5og" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ysqYE6eVEeeBGPv_1DT5og" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ysq_IKeVEeeBGPv_1DT5og" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ysq_IaeVEeeBGPv_1DT5og" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_zgJDcKeVEeeBGPv_1DT5og" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_oJg1U979EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_zgJDcaeVEeeBGPv_1DT5og"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ysq_IqeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ysq_I6eVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ysq_JKeVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysq_JaeVEeeBGPv_1DT5og"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ysq_JqeVEeeBGPv_1DT5og" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ysq_J6eVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ysq_KKeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ysq_KaeVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysq_KqeVEeeBGPv_1DT5og"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ysq_K6eVEeeBGPv_1DT5og" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ysq_LKeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ysq_LaeVEeeBGPv_1DT5og"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ysq_LqeVEeeBGPv_1DT5og"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysq_L6eVEeeBGPv_1DT5og"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysqYEaeVEeeBGPv_1DT5og" x="38" y="37" height="74"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ysxs06eVEeeBGPv_1DT5og" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ysxs1KeVEeeBGPv_1DT5og" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysyT4KeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ysxs1aeVEeeBGPv_1DT5og" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BOChIKg2EeeAVfY3jqnvAA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BODIMKg2EeeAVfY3jqnvAA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BODvQKg2EeeAVfY3jqnvAA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BODvQag2EeeAVfY3jqnvAA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BODvQqg2EeeAVfY3jqnvAA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_B9x8AKg2EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_TlA2g979EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B9x8Aag2EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_B9yjEKg2EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_TlA2hN79EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_B9yjEag2EeeAVfY3jqnvAA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BODvQ6g2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BODvRKg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BODvRag2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BODvRqg2EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BODvR6g2EeeAVfY3jqnvAA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BODvSKg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BODvSag2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BODvSqg2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BODvS6g2EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_BODvTKg2EeeAVfY3jqnvAA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_BODvTag2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_BOEWUKg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_BOEWUag2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BOEWUqg2EeeAVfY3jqnvAA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BOChIag2EeeAVfY3jqnvAA" x="310" y="38" height="81"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_BOTm46g2EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_BOTm5Kg2EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BOTm5qg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BOTm5ag2EeeAVfY3jqnvAA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_FvpEEKg2EeeAVfY3jqnvAA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FvprIKg2EeeAVfY3jqnvAA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_FvprIag2EeeAVfY3jqnvAA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_FvprIqg2EeeAVfY3jqnvAA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FvprI6g2EeeAVfY3jqnvAA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_GlwMsKg2EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXNdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_GlwMsag2EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_GlwzwKg2EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_KjZXOdyKEeWXdJnxZxtFYA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Glwzwag2EeeAVfY3jqnvAA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FvprJKg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FvprJag2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FvprJqg2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvprJ6g2EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FvprKKg2EeeAVfY3jqnvAA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FvprKag2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FvprKqg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FvprK6g2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvprLKg2EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FvprLag2EeeAVfY3jqnvAA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FvprLqg2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FvprL6g2EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FvprMKg2EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvprMag2EeeAVfY3jqnvAA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FvpEEag2EeeAVfY3jqnvAA" x="43" y="148" height="85"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Fv14Y6g2EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Fv14ZKg2EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fv14Zqg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Fv14Zag2EeeAVfY3jqnvAA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_qa14QMZUEeeAD9H5zOiMUQ" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_qa14QsZUEeeAD9H5zOiMUQ" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_qa14Q8ZUEeeAD9H5zOiMUQ" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_qa2fUMZUEeeAD9H5zOiMUQ" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_qa2fUcZUEeeAD9H5zOiMUQ" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_ra0HgMZUEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Ucqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ra0HgcZUEeeAD9H5zOiMUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ra1VoMZUEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Udqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ra1VocZUEeeAD9H5zOiMUQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_qa2fUsZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_qa2fU8ZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_qa2fVMZUEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa2fVcZUEeeAD9H5zOiMUQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_qa2fVsZUEeeAD9H5zOiMUQ" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_qa2fV8ZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_qa2fWMZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_qa2fWcZUEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa2fWsZUEeeAD9H5zOiMUQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_qa2fW8ZUEeeAD9H5zOiMUQ" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_qa2fXMZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_qa2fXcZUEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_qa2fXsZUEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa2fX8ZUEeeAD9H5zOiMUQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa14QcZUEeeAD9H5zOiMUQ" x="331" y="144" height="86"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_qa90EMZUEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qa90EcZUEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qa90E8ZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qa90EsZUEeeAD9H5zOiMUQ" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_vmLIQaeVEeeBGPv_1DT5og" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_vmLIQqeVEeeBGPv_1DT5og"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_vmLIQ6eVEeeBGPv_1DT5og">
+      <owner xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiCommon.uml#_XqBXAC5wEea0_JngOlSKcA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_whfhB6eVEeeBGPv_1DT5og" type="StereotypeCommentLink" source="_whVwAKeVEeeBGPv_1DT5og" target="_whfhA6eVEeeBGPv_1DT5og">
+      <styles xmi:type="notation:FontStyle" xmi:id="_whfhCKeVEeeBGPv_1DT5og"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_whfhDKeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_whfhCaeVEeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whfhCqeVEeeBGPv_1DT5og"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_whfhC6eVEeeBGPv_1DT5og"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ysyT4aeVEeeBGPv_1DT5og" type="StereotypeCommentLink" source="_ysqYEKeVEeeBGPv_1DT5og" target="_ysxs06eVEeeBGPv_1DT5og">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ysyT4qeVEeeBGPv_1DT5og"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ysyT5qeVEeeBGPv_1DT5og" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ysyT46eVEeeBGPv_1DT5og" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysyT5KeVEeeBGPv_1DT5og"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ysyT5aeVEeeBGPv_1DT5og"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BOTm56g2EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_BOChIKg2EeeAVfY3jqnvAA" target="_BOTm46g2EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_BOTm6Kg2EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BOUN8Kg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BOTm6ag2EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BOTm6qg2EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BOTm66g2EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Fv14Z6g2EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_FvpEEKg2EeeAVfY3jqnvAA" target="_Fv14Y6g2EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Fv14aKg2EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Fv14bKg2EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fv14aag2EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fv14aqg2EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fv14a6g2EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qa90FMZUEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_qa14QMZUEeeAD9H5zOiMUQ" target="_qa90EMZUEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qa90FcZUEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qa90GcZUEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qa90FsZUEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qa90F8ZUEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qa90GMZUEeeAD9H5zOiMUQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -8,12 +8,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_S3giBe_tEeWLlrwIF3w0vA" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" association="_S3giAO_tEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_aFAUMNnYEeWIOYiRCk5bbQ" name="SIPIncludesLP" memberEnd="_aFAUM9nYEeWIOYiRCk5bbQ _aFAUNdnYEeWIOYiRCk5bbQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aFAUMdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aFAUMtnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_aFAUNdnYEeWIOYiRCk5bbQ" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" association="_aFAUMNnYEeWIOYiRCk5bbQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_O3NPAMhqEeaVlemTikmRHw" name="ContextHasSIPs" memberEnd="_O3TVoshqEeaVlemTikmRHw _O3TVpchqEeaVlemTikmRHw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_O3TVoMhqEeaVlemTikmRHw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_O3TVochqEeaVlemTikmRHw" key="nature" value="UML_Nature"/>
@@ -57,36 +51,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjod8AEeW-BtRsuJPbqg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjot8AEeW-BtRsuJPbqg" value="*"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="LayerProtocol" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_r01pEb6nEeWRz-VHgA3LJQ" annotatedElement="_r01pEL6nEeWRz-VHgA3LJQ">
-          <body>Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. &#xD;
-It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. &#xD;
-Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. </body>
-        </ownedComment>
-        <generalization xmi:type="uml:Generalization" xmi:id="_D65isN8sEeWT9tG0gGLRFw" general="_UhrZoN8qEeWT9tG0gGLRFw"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pE76nEeWRz-VHgA3LJQ" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pFL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pE76nEeWRz-VHgA3LJQ">
-            <body>Indicate the specific layer-protocol described by the LayerProtocol entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r01pFb6nEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r01pFr6nEeWRz-VHgA3LJQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pH76nEeWRz-VHgA3LJQ" name="terminationDirection" visibility="public" type="_Ydx2sNnjEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pIL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pH76nEeWRz-VHgA3LJQ">
-            <body>The overall directionality of the LP. &#xD;
-- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.&#xD;
-- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows&#xD;
-- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r01pIb6nEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r01pIr6nEeWRz-VHgA3LJQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pI76nEeWRz-VHgA3LJQ" name="terminationState" type="_adPI0NnqEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pJL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pI76nEeWRz-VHgA3LJQ">
-            <body>Indicates whether the layer is terminated and if so how.</body>
-          </ownedComment>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_oJg1UN79EeW-BtRsuJPbqg" name="LifecycleStatePac" isLeaf="true" isAbstract="true">
@@ -140,12 +104,12 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
         </ownedComment>
         <generalization xmi:type="uml:Generalization" xmi:id="_6frNwO_nEeWLlrwIF3w0vA" general="_tjWBYD3fEea-1_BGg-qcjQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_aFAUM9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" aggregation="composite" association="_aFAUMNnYEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_XMuBMEq7EeexQa2RWFy3AQ" annotatedElement="_aFAUM9nYEeWIOYiRCk5bbQ">
-            <body>Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental</body>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NMt2sKeTEeeBGPv_1DT5og" name="layerProtocolName" type="_i92HIL6PEeWRz-VHgA3LJQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8_SKMMZcEeeAD9H5zOiMUQ" annotatedElement="_NMt2sKeTEeeBGPv_1DT5og">
+            <body>Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental</body>
           </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c7QIkNnYEeWIOYiRCk5bbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bfKooKeTEeeBGPv_1DT5og" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bfMd0KeTEeeBGPv_1DT5og" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AFxHsEwDEeewALXL7BvPYw" name="_capacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_AFtdUEwDEeewALXL7BvPYw"/>
@@ -172,6 +136,28 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXO9yKEeWXdJnxZxtFYA" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXPNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_7n4UcKg2EeeAVfY3jqnvAA" name="TerminationPac" isLeaf="true" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_7n4Ucag2EeeAVfY3jqnvAA" annotatedElement="_7n4UcKg2EeeAVfY3jqnvAA">
+          <body>Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. &#xD;
+It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. &#xD;
+Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. </body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7n4Ucqg2EeeAVfY3jqnvAA" name="terminationDirection" visibility="public" type="_Ydx2sNnjEeWIOYiRCk5bbQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7n4Uc6g2EeeAVfY3jqnvAA" annotatedElement="_7n4Ucqg2EeeAVfY3jqnvAA">
+            <body>The overall directionality of the LP. &#xD;
+- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.&#xD;
+- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows&#xD;
+- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7n4UdKg2EeeAVfY3jqnvAA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7n4Udag2EeeAVfY3jqnvAA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7n4Udqg2EeeAVfY3jqnvAA" name="terminationState" type="_adPI0NnqEeWIOYiRCk5bbQ" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7n4Ud6g2EeeAVfY3jqnvAA" annotatedElement="_7n4Udqg2EeeAVfY3jqnvAA">
+            <body>Indicates whether the layer is terminated and if so how.</body>
+          </ownedComment>
         </ownedAttribute>
       </packagedElement>
     </packagedElement>
@@ -593,9 +579,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   </uml:Model>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nkyJ0b2OEeWdore3Cxez9g" base_StructuralFeature="_nkyJ0L2OEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_qDhdIb2OEeWdore3Cxez9g" base_StructuralFeature="_qDhdIL2OEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pJr6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pE76nEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pKb6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pH76nEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pKr6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pI76nEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6gSbINnVEeWIOYiRCk5bbQ" base_StructuralFeature="_6efrYtnVEeWIOYiRCk5bbQ" partOfObjectKey="1"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6gSbIdnVEeWIOYiRCk5bbQ" base_StructuralFeature="_6efrZtnVEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_FRsvQNnWEeWIOYiRCk5bbQ" base_StructuralFeature="_FRi-QtnWEeWIOYiRCk5bbQ"/>
@@ -627,7 +610,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelClass xmi:id="_j2GU1t78EeW-BtRsuJPbqg" base_Class="_j2GU0N78EeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_UhrZst8qEeWT9tG0gGLRFw" base_Class="_UhrZoN8qEeWT9tG0gGLRFw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_TlA2hd79EeW-BtRsuJPbqg" base_Class="_TlA2gN79EeW-BtRsuJPbqg"/>
-  <OpenModel_Profile:OpenModelClass xmi:id="_r01pJb6nEeWRz-VHgA3LJQ" base_Class="_r01pEL6nEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_oJg1VN79EeW-BtRsuJPbqg" base_Class="_oJg1UN79EeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_xGhsQN8AEeW-BtRsuJPbqg" base_Class="_xEvjkN8AEeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_sfccPOK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
@@ -635,13 +617,10 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelClass xmi:id="_sfccQeK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_tjWBYj3fEea-1_BGg-qcjQ" base_Class="_tjWBYD3fEea-1_BGg-qcjQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_zC-54j3fEea-1_BGg-qcjQ" base_Class="_zC-54D3fEea-1_BGg-qcjQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNNnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUM9nYEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNtnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUNdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giA-_tEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBu_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giBe_tEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_2_jzcCzkEeaYO8M_h7XJ5A" base_Association="_S3giAO_tEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_It0sfkG-EeWMO5szP8dKiA" base_Class="_It0sYEG-EeWMO5szP8dKiA"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_48dNwC6AEea0_JngOlSKcA" base_Association="_aFAUMNnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelInterface xmi:id="_JSoWcXrqEeavcODnuX7FyA" base_Interface="_JSfMgHrqEeavcODnuX7FyA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zlJvEeWcs7ZjyujtOg" base_Parameter="_WHPN8VJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1z1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN8lJvEeWcs7ZjyujtOg"/>
@@ -653,16 +632,12 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelAttribute xmi:id="_O3TVpshqEeaVlemTikmRHw" base_StructuralFeature="_O3TVpchqEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:RootElement xmi:id="_yVqK4BM4Eee0L_IMWjydgQ" base_Class="_sfccMOK0EeSq5fATALSQkQ" name="_context" description="Root container for all TAPI interaction"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3s6foBhrEeewCs0lkpWskw" base_Property="_S3giBe_tEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmQBhrEeewCs0lkpWskw" base_Property="_aFAUNdnYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmQRhrEeewCs0lkpWskw" base_Property="_O3TVpchqEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmQhhrEeewCs0lkpWskw" base_Property="_4ZaA0N78EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmQxhrEeewCs0lkpWskw" base_Property="_BY3PIN79EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRBhrEeewCs0lkpWskw" base_Property="_ER7uAN79EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRRhrEeewCs0lkpWskw" base_Property="_xEvjm98AEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmRhhrEeewCs0lkpWskw" base_Property="_xEvjn98AEeW-BtRsuJPbqg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmSBhrEeewCs0lkpWskw" base_Property="_r01pE76nEeWRz-VHgA3LJQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmSRhrEeewCs0lkpWskw" base_Property="_r01pH76nEeWRz-VHgA3LJQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tAmShhrEeewCs0lkpWskw" base_Property="_r01pI76nEeWRz-VHgA3LJQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs4BhrEeewCs0lkpWskw" base_Property="_oJg1U979EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs4RhrEeewCs0lkpWskw" base_Property="_dlarAN8qEeWT9tG0gGLRFw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs4hhrEeewCs0lkpWskw" base_Property="_MP7aAJLQEeaqpNd__7dv4w"/>
@@ -671,7 +646,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs5RhrEeewCs0lkpWskw" base_Property="_qDhdIL2OEeWdore3Cxez9g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs5hhrEeewCs0lkpWskw" base_Property="_nkyJ0L2OEeWdore3Cxez9g"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tGs5xhrEeewCs0lkpWskw" base_Property="_O3TVoshqEeaVlemTikmRHw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgBhrEeewCs0lkpWskw" base_Property="_aFAUM9nYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgRhrEeewCs0lkpWskw" base_Property="_S3giA-_tEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzgxhrEeewCs0lkpWskw" base_Property="_l1ltgO-pEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3tMzhBhrEeewCs0lkpWskw" base_Property="_6efrYtnVEeWIOYiRCk5bbQ"/>
@@ -706,7 +680,6 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:ExtendedComposite xmi:id="_JvqaIEwDEeewALXL7BvPYw" base_Association="_AFtdUEwDEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qWCsFqnEeexvMtO2oNM9g" base_Class="_j2GU0N78EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qWpwFqnEeexvMtO2oNM9g" base_Class="_xEvjkN8AEeW-BtRsuJPbqg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qWpwVqnEeexvMtO2oNM9g" base_Class="_r01pEL6nEeWRz-VHgA3LJQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qXQ0FqnEeexvMtO2oNM9g" base_Class="_oJg1UN79EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qXQ0VqnEeexvMtO2oNM9g" base_Class="_UhrZoN8qEeWT9tG0gGLRFw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_0qXQ0lqnEeexvMtO2oNM9g" base_Class="_TlA2gN79EeW-BtRsuJPbqg"/>
@@ -725,4 +698,12 @@ Example of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
   <OpenModel_Profile:OpenModelOperation xmi:id="_OxAk4GNAEee0bPnI-Gt-mQ" base_Operation="_OsQnwGNAEee0bPnI-Gt-mQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_qbqmsGNDEee0bPnI-Gt-mQ" base_Parameter="_qZ9WgGNDEee0bPnI-Gt-mQ"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_ee1y4GNEEee0bPnI-Gt-mQ" base_Parameter="_ee1L0GNEEee0bPnI-Gt-mQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_NMt2saeTEeeBGPv_1DT5og" base_Property="_NMt2sKeTEeeBGPv_1DT5og"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NMvE0KeTEeeBGPv_1DT5og" base_StructuralFeature="_NMt2sKeTEeeBGPv_1DT5og"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_7n9M8Kg2EeeAVfY3jqnvAA" base_Class="_7n4UcKg2EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_7oAQQKg2EeeAVfY3jqnvAA" base_Class="_7n4UcKg2EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7oAQQag2EeeAVfY3jqnvAA" base_StructuralFeature="_7n4Ucqg2EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7oAQQqg2EeeAVfY3jqnvAA" base_Property="_7n4Ucqg2EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7oAQQ6g2EeeAVfY3jqnvAA" base_StructuralFeature="_7n4Udqg2EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7oAQRKg2EeeAVfY3jqnvAA" base_Property="_7n4Udqg2EeeAVfY3jqnvAA"/>
 </xmi:XMI>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -259,10 +259,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ThJgsWJcEeek3OrhDuslYQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ThKHwGJcEeek3OrhDuslYQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_TsAkwEEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKHwWJcEeek3OrhDuslYQ"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_ThKHwmJcEeek3OrhDuslYQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_EN4L8WJREeek3OrhDuslYQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKHw2JcEeek3OrhDuslYQ"/>
@@ -1071,21 +1067,9 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_SCZesIhDEeeOl5P_FBJSmA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_SCZesYhDEeeOl5P_FBJSmA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_TUPhEIhDEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUPhEYhDEeeOl5P_FBJSmA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_TUQIIIhDEeeOl5P_FBJSmA" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQIIYhDEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQIIohDEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQII4hDEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQvMIhDEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_cfZ_c4bpEeWLkaOCu--9xg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQvMYhDEeeOl5P_FBJSmA"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_TUQvMohDEeeOl5P_FBJSmA" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
@@ -1615,7 +1599,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i926QohDEeeOl5P_FBJSmA" points="[0, 0, 9, 252]$[-2, -49, 7, 203]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcIhDEeeOl5P_FBJSmA" id="(0.4440789473684211,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcYhDEeeOl5P_FBJSmA" id="(0.45098039215686275,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcYhDEeeOl5P_FBJSmA" id="(0.5387596899224806,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_4p8MMIhDEeeOl5P_FBJSmA" type="4001" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_0HHioDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_4p8MM4hDEeeOl5P_FBJSmA" type="6001">
@@ -1972,9 +1956,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BmEbMDBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BmEbMTBGEeam35bpdXJzEw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmEbMzBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmEbMzBGEeam35bpdXJzEw" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BmEbMjBGEeam35bpdXJzEw" x="1057" y="506"/>
     </children>
@@ -1996,9 +1978,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BmhHIDBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BmhHITBGEeam35bpdXJzEw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmhHIzBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmhHIzBGEeam35bpdXJzEw" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BmhHIjBGEeam35bpdXJzEw" x="834" y="508"/>
     </children>
@@ -2430,7 +2410,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgsxMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="848" y="179" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="884" y="180" width="194" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6_LyABMjEee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_6_LyAhMjEee0L_IMWjydgQ" type="5029"/>
@@ -2456,7 +2436,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyExMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="820" y="-143" width="229" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="821" y="-110" width="229" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UI4IaxMmEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_UI4IbBMmEee0L_IMWjydgQ" showTitle="true"/>
@@ -2498,7 +2478,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwMxM2Eee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwIRM2Eee0L_IMWjydgQ" x="505" y="-248" width="204" height="73"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GbpwIRM2Eee0L_IMWjydgQ" x="478" y="-249" width="204" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Gb8EAxM2Eee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Gb8EBBM2Eee0L_IMWjydgQ" showTitle="true"/>
@@ -2636,6 +2616,56 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e8M49XIZEeeSiaQ95-6r9w" x="669" y="123"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_3YdyUKLTEeeG6K0eZHmVww" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3Ym8QKLTEeeG6K0eZHmVww" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3Ym8QaLTEeeG6K0eZHmVww" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ym8QqLTEeeG6K0eZHmVww" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3YnjUKLTEeeG6K0eZHmVww" visible="false" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3YnjUaLTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3YnjUqLTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3YnjU6LTEeeG6K0eZHmVww"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YnjVKLTEeeG6K0eZHmVww"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3YnjVaLTEeeG6K0eZHmVww" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3YnjVqLTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3YnjV6LTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3YnjWKLTEeeG6K0eZHmVww"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YnjWaLTEeeG6K0eZHmVww"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_3YnjWqLTEeeG6K0eZHmVww" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_3YnjW6LTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_3YnjXKLTEeeG6K0eZHmVww"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_3YnjXaLTEeeG6K0eZHmVww"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YnjXqLTEeeG6K0eZHmVww"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YdyUaLTEeeG6K0eZHmVww" x="834" y="-253" width="206" height="64"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3Y4pEKLTEeeG6K0eZHmVww" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3Y4pEaLTEeeG6K0eZHmVww" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Y5QIKLTEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y4pEqLTEeeG6K0eZHmVww" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3a3mEKLTEeeG6K0eZHmVww" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3a3mEaLTEeeG6K0eZHmVww" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3a3mE6LTEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3a3mEqLTEeeG6K0eZHmVww" x="1020" y="-243"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_DYOv86LUEeeG6K0eZHmVww" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_DYOv9KLUEeeG6K0eZHmVww" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DYOv9qLUEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DYOv9aLUEeeG6K0eZHmVww" x="1034" y="-353"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_9y8uwTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_9y8uwjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_9y8uwzBFEeam35bpdXJzEw">
@@ -2647,7 +2677,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1RzBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1SDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1STBGEeam35bpdXJzEw" x="-11" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1STBGEeam35bpdXJzEw" x="3" y="-15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU1SjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU1SzBGEeam35bpdXJzEw" x="-49" y="62"/>
@@ -2663,8 +2693,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU1UjBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -392, 0]$[0, 73, -392, 73]$[392, 73, 0, 73]$[392, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1VzBGEeam35bpdXJzEw" id="(0.6853146853146853,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU1VjBGEeam35bpdXJzEw" points="[0, 0, -429, 0]$[0, 73, -429, 73]$[429, 73, 0, 73]$[429, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1VzBGEeam35bpdXJzEw" id="(0.42657342657342656,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU1WDBGEeam35bpdXJzEw" id="(0.4338235294117647,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU11TBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
@@ -2691,56 +2721,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU15jBGEeam35bpdXJzEw" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.4855769230769231,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.5174825174825175,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BlU2LjBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2LzBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2MDBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2MTBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2MjBGEeam35bpdXJzEw" x="7" y="9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2MzBGEeam35bpdXJzEw" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2NDBGEeam35bpdXJzEw" x="-11" y="-17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2NTBGEeam35bpdXJzEw" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2NjBGEeam35bpdXJzEw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2NzBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2ODBGEeam35bpdXJzEw" x="11" y="13"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2OTBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2OjBGEeam35bpdXJzEw" x="-7" y="9"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BlU2OzBGEeam35bpdXJzEw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2PzBGEeam35bpdXJzEw" points="[0, 0, 323, 0]$[0, 39, 323, 39]$[-323, 39, 0, 39]$[-323, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QDBGEeam35bpdXJzEw" id="(0.14705882352941177,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2QTBGEeam35bpdXJzEw" id="(0.8951048951048951,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BlU2jzBGEeam35bpdXJzEw" type="4001" source="_BlU1WTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2kDBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2kTBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2kjBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2kzBGEeam35bpdXJzEw" x="18" y="-10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2lDBGEeam35bpdXJzEw" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2lTBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2ljBGEeam35bpdXJzEw" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2lzBGEeam35bpdXJzEw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2mDBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2mTBGEeam35bpdXJzEw" x="12" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU2mjBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU2mzBGEeam35bpdXJzEw" x="-12" y="12"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BlU2nDBGEeam35bpdXJzEw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU2oDBGEeam35bpdXJzEw" points="[0, 0, 61, 0]$[0, 38, 61, 38]$[-61, 38, 0, 38]$[-61, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2oTBGEeam35bpdXJzEw" id="(0.4755244755244755,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU2ojBGEeam35bpdXJzEw" id="(0.04895104895104895,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2ozBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU2tzBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2pDBGEeam35bpdXJzEw" type="6001">
@@ -2987,16 +2967,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmEbITBGEeam35bpdXJzEw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmEbIjBGEeam35bpdXJzEw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BmEbNDBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU2LjBGEeam35bpdXJzEw" target="_BmEbMDBGEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BmEbNTBGEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmEbOTBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BmEbNjBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmEbNzBGEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmEbODBGEeam35bpdXJzEw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BmhHDjBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU1RTBGEeam35bpdXJzEw" target="_BmhHCjBGEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_BmhHDzBGEeam35bpdXJzEw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmhHEzBGEeam35bpdXJzEw" name="BASE_ELEMENT">
@@ -3006,16 +2976,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BmhHEDBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHETBGEeam35bpdXJzEw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHEjBGEeam35bpdXJzEw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BmhHJDBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU2jzBGEeam35bpdXJzEw" target="_BmhHIDBGEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BmhHJTBGEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_BmhHKTBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BmhHJjBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHJzBGEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHKDBGEeam35bpdXJzEw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Bn3K3jBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU3DzBGEeam35bpdXJzEw" target="_Bn3K2jBGEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_Bn3K3zBGEeam35bpdXJzEw"/>
@@ -3230,7 +3190,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -107, -57]$[107, 0, 0, -57]$[107, 57, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32HxMjEee0L_IMWjydgQ" id="(1.0,0.7413793103448276)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.41700404858299595,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.34536082474226804,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_piyMkBMjEee0L_IMWjydgQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_piyMkxMjEee0L_IMWjydgQ" type="6001">
@@ -3253,16 +3213,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_piyMkRMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -133, 74]$[133, 0, 0, 74]$[133, -74, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -142, 73]$[142, 0, 0, 73]$[142, -73, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMnxMjEee0L_IMWjydgQ" id="(1.0,0.4603174603174603)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.4939271255060729,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AFw8BMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw8xMjEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="23"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="7" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9RMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="38" y="3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="24" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9xMjEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw-BMjEee0L_IMWjydgQ" y="-20"/>
@@ -3284,7 +3244,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Fd7BwBMkEee0L_IMWjydgQ" type="4001" source="_luMgoBMjEee0L_IMWjydgQ" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BwxMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="60" y="-5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="63" y="-1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxRMkEee0L_IMWjydgQ" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="74" y="-12"/>
@@ -3304,15 +3264,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Fd7BwRMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fd7BwhMkEee0L_IMWjydgQ" points="[0, 0, 89, 177]$[-60, -118, 29, 59]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7773279352226721,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9606986899563319,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7783505154639175,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9301310043668122,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_tVhB4BMkEee0L_IMWjydgQ" type="4001" source="_6_LyABMjEee0L_IMWjydgQ" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB4xMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5BMkEee0L_IMWjydgQ" x="-14" y="2"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5BMkEee0L_IMWjydgQ" x="-21" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB5RMkEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5hMkEee0L_IMWjydgQ" x="-33" y="-3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5hMkEee0L_IMWjydgQ" x="-39" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB5xMkEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB6BMkEee0L_IMWjydgQ" y="-20"/>
@@ -3328,7 +3288,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_tVhB4RMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 94, -171]$[0, 171, 94, 0]$[-94, 171, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 95, -138]$[0, 138, 95, 0]$[-95, 138, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.5152838427947598,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB8BMkEee0L_IMWjydgQ" id="(1.0,0.13793103448275862)"/>
     </edges>
@@ -3417,7 +3377,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5EwOEeewALXL7BvPYw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_VZoF5UwOEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-125" y="-93"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-47" y="-10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_VZoF50wOEeewALXL7BvPYw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6EwOEeewALXL7BvPYw" y="-20"/>
@@ -3433,7 +3393,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VZoF4UwOEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_U4H7UEwOEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -429, -136]$[0, 136, -429, 0]$[429, 136, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -465, -137]$[0, 137, -465, 0]$[465, 137, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbFecEwOEeewALXL7BvPYw" id="(0.8461538461538461,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbGFgEwOEeewALXL7BvPYw" id="(0.0,0.3728813559322034)"/>
     </edges>
@@ -3507,10 +3467,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_HPiAQGJrEeek3OrhDuslYQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_HPiAQ2JrEeek3OrhDuslYQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUGJrEeek3OrhDuslYQ" x="32" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUGJrEeek3OrhDuslYQ" x="36" y="4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HPinUWJrEeek3OrhDuslYQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUmJrEeek3OrhDuslYQ" x="45" y="-3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUmJrEeek3OrhDuslYQ" x="48" y="22"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HPinU2JrEeek3OrhDuslYQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinVGJrEeek3OrhDuslYQ" y="-20"/>
@@ -3527,8 +3487,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_HPiAQWJrEeek3OrhDuslYQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HPiAQmJrEeek3OrhDuslYQ" points="[0, 0, 24, 204]$[-18, -146, 6, 58]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinW2JrEeek3OrhDuslYQ" id="(0.4411764705882353,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinXGJrEeek3OrhDuslYQ" id="(0.49101796407185627,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinW2JrEeek3OrhDuslYQ" id="(0.7867647058823529,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinXGJrEeek3OrhDuslYQ" id="(0.7844311377245509,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_HPsYUWJrEeek3OrhDuslYQ" type="StereotypeCommentLink" source="_HPiAQGJrEeek3OrhDuslYQ" target="_HPrxQ2JrEeek3OrhDuslYQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_HPsYUmJrEeek3OrhDuslYQ"/>
@@ -3599,8 +3559,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__l2hIXIYEeeSiaQ95-6r9w"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#__jfwsHIYEeeSiaQ95-6r9w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__l2hInIYEeeSiaQ95-6r9w" points="[0, 0, 106, -46]$[0, 46, 106, 0]$[-106, 46, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oGj4HIYEeeSiaQ95-6r9w" id="(0.2158273381294964,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__l2hInIYEeeSiaQ95-6r9w" points="[0, 0, 135, -46]$[0, 46, 135, 0]$[-135, 46, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oGj4HIYEeeSiaQ95-6r9w" id="(0.4244604316546763,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__oHK8HIYEeeSiaQ95-6r9w" id="(1.0,0.6451612903225806)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_MoYjV3IZEeeSiaQ95-6r9w" type="StereotypeCommentLink" source="__l2hIHIYEeeSiaQ95-6r9w" target="_MoYjU3IZEeeSiaQ95-6r9w">
@@ -3615,15 +3575,15 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_XDTqEHIZEeeSiaQ95-6r9w" type="4006" source="_1ZxusHIYEeeSiaQ95-6r9w" target="_BlU1BDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_XDURIHIZEeeSiaQ95-6r9w" type="6014">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_XDURIXIZEeeSiaQ95-6r9w" x="1" y="-14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_XDURIXIZEeeSiaQ95-6r9w" x="23" y="-11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_XDURInIZEeeSiaQ95-6r9w" type="6015">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_XDURI3IZEeeSiaQ95-6r9w" y="6"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_XDTqEXIZEeeSiaQ95-6r9w"/>
       <element xmi:type="uml:Abstraction" href="TapiConnectivity.uml#_XDNjcHIZEeeSiaQ95-6r9w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XDTqEnIZEeeSiaQ95-6r9w" points="[0, 0, -110, -42]$[0, 42, -110, 0]$[110, 42, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XF65MHIZEeeSiaQ95-6r9w" id="(0.7338129496402878,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XDTqEnIZEeeSiaQ95-6r9w" points="[0, 0, -135, -42]$[0, 42, -135, 0]$[135, 42, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XF65MHIZEeeSiaQ95-6r9w" id="(0.5539568345323741,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XF65MXIZEeeSiaQ95-6r9w" id="(0.0,0.5873015873015873)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_e8M493IZEeeSiaQ95-6r9w" type="StereotypeCommentLink" source="_XDTqEHIZEeeSiaQ95-6r9w" target="_e8M483IZEeeSiaQ95-6r9w">
@@ -3641,7 +3601,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3FHIzEeeSiaQ95-6r9w" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hKZ3FXIzEeeSiaQ95-6r9w" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3FnIzEeeSiaQ95-6r9w" x="-7" y="13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3FnIzEeeSiaQ95-6r9w" x="4" y="-11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hKZ3F3IzEeeSiaQ95-6r9w" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3GHIzEeeSiaQ95-6r9w" y="-20"/>
@@ -3653,13 +3613,131 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3HHIzEeeSiaQ95-6r9w" x="11" y="13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_hKZ3HXIzEeeSiaQ95-6r9w" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3HnIzEeeSiaQ95-6r9w" x="-18" y="19"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_hKZ3HnIzEeeSiaQ95-6r9w" x="-11" y="12"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_hKZ3EXIzEeeSiaQ95-6r9w"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hF804HIzEeeSiaQ95-6r9w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hKZ3EnIzEeeSiaQ95-6r9w" points="[15, -1, -160, 0]$[163, 0, -12, 1]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hMWX0HIzEeeSiaQ95-6r9w" id="(1.0,0.7164179104477612)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hMWX0XIzEeeSiaQ95-6r9w" id="(0.0,0.8387096774193549)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3Y5QIaLTEeeG6K0eZHmVww" type="StereotypeCommentLink" source="_3YdyUKLTEeeG6K0eZHmVww" target="_3Y4pEKLTEeeG6K0eZHmVww">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3Y5QIqLTEeeG6K0eZHmVww"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3Y53MqLTEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_PSCGoMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Y5QI6LTEeeG6K0eZHmVww" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Y53MKLTEeeG6K0eZHmVww"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Y53MaLTEeeG6K0eZHmVww"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3aRwMKLTEeeG6K0eZHmVww" type="4001" source="_6_LyABMjEee0L_IMWjydgQ" target="_3YdyUKLTEeeG6K0eZHmVww">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aTlYKLTEeeG6K0eZHmVww" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aTlYaLTEeeG6K0eZHmVww" x="1" y="-2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aTlYqLTEeeG6K0eZHmVww" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aTlY6LTEeeG6K0eZHmVww" x="10" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aUMcKLTEeeG6K0eZHmVww" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMcaLTEeeG6K0eZHmVww" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aUMcqLTEeeG6K0eZHmVww" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMc6LTEeeG6K0eZHmVww" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aUMdKLTEeeG6K0eZHmVww" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMdaLTEeeG6K0eZHmVww" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3aWosKLTEeeG6K0eZHmVww" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aWosaLTEeeG6K0eZHmVww" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_3aRwMaLTEeeG6K0eZHmVww"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3aRwMqLTEeeG6K0eZHmVww" points="[0, 0, 820, -143]$[-820, 143, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZE8KLTEeeG6K0eZHmVww" id="(0.48034934497816595,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZE8aLTEeeG6K0eZHmVww" id="(0.46601941747572817,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3a3mFKLTEeeG6K0eZHmVww" type="StereotypeCommentLink" source="_3aRwMKLTEeeG6K0eZHmVww" target="_3a3mEKLTEeeG6K0eZHmVww">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3a3mFaLTEeeG6K0eZHmVww"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3a3mGaLTEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3a3mFqLTEeeG6K0eZHmVww" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3a3mF6LTEeeG6K0eZHmVww"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3a3mGKLTEeeG6K0eZHmVww"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DXw14KLUEeeG6K0eZHmVww" type="4008" source="_3YdyUKLTEeeG6K0eZHmVww" target="_GbpwIBM2Eee0L_IMWjydgQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_DXw146LUEeeG6K0eZHmVww" type="6026">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DXw15KLUEeeG6K0eZHmVww" x="-2" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_DXw15aLUEeeG6K0eZHmVww" type="6027">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_DXxc8KLUEeeG6K0eZHmVww" x="2" y="-11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_DXw14aLUEeeG6K0eZHmVww"/>
+      <element xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DXw14qLUEeeG6K0eZHmVww" points="[0, 0, 329, -5]$[-329, 5, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DXyEAKLUEeeG6K0eZHmVww" id="(0.0,0.4375)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DXyEAaLUEeeG6K0eZHmVww" id="(1.0,0.3150684931506849)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_DYOv96LUEeeG6K0eZHmVww" type="StereotypeCommentLink" source="_DXw14KLUEeeG6K0eZHmVww" target="_DYOv86LUEeeG6K0eZHmVww">
+      <styles xmi:type="notation:FontStyle" xmi:id="_DYOv-KLUEeeG6K0eZHmVww"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_DYPXAqLUEeeG6K0eZHmVww" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiTopology.uml#_ti-UcBM3Eee0L_IMWjydgQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DYOv-aLUEeeG6K0eZHmVww" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DYPXAKLUEeeG6K0eZHmVww"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DYPXAaLUEeeG6K0eZHmVww"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_BlSk4KOTEeeDzr1ZQC1JMQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU3KDBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlYEcKOTEeeDzr1ZQC1JMQ" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlYrgKOTEeeDzr1ZQC1JMQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlYrgaOTEeeDzr1ZQC1JMQ" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSkKOTEeeDzr1ZQC1JMQ" x="31" y="-23"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlZSkaOTEeeDzr1ZQC1JMQ" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSkqOTEeeDzr1ZQC1JMQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlZSk6OTEeeDzr1ZQC1JMQ" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSlKOTEeeDzr1ZQC1JMQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlZSlaOTEeeDzr1ZQC1JMQ" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSlqOTEeeDzr1ZQC1JMQ" x="11" y="-24"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_BlZSl6OTEeeDzr1ZQC1JMQ" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSmKOTEeeDzr1ZQC1JMQ" x="-13" y="-26"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_BlSk4aOTEeeDzr1ZQC1JMQ"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlSk4qOTEeeDzr1ZQC1JMQ" points="[0, 0, 24, 204]$[-18, -146, 6, 58]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Blmt8KOTEeeDzr1ZQC1JMQ" id="(0.125,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlnVAKOTEeeDzr1ZQC1JMQ" id="(0.24550898203592814,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eIpYwMZSEeeAD9H5zOiMUQ" type="4001" source="_BlU1WTBGEeam35bpdXJzEw" target="_BlU1BDBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_eIscEMZSEeeAD9H5zOiMUQ" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItDIMZSEeeAD9H5zOiMUQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eItDIcZSEeeAD9H5zOiMUQ" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItDIsZSEeeAD9H5zOiMUQ" x="-9" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eItqMMZSEeeAD9H5zOiMUQ" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItqMcZSEeeAD9H5zOiMUQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eItqMsZSEeeAD9H5zOiMUQ" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItqM8ZSEeeAD9H5zOiMUQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eItqNMZSEeeAD9H5zOiMUQ" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItqNcZSEeeAD9H5zOiMUQ" x="11" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eItqNsZSEeeAD9H5zOiMUQ" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eItqN8ZSEeeAD9H5zOiMUQ" x="-10" y="-16"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_eIpYwcZSEeeAD9H5zOiMUQ"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eIpYwsZSEeeAD9H5zOiMUQ" points="[0, 0, -342, 0]$[0, 34, -342, 34]$[342, 34, 0, 34]$[342, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eIxUkMZSEeeAD9H5zOiMUQ" id="(0.8111888111888111,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eIxUkcZSEeeAD9H5zOiMUQ" id="(0.19852941176470587,1.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_Hdao8DBGEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">
@@ -3669,41 +3747,49 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrifzBGEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_LsrigDBGEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="__HmQAMFtEeaALJQAf08uAg" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQAcFtEeaALJQAf08uAg"/>
+        <children xmi:type="notation:Shape" xmi:id="_ZBoskMZbEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBoskcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQAsFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBp6sMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQA8FtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBp6scZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQBMFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBp6ssZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQBcFtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBp6s8ZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQBsFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBqhwMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_cfZ_c4bpEeWLkaOCu--9xg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQB8FtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhwcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQCMFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBqhwsZbEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhw8ZbEeeAD9H5zOiMUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ZBqhxMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQCcFtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhxcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQDMFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBqhxsZbEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhx8ZbEeeAD9H5zOiMUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ZBqhyMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQDcFtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhycZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="__HmQDsFtEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBrI0MZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="__HmQD8FtEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI0cZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RCqFsBMjEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBrI0sZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RCqFsRMjEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI08ZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_RCqFshMjEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_ZBrI1MZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_RCqFsxMjEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI1cZbEeeAD9H5zOiMUQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LsrjdjBGEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LsrjdzBGEeam35bpdXJzEw"/>
@@ -3723,7 +3809,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjgzBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjsTBGEeam35bpdXJzEw" x="-59" y="53" width="435" height="196"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrjsTBGEeam35bpdXJzEw" x="-55" y="42" width="435" height="218"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_LsrjxjBGEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_LsrjxzBGEeam35bpdXJzEw" type="5029"/>
@@ -3757,53 +3843,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrkGDBGEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrkRjBGEeam35bpdXJzEw" x="612" y="97" height="75"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_LsrlYzBGEeam35bpdXJzEw" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrlZDBGEeam35bpdXJzEw" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrlZTBGEeam35bpdXJzEw" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrlZjBGEeam35bpdXJzEw" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LsrlZzBGEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_LsrliDBGEeam35bpdXJzEw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pE76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrlpzBGEeam35bpdXJzEw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_LsrlqDBGEeam35bpdXJzEw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pH76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrlxzBGEeam35bpdXJzEw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_LsrlyDBGEeam35bpdXJzEw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pI76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Lsrl5zBGEeam35bpdXJzEw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_PoJ2kBMjEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PoJ2kRMjEee0L_IMWjydgQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_PoJ2khMjEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PoJ2kxMjEee0L_IMWjydgQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LsrmCDBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LsrmCTBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LsrmCjBGEeam35bpdXJzEw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmCzBGEeam35bpdXJzEw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LsrmDDBGEeam35bpdXJzEw" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LsrmDTBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LsrmDjBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LsrmDzBGEeam35bpdXJzEw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmEDBGEeam35bpdXJzEw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_LsrmETBGEeam35bpdXJzEw" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_LsrmEjBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_LsrmEzBGEeam35bpdXJzEw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_LsrmFDBGEeam35bpdXJzEw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmFTBGEeam35bpdXJzEw"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrmQzBGEeam35bpdXJzEw" x="586" y="228" width="289" height="121"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LsrkRjBGEeam35bpdXJzEw" x="612" y="92" height="75"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__g_RQzIvEeamvfKYyWmELQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__g_RRDIvEeamvfKYyWmELQ" showTitle="true"/>
@@ -3829,14 +3869,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__iLkJjIvEeamvfKYyWmELQ" x="880" y="-5"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="__i7LBDIvEeamvfKYyWmELQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__i7LBTIvEeamvfKYyWmELQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__i7LBzIvEeamvfKYyWmELQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__i7LBjIvEeamvfKYyWmELQ" x="537" y="391"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_USHkQxMmEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_USHkRBMmEee0L_IMWjydgQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USHkRhMmEee0L_IMWjydgQ" name="BASE_ELEMENT">
@@ -3845,24 +3877,12 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_USHkRRMmEee0L_IMWjydgQ" x="126" y="28"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_USf-cxMmEee0L_IMWjydgQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_USf-dBMmEee0L_IMWjydgQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USf-dhMmEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_USf-dRMmEee0L_IMWjydgQ" x="777" y="119"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_rT034EwEEeewALXL7BvPYw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_rT1e8EwEEeewALXL7BvPYw" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_rT1e8UwEEeewALXL7BvPYw" type="8510">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_rT1e8kwEEeewALXL7BvPYw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_rT1e80wEEeewALXL7BvPYw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_AR-QUEwGEeewALXL7BvPYw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_TsAkwEEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR-QUUwGEeewALXL7BvPYw"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_AR_ecEwGEeewALXL7BvPYw" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_AR_ecUwGEeewALXL7BvPYw"/>
@@ -3905,7 +3925,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT1fAUwEEeewALXL7BvPYw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT034UwEEeewALXL7BvPYw" x="15" y="321" height="155"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT034UwEEeewALXL7BvPYw" x="15" y="306" height="155"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rT-o4EwEEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rT-o4UwEEeewALXL7BvPYw" showTitle="true"/>
@@ -3914,14 +3934,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT-o4kwEEeewALXL7BvPYw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_FdXMk0wFEeewALXL7BvPYw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FdXMlEwFEeewALXL7BvPYw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FdXMlkwFEeewALXL7BvPYw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FdXMlUwFEeewALXL7BvPYw" x="180" y="279"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Wnt_wEwFEeewALXL7BvPYw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_Wnum0EwFEeewALXL7BvPYw" type="5029"/>
@@ -3955,7 +3967,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnum4UwFEeewALXL7BvPYw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnt_wUwFEeewALXL7BvPYw" x="590" y="397" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnt_wUwFEeewALXL7BvPYw" x="607" y="345" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Wn2io0wFEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Wn2ipEwFEeewALXL7BvPYw" showTitle="true"/>
@@ -3972,6 +3984,56 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUeTgkwGEeewALXL7BvPYw" x="215" y="221"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_n4MtoMZaEeeAD9H5zOiMUQ" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_n4NUscZaEeeAD9H5zOiMUQ" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_n4NUssZaEeeAD9H5zOiMUQ" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_n4NUs8ZaEeeAD9H5zOiMUQ" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n4NUtMZaEeeAD9H5zOiMUQ" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_o6nz8MZaEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Ucqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_o6nz8cZaEeeAD9H5zOiMUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_o6obAMZaEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Udqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_o6obAcZaEeeAD9H5zOiMUQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n4NUtcZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n4NUtsZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n4NUt8ZaEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n4NUuMZaEeeAD9H5zOiMUQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n4NUucZaEeeAD9H5zOiMUQ" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n4NUusZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n4NUu8ZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n4NUvMZaEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n4NUvcZaEeeAD9H5zOiMUQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_n4NUvsZaEeeAD9H5zOiMUQ" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_n4NUv8ZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_n4NUwMZaEeeAD9H5zOiMUQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_n4NUwcZaEeeAD9H5zOiMUQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n4NUwsZaEeeAD9H5zOiMUQ"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n4NUsMZaEeeAD9H5zOiMUQ" x="608" y="191" height="84"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_n4UCY8ZaEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n4UCZMZaEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n4UpcMZaEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n4UCZcZaEeeAD9H5zOiMUQ" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zl1ZcMZaEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zl1ZccZaEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zl1Zc8ZaEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_sGvKoMZaEeeAD9H5zOiMUQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zl1ZcsZaEeeAD9H5zOiMUQ" x="784" y="201"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Hdao8TBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Hdao8jBGEeam35bpdXJzEw"/>
@@ -4004,33 +4066,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Lsre4TBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_TPT-AO_tEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lsre6DBGEeam35bpdXJzEw" points="[47, 100, -36, -74]$[89, 153, 6, -21]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6TBGEeam35bpdXJzEw" id="(1.0,0.3826530612244898)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6TBGEeam35bpdXJzEw" id="(1.0,0.37155963302752293)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lsre6jBGEeam35bpdXJzEw" id="(0.0,0.41333333333333333)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_LsrfcjBGEeam35bpdXJzEw" type="4001" source="_LsrlYzBGEeam35bpdXJzEw" target="_LsrifDBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrfczBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrfdDBGEeam35bpdXJzEw" x="12" y="-5"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrfdTBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrfdjBGEeam35bpdXJzEw" x="10" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrfdzBGEeam35bpdXJzEw" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrfeDBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrfeTBGEeam35bpdXJzEw" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrfejBGEeam35bpdXJzEw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrfezBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrffDBGEeam35bpdXJzEw" x="19" y="15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_LsrffTBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrffjBGEeam35bpdXJzEw" x="-8" y="17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_LsrffzBGEeam35bpdXJzEw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LsrfhjBGEeam35bpdXJzEw" points="[-5, -54, 6, 81]$[-11, -135, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfhzBGEeam35bpdXJzEw" id="(0.0,0.09090909090909091)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LsrfiDBGEeam35bpdXJzEw" id="(1.0,0.9489795918367347)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__hSMQzIvEeamvfKYyWmELQ" type="StereotypeCommentLink" source="_LsrifDBGEeam35bpdXJzEw" target="__hSMPzIvEeamvfKYyWmELQ">
       <styles xmi:type="notation:FontStyle" xmi:id="__hSMRDIvEeamvfKYyWmELQ"/>
@@ -4052,16 +4089,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__iLkKzIvEeamvfKYyWmELQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__iLkLDIvEeamvfKYyWmELQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__i7LCDIvEeamvfKYyWmELQ" type="StereotypeCommentLink" source="_LsrlYzBGEeam35bpdXJzEw" target="__i7LBDIvEeamvfKYyWmELQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="__i7LCTIvEeamvfKYyWmELQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__i7LDTIvEeamvfKYyWmELQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__i7LCjIvEeamvfKYyWmELQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__i7LCzIvEeamvfKYyWmELQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__i7LDDIvEeamvfKYyWmELQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_USHkRxMmEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_Lsre0jBGEeam35bpdXJzEw" target="_USHkQxMmEee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_USHkSBMmEee0L_IMWjydgQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USHkTBMmEee0L_IMWjydgQ" name="BASE_ELEMENT">
@@ -4072,16 +4099,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USHkShMmEee0L_IMWjydgQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USHkSxMmEee0L_IMWjydgQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_USf-dxMmEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_LsrfcjBGEeam35bpdXJzEw" target="_USf-cxMmEee0L_IMWjydgQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_USf-eBMmEee0L_IMWjydgQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_USf-fBMmEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_USf-eRMmEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USf-ehMmEee0L_IMWjydgQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_USf-exMmEee0L_IMWjydgQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_rT-o5EwEEeewALXL7BvPYw" type="StereotypeCommentLink" source="_rT034EwEEeewALXL7BvPYw" target="_rT-o4EwEEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_rT-o5UwEEeewALXL7BvPYw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rT-o6UwEEeewALXL7BvPYw" name="BASE_ELEMENT">
@@ -4091,41 +4108,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rT-o5kwEEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rT-o50wEEeewALXL7BvPYw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rT-o6EwEEeewALXL7BvPYw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4_DRwEwEEeewALXL7BvPYw" type="4001" source="_rT034EwEEeewALXL7BvPYw" target="_LsrlYzBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRw0wEEeewALXL7BvPYw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRxEwEEeewALXL7BvPYw" x="-8" y="11"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRxUwEEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRxkwEEeewALXL7BvPYw" x="-4" y="-15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRx0wEEeewALXL7BvPYw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRyEwEEeewALXL7BvPYw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRyUwEEeewALXL7BvPYw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRykwEEeewALXL7BvPYw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRy0wEEeewALXL7BvPYw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRzEwEEeewALXL7BvPYw" x="10" y="18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4_DRzUwEEeewALXL7BvPYw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_4_DRzkwEEeewALXL7BvPYw" x="-14" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_4_DRwUwEEeewALXL7BvPYw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4_DRwkwEEeewALXL7BvPYw" points="[29, -10, -350, 114]$[360, -115, -19, 9]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ACwQEwEEeewALXL7BvPYw" id="(1.0,0.1032258064516129)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ACwQUwEEeewALXL7BvPYw" id="(0.0,0.9008264462809917)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FdXMl0wFEeewALXL7BvPYw" type="StereotypeCommentLink" source="_4_DRwEwEEeewALXL7BvPYw" target="_FdXMk0wFEeewALXL7BvPYw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FdXMmEwFEeewALXL7BvPYw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FdXzokwFEeewALXL7BvPYw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_3_TE8EwEEeewALXL7BvPYw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FdXMmUwFEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FdXzoEwFEeewALXL7BvPYw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FdXzoUwFEeewALXL7BvPYw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Wn3JsEwFEeewALXL7BvPYw" type="StereotypeCommentLink" source="_Wnt_wEwFEeewALXL7BvPYw" target="_Wn2io0wFEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_Wn3JsUwFEeewALXL7BvPYw"/>
@@ -4142,7 +4124,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZEwFEeewALXL7BvPYw" x="-4" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZUwFEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZkwFEeewALXL7BvPYw" x="-3" y="-6"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmZkwFEeewALXL7BvPYw" x="-2" y="-12"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_nLYmZ0wFEeewALXL7BvPYw" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_nLYmaEwFEeewALXL7BvPYw" y="-20"/>
@@ -4159,7 +4141,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_nLYmYUwFEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nLYmYkwFEeewALXL7BvPYw" points="[15, 0, -301, -9]$[306, 6, -10, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.7161290322580646)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.47096774193548385)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQUwFEeewALXL7BvPYw" id="(0.0,0.3655913978494624)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_uUeThEwGEeewALXL7BvPYw" type="StereotypeCommentLink" source="_nLYmYEwFEeewALXL7BvPYw" target="_uUeTgEwGEeewALXL7BvPYw">
@@ -4171,6 +4153,51 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uUeThkwGEeewALXL7BvPYw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTh0wGEeewALXL7BvPYw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uUeTiEwGEeewALXL7BvPYw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_n4UpccZaEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_n4MtoMZaEeeAD9H5zOiMUQ" target="_n4UCY8ZaEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n4UpcsZaEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n4UpdsZaEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n4Upc8ZaEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n4UpdMZaEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n4UpdcZaEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sJ5zYMZaEeeAD9H5zOiMUQ" type="4001" source="_n4MtoMZaEeeAD9H5zOiMUQ" target="_LsrifDBGEeam35bpdXJzEw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ5zY8ZaEeeAD9H5zOiMUQ" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ5zZMZaEeeAD9H5zOiMUQ" x="3" y="-12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ6acMZaEeeAD9H5zOiMUQ" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ6accZaEeeAD9H5zOiMUQ" x="-2" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ6acsZaEeeAD9H5zOiMUQ" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ6ac8ZaEeeAD9H5zOiMUQ" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ6adMZaEeeAD9H5zOiMUQ" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ6adcZaEeeAD9H5zOiMUQ" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ6adsZaEeeAD9H5zOiMUQ" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ6ad8ZaEeeAD9H5zOiMUQ" x="12" y="18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_sJ6aeMZaEeeAD9H5zOiMUQ" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_sJ6aecZaEeeAD9H5zOiMUQ" x="-9" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_sJ5zYcZaEeeAD9H5zOiMUQ"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_sGvKoMZaEeeAD9H5zOiMUQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sJ5zYsZaEeeAD9H5zOiMUQ" points="[2, -31, 5, -74]$[29, 41, 32, -2]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sLRFUMZaEeeAD9H5zOiMUQ" id="(0.0,0.5)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sLRFUcZaEeeAD9H5zOiMUQ" id="(1.0,0.8761467889908257)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zl1ZdMZaEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_sJ5zYMZaEeeAD9H5zOiMUQ" target="_zl1ZcMZaEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zl1ZdcZaEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zl1ZecZaEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_sGvKoMZaEeeAD9H5zOiMUQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zl1ZdsZaEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zl1Zd8ZaEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zl1ZeMZaEeeAD9H5zOiMUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_l51YUOr0EeaeHOJw3lCT8A" type="PapyrusUMLClassDiagram" name="Resilience" measurementUnit="Pixel">
@@ -4530,21 +4557,9 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__j6ptOscEealN7CdLT_GPw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__j6ptescEealN7CdLT_GPw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_TNw7EIhCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNw7EYhCEeeOl5P_FBJSmA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_TNxiIIhCEeeOl5P_FBJSmA" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_TNxiIYhCEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNxiIohCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNxiI4hCEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNyJMIhCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_cfZ_c4bpEeWLkaOCu--9xg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNyJMYhCEeeOl5P_FBJSmA"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_TNyJMohCEeeOl5P_FBJSmA" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -20,12 +20,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_B00SgO_sEeWLlrwIF3w0vA" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_B0rIkO_sEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_hv9NsNnYEeWIOYiRCk5bbQ" name="CEPIncludesLP" memberEnd="_hv9Ns9nYEeWIOYiRCk5bbQ _hv9NtdnYEeWIOYiRCk5bbQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hv9NsdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hv9NstnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_hv9NtdnYEeWIOYiRCk5bbQ" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_WFlH4O_qEeWLlrwIF3w0vA" name="ConnServiceHasConnConstraints" memberEnd="_WFu44u_qEeWLlrwIF3w0vA _WFu45O_qEeWLlrwIF3w0vA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WFu44O_qEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WFu44e_qEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
@@ -226,12 +220,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_nJqvIUwFEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_nJo58EwFEeewALXL7BvPYw"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_3_TE8EwEEeewALXL7BvPYw" name="SEPIncludesLP" memberEnd="_3_TsAkwEEeewALXL7BvPYw _3_U6IEwEEeewALXL7BvPYw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3_TsAEwEEeewALXL7BvPYw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3_TsAUwEEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_3_U6IEwEEeewALXL7BvPYw" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_3_TE8EwEEeewALXL7BvPYw"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_ihpPkEwPEeewALXL7BvPYw" name="ConnectionHasLowerLevelConnections" memberEnd="_ihp2oUwPEeewALXL7BvPYw _ihqdsUwPEeewALXL7BvPYw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ihpPkUwPEeewALXL7BvPYw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ihp2oEwPEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
@@ -300,6 +288,12 @@
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7ZrR4YfgEeet-8tHdGGp_w" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_7ZsgAofgEeet-8tHdGGp_w" name="connectivityconstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_7ZpcsIfgEeet-8tHdGGp_w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_sGvKoMZaEeeAD9H5zOiMUQ" name="CEPHasTerminationPac" memberEnd="_sGvxssZaEeeAD9H5zOiMUQ _sGwYwMZaEeeAD9H5zOiMUQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sGvxsMZaEeeAD9H5zOiMUQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_sGvxscZaEeeAD9H5zOiMUQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_sGwYwMZaEeeAD9H5zOiMUQ" name="connectionendpoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_sGvKoMZaEeeAD9H5zOiMUQ"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams"/>
@@ -451,10 +445,8 @@ The structure of LTP supports all transport protocols including circuit and pack
         <generalization xmi:type="uml:Generalization" xmi:id="_89GScO_nEeWLlrwIF3w0vA">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_layerProtocol" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ldi5wNnYEeWIOYiRCk5bbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ldi5wdnYEeWIOYiRCk5bbQ" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IOhXAKeWEeeBGPv_1DT5og" name="layerProtocolName" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Zb_6UH5NEeWWkJKpap4S3A" name="_clientNodeEdgePoint" isReadOnly="true" aggregation="shared" association="_Zb5MoH5NEeWWkJKpap4S3A">
           <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
@@ -473,6 +465,9 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sGvxssZaEeeAD9H5zOiMUQ" name="_termination" aggregation="composite" association="_sGvKoMZaEeeAD9H5zOiMUQ">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_sIutK2h-EeWZEqTYAF8eqA" name="connectionPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_sIutLGh-EeWZEqTYAF8eqA" annotatedElement="_sIutK2h-EeWZEqTYAF8eqA">
@@ -606,10 +601,8 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X5h9EHI9EeeSiaQ95-6r9w"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X5mOgHI9EeeSiaQ95-6r9w" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_TsAkwEEeewALXL7BvPYw" name="_layerProtocol" aggregation="composite" association="_3_TE8EwEEeewALXL7BvPYw">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AzVGYEwFEeewALXL7BvPYw" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AzW7kEwFEeewALXL7BvPYw" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nPhusKhLEeeAVfY3jqnvAA" name="layerProtocolName">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4L8WJREeek3OrhDuslYQ" name="_state" aggregation="composite" association="_EN290GJREeek3OrhDuslYQ">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
@@ -1002,7 +995,6 @@ Note: Only relevant when part of a protection scheme.</body>
       <appliedProfile xmi:type="uml:Profile" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_UbM6ILbyEeaufdfMFhfy_A"/>
     </profileApplication>
   </uml:Model>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_B3KZwkHCEeWqPKyD1j6LMg" base_StructuralFeature="_B3KZwUHCEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_B3Ln4UHCEeWqPKyD1j6LMg" base_StructuralFeature="_B3Ln4EHCEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_kuEaUEHaEeWqPKyD1j6LMg" base_StructuralFeature="_kuDzQ0HaEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_IZ49kEHbEeWqPKyD1j6LMg" base_StructuralFeature="_IZ3vc0HbEeWqPKyD1j6LMg"/>
@@ -1030,7 +1022,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcAhYH5NEeWWkJKpap4S3A" base_StructuralFeature="_Zb_6UH5NEeWWkJKpap4S3A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcC9oX5NEeWWkJKpap4S3A" base_StructuralFeature="_ZcC9oH5NEeWWkJKpap4S3A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_cfZ_dIbpEeWLkaOCu--9xg" base_StructuralFeature="_cfZ_c4bpEeWLkaOCu--9xg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_cfjJYYbpEeWLkaOCu--9xg" base_StructuralFeature="_cfjJYIbpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_T9ChoaU5EeWkWNPM1BHzGA" base_Parameter="_T9ChoKU5EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_7BwFUbvMEeWYrqoqXLgguw" base_Parameter="_7BwFULvMEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lY2XUbvZEeWYrqoqXLgguw" base_StructuralFeature="_lY2XULvZEeWYrqoqXLgguw"/>
@@ -1046,8 +1037,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelParameter xmi:id="_zEZcMb2YEeWdore3Cxez9g" base_Parameter="_zEZcML2YEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_L70owb2ZEeWdore3Cxez9g" base_Parameter="_L70owL2ZEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Y9jZsb2ZEeWdore3Cxez9g" base_Parameter="_Y9jZsL2ZEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_hv9NtNnYEeWIOYiRCk5bbQ" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_hv9NttnYEeWIOYiRCk5bbQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_V2I0IdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_V2I0INnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_caIFkdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_caIFkNnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpO_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxo-_pEeWLlrwIF3w0vA"/>
@@ -1073,9 +1062,10 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk10FJvEeWcs7ZjyujtOg" base_Operation="_WHPN81JvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1x1JvEeWcs7ZjyujtOg" base_Operation="_WHPN6FJvEeWcs7ZjyujtOg"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_qH8fkb2NEeWdore3Cxez9g" base_Operation="_qH8fkL2NEeWdore3Cxez9g"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_6FRP8C6AEea0_JngOlSKcA" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nxcI8zLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxcI8jLCEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLxTLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxDLEEeaULOmJRJKM0Q"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yA-gBhrEeewCs0lkpWskw" base_Property="_B3Ln4EHCEeWqPKyD1j6LMg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkBhrEeewCs0lkpWskw" base_Property="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nxl58TLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxl58DLCEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLyDLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxzLEEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wt-RdEXOEeaB8vMnkFQLXQ" base_StructuralFeature="_wt-RckXOEeaB8vMnkFQLXQ"/>
@@ -1142,14 +1132,11 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xxt8BhrEeewCs0lkpWskw" base_Property="_TPT-Be_tEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xzjIBhrEeewCs0lkpWskw" base_Property="_ZiZgIEUcEeWEwNCluy4jrw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__xzjIRhrEeewCs0lkpWskw" base_Property="_B00SgO_sEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x0KMBhrEeewCs0lkpWskw" base_Property="_hv9NtdnYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x0xQBhrEeewCs0lkpWskw" base_Property="_WFu45O_qEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x1_YRhrEeewCs0lkpWskw" base_Property="_4Es8NWkIEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x2mcBhrEeewCs0lkpWskw" base_Property="_nfDxpe_pEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x2mcRhrEeewCs0lkpWskw" base_Property="_niJd82kKEeWZEqTYAF8eqA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x2mchhrEeewCs0lkpWskw" base_Property="_cfjJYIbpEeWLkaOCu--9xg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x3NgBhrEeewCs0lkpWskw" base_Property="_ZcC9oH5NEeWWkJKpap4S3A"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x3NgRhrEeewCs0lkpWskw" base_Property="_B3KZwUHCEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x3NghhrEeewCs0lkpWskw" base_Property="_ijcPpWkHEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x30kBhrEeewCs0lkpWskw" base_Property="_4EuaAEUcEeWEwNCluy4jrw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x30kRhrEeewCs0lkpWskw" base_Property="_YyoyBGkJEeWZEqTYAF8eqA"/>
@@ -1178,10 +1165,7 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97NBhrEeewCs0lkpWskw" base_Property="_B0rIk-_sEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x-iQBhrEeewCs0lkpWskw" base_Property="_IZ3vc0HbEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x-iQRhrEeewCs0lkpWskw" base_Property="_V2I0INnlEeWIOYiRCk5bbQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x_wYBhrEeewCs0lkpWskw" base_Property="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yAXcBhrEeewCs0lkpWskw" base_Property="_Zb_6UH5NEeWWkJKpap4S3A"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yA-gBhrEeewCs0lkpWskw" base_Property="_B3Ln4EHCEeWqPKyD1j6LMg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkBhrEeewCs0lkpWskw" base_Property="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkRhrEeewCs0lkpWskw" base_Property="_TPT-A-_tEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkxhrEeewCs0lkpWskw" base_Property="_sIutK2h-EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBllBhrEeewCs0lkpWskw" base_Property="_sIutJ2h-EeWZEqTYAF8eqA"/>
@@ -1226,13 +1210,8 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMRhrEeewCs0lkpWskw" base_Property="_Ca3vhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMhhrEeewCs0lkpWskw" base_Property="_MjEHhP4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yQPMxhrEeewCs0lkpWskw" base_Property="_3_SWwL11EeWdore3Cxez9g"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3_TsA0wEEeewALXL7BvPYw" base_Property="_3_TsAkwEEeewALXL7BvPYw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_3_UTEEwEEeewALXL7BvPYw" base_StructuralFeature="_3_TsAkwEEeewALXL7BvPYw"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_FdQe4EwFEeewALXL7BvPYw" base_Association="_3_TE8EwEEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqIEkwFEeewALXL7BvPYw" base_Property="_nJqIEUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nJqvIEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqIEUwFEeewALXL7BvPYw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_3_U6IUwEEeewALXL7BvPYw" base_Property="_3_U6IEwEEeewALXL7BvPYw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_49ZE4EwEEeewALXL7BvPYw" base_StructuralFeature="_3_U6IEwEEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqvIkwFEeewALXL7BvPYw" base_Property="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nJrWMEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_uUXl0EwGEeewALXL7BvPYw" base_Association="_nJo58EwFEeewALXL7BvPYw"/>
@@ -1323,4 +1302,13 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelParameter xmi:id="_KCNMEYfiEeet-8tHdGGp_w" base_Parameter="_KCNMEIfiEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_207M8YfjEeet-8tHdGGp_w" base_StructuralFeature="_207M8IfjEeet-8tHdGGp_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2070AIfjEeet-8tHdGGp_w" base_Property="_207M8IfjEeet-8tHdGGp_w"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_IOhXAaeWEeeBGPv_1DT5og" base_Property="_IOhXAKeWEeeBGPv_1DT5og"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IOhXAqeWEeeBGPv_1DT5og" base_StructuralFeature="_IOhXAKeWEeeBGPv_1DT5og"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nPhusahLEeeAVfY3jqnvAA" base_StructuralFeature="_nPhusKhLEeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nPrfsKhLEeeAVfY3jqnvAA" base_Property="_nPhusKhLEeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sGvxs8ZaEeeAD9H5zOiMUQ" base_Property="_sGvxssZaEeeAD9H5zOiMUQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sGvxtMZaEeeAD9H5zOiMUQ" base_StructuralFeature="_sGvxssZaEeeAD9H5zOiMUQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sGwYwcZaEeeAD9H5zOiMUQ" base_Property="_sGwYwMZaEeeAD9H5zOiMUQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sGwYwsZaEeeAD9H5zOiMUQ" base_StructuralFeature="_sGwYwMZaEeeAD9H5zOiMUQ"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_zltdoMZaEeeAD9H5zOiMUQ" base_Association="_sGvKoMZaEeeAD9H5zOiMUQ"/>
 </xmi:XMI>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -460,44 +460,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W13n9EWlEeaB8vMnkFQLXQ" x="271" y="89"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_sZ2mIEWoEeaB8vMnkFQLXQ" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_sZ2mIkWoEeaB8vMnkFQLXQ" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_sZ2mI0WoEeaB8vMnkFQLXQ" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_sZ2mJEWoEeaB8vMnkFQLXQ" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_sZ2mJUWoEeaB8vMnkFQLXQ" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_yqGKQEWqEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pE76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_yqGKQUWqEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_yqGKQkWqEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pH76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_yqGKQ0WqEeaB8vMnkFQLXQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_yqGKREWqEeaB8vMnkFQLXQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pI76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_yqGKRUWqEeaB8vMnkFQLXQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_sZ2mJkWoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_sZ2mJ0WoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_sZ2mKEWoEeaB8vMnkFQLXQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sZ2mKUWoEeaB8vMnkFQLXQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_sZ2mKkWoEeaB8vMnkFQLXQ" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_sZ2mK0WoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_sZ2mLEWoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_sZ2mLUWoEeaB8vMnkFQLXQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sZ2mLkWoEeaB8vMnkFQLXQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_sZ2mL0WoEeaB8vMnkFQLXQ" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_sZ2mMEWoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_sZ2mMUWoEeaB8vMnkFQLXQ"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_sZ2mMkWoEeaB8vMnkFQLXQ"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sZ2mM0WoEeaB8vMnkFQLXQ"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sZ2mIUWoEeaB8vMnkFQLXQ" x="166" y="-197" height="92"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_saAXO0WoEeaB8vMnkFQLXQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_saAXPEWoEeaB8vMnkFQLXQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_saAXPkWoEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
@@ -538,7 +500,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Giml00WrEeaB8vMnkFQLXQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GimlwUWrEeaB8vMnkFQLXQ" x="595" y="-211" width="137" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GimlwUWrEeaB8vMnkFQLXQ" x="64" y="-113" width="137" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Givvy0WrEeaB8vMnkFQLXQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_GivvzEWrEeaB8vMnkFQLXQ" showTitle="true"/>
@@ -580,7 +542,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TLA300WrEeaB8vMnkFQLXQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TLA3wUWrEeaB8vMnkFQLXQ" x="594" y="-143" width="140" height="56"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TLA3wUWrEeaB8vMnkFQLXQ" x="432" y="-117" width="140" height="56"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TLTyukWrEeaB8vMnkFQLXQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_TLTyu0WrEeaB8vMnkFQLXQ" showTitle="true"/>
@@ -644,21 +606,21 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_I0TtNUWsEeaB8vMnkFQLXQ" x="127" y="32"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_95QhMxNJEeeQQtMBY9ly8w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_95QhNBNJEeeQQtMBY9ly8w" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_95QhNhNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_06Zv0BNJEeeQQtMBY9ly8w"/>
+    <children xmi:type="notation:Shape" xmi:id="_l31pIMivEees0-2jg5eWTg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_l31pIcivEees0-2jg5eWTg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l31pI8ivEees0-2jg5eWTg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_isDCkMivEees0-2jg5eWTg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_95QhNRNJEeeQQtMBY9ly8w" x="220" y="-82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l31pIsivEees0-2jg5eWTg" x="527" y="-88"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="__MlxUxNJEeeQQtMBY9ly8w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="__MlxVBNJEeeQQtMBY9ly8w" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MlxVhNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_3EC84BNJEeeQQtMBY9ly8w"/>
+    <children xmi:type="notation:Shape" xmi:id="_nAesMMivEees0-2jg5eWTg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nAesMcivEees0-2jg5eWTg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nAesM8ivEees0-2jg5eWTg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_earUAMivEees0-2jg5eWTg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__MlxVRNJEeeQQtMBY9ly8w" x="527" y="-88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nAesMsivEees0-2jg5eWTg" x="220" y="-82"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Oq90sTN7Eea40e5DA9KE3w" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Oq90sjN7Eea40e5DA9KE3w"/>
@@ -726,7 +688,7 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_VBVDsEWsEeaB8vMnkFQLXQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_VBVDsUWsEeaB8vMnkFQLXQ" key="visible" value="true"/>
         </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUTGMTN-Eea40e5DA9KE3w" x="-12" y="21"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUTGMTN-Eea40e5DA9KE3w" x="-47" y="24"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_IUR4ETN-Eea40e5DA9KE3w"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_ITi4QDN-Eea40e5DA9KE3w"/>
@@ -890,16 +852,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n-UWlEeaB8vMnkFQLXQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W13n-kWlEeaB8vMnkFQLXQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_saAXP0WoEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_sZ2mIEWoEeaB8vMnkFQLXQ" target="_saAXO0WoEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_saAXQEWoEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_saAXREWoEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_saAXQUWoEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_saAXQkWoEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_saAXQ0WoEeaB8vMnkFQLXQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xJRiqkWoEeaB8vMnkFQLXQ" type="StereotypeCommentLink" target="_xJRipkWoEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_xJRiq0WoEeaB8vMnkFQLXQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xJRir0WoEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
@@ -920,41 +872,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Givv0kWrEeaB8vMnkFQLXQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Givv00WrEeaB8vMnkFQLXQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_GjpHkEWrEeaB8vMnkFQLXQ" type="4001" source="_sZ2mIEWoEeaB8vMnkFQLXQ" target="_GimlwEWrEeaB8vMnkFQLXQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHk0WrEeaB8vMnkFQLXQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHlEWrEeaB8vMnkFQLXQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHlUWrEeaB8vMnkFQLXQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHlkWrEeaB8vMnkFQLXQ" x="-3" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHl0WrEeaB8vMnkFQLXQ" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHmEWrEeaB8vMnkFQLXQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHmUWrEeaB8vMnkFQLXQ" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHmkWrEeaB8vMnkFQLXQ" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHm0WrEeaB8vMnkFQLXQ" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHnEWrEeaB8vMnkFQLXQ" x="11" y="16"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_GjpHnUWrEeaB8vMnkFQLXQ" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_GjpHnkWrEeaB8vMnkFQLXQ" x="-10" y="16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_GjpHkUWrEeaB8vMnkFQLXQ"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GjpHkkWrEeaB8vMnkFQLXQ" points="[0, 0, 326, -115]$[-326, 115, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GjpHn0WrEeaB8vMnkFQLXQ" id="(1.0,0.11904761904761904)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GjpHoEWrEeaB8vMnkFQLXQ" id="(0.0,0.41379310344827586)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_GkFzikWrEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_GjpHkEWrEeaB8vMnkFQLXQ" target="_GkFzhkWrEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_GkFzi0WrEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GkFzj0WrEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GkFzjEWrEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GkFzjUWrEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GkFzjkWrEeaB8vMnkFQLXQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_TLTyvkWrEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_TLA3wEWrEeaB8vMnkFQLXQ" target="_TLTyukWrEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_TLTyv0WrEeaB8vMnkFQLXQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TLTyw0WrEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
@@ -964,41 +881,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TLTywEWrEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TLTywUWrEeaB8vMnkFQLXQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TLTywkWrEeaB8vMnkFQLXQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TMMjgEWrEeaB8vMnkFQLXQ" type="4001" source="_sZ2mIEWoEeaB8vMnkFQLXQ" target="_TLA3wEWrEeaB8vMnkFQLXQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMjg0WrEeaB8vMnkFQLXQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjhEWrEeaB8vMnkFQLXQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMjhUWrEeaB8vMnkFQLXQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjhkWrEeaB8vMnkFQLXQ" x="2" y="13"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMjh0WrEeaB8vMnkFQLXQ" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjiEWrEeaB8vMnkFQLXQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMjiUWrEeaB8vMnkFQLXQ" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjikWrEeaB8vMnkFQLXQ" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMji0WrEeaB8vMnkFQLXQ" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjjEWrEeaB8vMnkFQLXQ" x="9" y="19"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMMjjUWrEeaB8vMnkFQLXQ" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TMMjjkWrEeaB8vMnkFQLXQ" x="-9" y="18"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_TMMjgUWrEeaB8vMnkFQLXQ"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TMMjgkWrEeaB8vMnkFQLXQ" points="[0, 0, 326, -115]$[-326, 115, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMWUgEWrEeaB8vMnkFQLXQ" id="(1.0,0.8369565217391305)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMWUgUWrEeaB8vMnkFQLXQ" id="(0.0,0.39285714285714285)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TM8KakWrEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_TMMjgEWrEeaB8vMnkFQLXQ" target="_TM8KZkWrEeaB8vMnkFQLXQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TM8Ka0WrEeaB8vMnkFQLXQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TM8Kb0WrEeaB8vMnkFQLXQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_hv9NsNnYEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TM8KbEWrEeaB8vMnkFQLXQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TM8KbUWrEeaB8vMnkFQLXQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TM8KbkWrEeaB8vMnkFQLXQ"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Cpa4R0WsEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_Co1CYEWsEeaB8vMnkFQLXQ" target="_Cpa4Q0WsEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_Cpa4SEWsEeaB8vMnkFQLXQ"/>
@@ -1032,7 +914,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Iy9pYUWsEeaB8vMnkFQLXQ"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_IyE4kEWsEeaB8vMnkFQLXQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Iy9pYkWsEeaB8vMnkFQLXQ" points="[-2, 8, 60, -308]$[-83, 297, -21, -19]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I2F14EWsEeaB8vMnkFQLXQ" id="(0.3511450381679389,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I2F14EWsEeaB8vMnkFQLXQ" id="(0.3724696356275304,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I2F14UWsEeaB8vMnkFQLXQ" id="(0.50199203187251,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_I0c3IUWsEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_Iy9pYEWsEeaB8vMnkFQLXQ" target="_I0TtM0WsEeaB8vMnkFQLXQ">
@@ -1045,51 +927,51 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I0c3JEWsEeaB8vMnkFQLXQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_I0c3JUWsEeaB8vMnkFQLXQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_06Zv0RNJEeeQQtMBY9ly8w" type="4006" source="_Co1CYEWsEeaB8vMnkFQLXQ" target="_sZ2mIEWoEeaB8vMnkFQLXQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_06Zv1BNJEeeQQtMBY9ly8w" type="6014">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_06Zv1RNJEeeQQtMBY9ly8w" x="27" y="3"/>
+    <edges xmi:type="notation:Connector" xmi:id="_ea6kkMivEees0-2jg5eWTg" type="4006" source="_Co1CYEWsEeaB8vMnkFQLXQ" target="_GimlwEWrEeaB8vMnkFQLXQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ebBSQMivEees0-2jg5eWTg" type="6014">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ebBSQcivEees0-2jg5eWTg" x="5" y="5"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_06Zv1hNJEeeQQtMBY9ly8w" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_06Zv1xNJEeeQQtMBY9ly8w" x="4" y="2"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ebBSQsivEees0-2jg5eWTg" type="6015">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ebBSQ8ivEees0-2jg5eWTg" x="-16" y="1"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_06Zv0hNJEeeQQtMBY9ly8w"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_06Zv0BNJEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06Zv0xNJEeeQQtMBY9ly8w" points="[5, -9, -76, 131]$[66, -132, -15, 8]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_08NtsBNJEeeQQtMBY9ly8w" id="(0.6106870229007634,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_08NtsRNJEeeQQtMBY9ly8w" id="(0.05338078291814947,1.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ea6kkcivEees0-2jg5eWTg"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_earUAMivEees0-2jg5eWTg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ea6kksivEees0-2jg5eWTg" points="[0, 0, -139, 86]$[160, -73, 21, 13]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eeNwMMivEees0-2jg5eWTg" id="(0.5546558704453441,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eeNwMcivEees0-2jg5eWTg" id="(0.6861313868613139,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3EC84RNJEeeQQtMBY9ly8w" type="4006" source="_T7eFADN7Eea40e5DA9KE3w" target="_sZ2mIEWoEeaB8vMnkFQLXQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_3EC85BNJEeeQQtMBY9ly8w" type="6014">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3EC85RNJEeeQQtMBY9ly8w" x="19" y="3"/>
+    <edges xmi:type="notation:Connector" xmi:id="_isFe0MivEees0-2jg5eWTg" type="4006" source="_T7eFADN7Eea40e5DA9KE3w" target="_TLA3wEWrEeaB8vMnkFQLXQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_isFe08ivEees0-2jg5eWTg" type="6014">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_isFe1MivEees0-2jg5eWTg" x="15" y="4"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_3EC85hNJEeeQQtMBY9ly8w" type="6015">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3EC85xNJEeeQQtMBY9ly8w" x="-3" y="-2"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_isFe1civEees0-2jg5eWTg" type="6015">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_isGF4MivEees0-2jg5eWTg" x="-5" y="-2"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_3EC84hNJEeeQQtMBY9ly8w"/>
-      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_3EC84BNJEeeQQtMBY9ly8w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3EC84xNJEeeQQtMBY9ly8w" points="[0, 0, -75, 133]$[120, -119, 45, 14]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3F5-EBNJEeeQQtMBY9ly8w" id="(0.29428571428571426,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3F5-ERNJEeeQQtMBY9ly8w" id="(0.9501779359430605,1.0)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_isFe0civEees0-2jg5eWTg"/>
+      <element xmi:type="uml:Abstraction" href="TapiEth.uml#_isDCkMivEees0-2jg5eWTg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_isFe0sivEees0-2jg5eWTg" points="[0, 0, -105, 129]$[244, -73, 139, 56]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iuw_YMivEees0-2jg5eWTg" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iuw_YcivEees0-2jg5eWTg" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_95QhNxNJEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_06Zv0RNJEeeQQtMBY9ly8w" target="_95QhMxNJEeeQQtMBY9ly8w">
-      <styles xmi:type="notation:FontStyle" xmi:id="_95QhOBNJEeeQQtMBY9ly8w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_95QhPBNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_06Zv0BNJEeeQQtMBY9ly8w"/>
+    <edges xmi:type="notation:Connector" xmi:id="_l31pJMivEees0-2jg5eWTg" type="StereotypeCommentLink" source="_isFe0MivEees0-2jg5eWTg" target="_l31pIMivEees0-2jg5eWTg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_l31pJcivEees0-2jg5eWTg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_l31pKcivEees0-2jg5eWTg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_isDCkMivEees0-2jg5eWTg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_95QhORNJEeeQQtMBY9ly8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_95QhOhNJEeeQQtMBY9ly8w"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_95QhOxNJEeeQQtMBY9ly8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l31pJsivEees0-2jg5eWTg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l31pJ8ivEees0-2jg5eWTg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l31pKMivEees0-2jg5eWTg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__MlxVxNJEeeQQtMBY9ly8w" type="StereotypeCommentLink" source="_3EC84RNJEeeQQtMBY9ly8w" target="__MlxUxNJEeeQQtMBY9ly8w">
-      <styles xmi:type="notation:FontStyle" xmi:id="__MlxWBNJEeeQQtMBY9ly8w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="__MlxXBNJEeeQQtMBY9ly8w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_3EC84BNJEeeQQtMBY9ly8w"/>
+    <edges xmi:type="notation:Connector" xmi:id="_nAesNMivEees0-2jg5eWTg" type="StereotypeCommentLink" source="_ea6kkMivEees0-2jg5eWTg" target="_nAesMMivEees0-2jg5eWTg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nAesNcivEees0-2jg5eWTg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nAesOcivEees0-2jg5eWTg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="TapiEth.uml#_earUAMivEees0-2jg5eWTg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MlxWRNJEeeQQtMBY9ly8w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MlxWhNJEeeQQtMBY9ly8w"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__MlxWxNJEeeQQtMBY9ly8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nAesNsivEees0-2jg5eWTg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nAesN8ivEees0-2jg5eWTg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nAesOMivEees0-2jg5eWTg"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -19,7 +19,7 @@
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_SdNnUJKmEdybINoKQq_hfQ" name="ObjectClasses">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SdNnUZKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
-      <packagedElement xmi:type="uml:Class" xmi:id="_7ySKwOuGEeGZr5p9Vdkojw" name="ConnectionPointAndAdapterPac">
+      <packagedElement xmi:type="uml:Class" xmi:id="_7ySKwOuGEeGZr5p9Vdkojw" name="EthCtpPac">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7ySKweuGEeGZr5p9Vdkojw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Osz7EOuHEeGZr5p9Vdkojw" name="auxiliaryFunctionPositionSequence" visibility="public" isOrdered="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_UtlxwOuHEeGZr5p9Vdkojw" annotatedElement="_Osz7EOuHEeGZr5p9Vdkojw">
@@ -215,12 +215,12 @@ Indicates the priority associated with the Partner’s System ID. If the aggrega
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_T7cP0DN7Eea40e5DA9KE3w" name="ConnectionEndPointLpSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__18Z0jN9Eea40e5DA9KE3w" name="_terminationSpec" type="_ACUEMOxFEeGzwM2Uvwf5Xw" aggregation="composite" association="__17LsDN9Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Class" xmi:id="_T7cP0DN7Eea40e5DA9KE3w" name="EthConnectionEndPointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__18Z0jN9Eea40e5DA9KE3w" name="_ethTerm" type="_ACUEMOxFEeGzwM2Uvwf5Xw" aggregation="composite" association="__17LsDN9Eea40e5DA9KE3w">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JC0N0EWtEeaB8vMnkFQLXQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JC0N0kWtEeaB8vMnkFQLXQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ITjfUjN-Eea40e5DA9KE3w" name="_adapterSpec" type="_7ySKwOuGEeGZr5p9Vdkojw" aggregation="composite" association="_ITi4QDN-Eea40e5DA9KE3w">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ITjfUjN-Eea40e5DA9KE3w" name="_ethCtp" type="_7ySKwOuGEeGZr5p9Vdkojw" aggregation="composite" association="_ITi4QDN-Eea40e5DA9KE3w">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ds3bAEWtEeaB8vMnkFQLXQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ds3bAkWtEeaB8vMnkFQLXQ" value="1"/>
         </ownedAttribute>
@@ -419,8 +419,8 @@ Note that the only significance of the GTCS function defined in G.8021 is the us
           </defaultValue>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="__0LJcEWrEeaB8vMnkFQLXQ" name="NodeEdgePointLpSpec">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_IyOCgkWsEeaB8vMnkFQLXQ" name="_terminationSpec" type="_fzLz0OxQEeGzwM2Uvwf5Xw" aggregation="composite" association="_IyE4kEWsEeaB8vMnkFQLXQ">
+      <packagedElement xmi:type="uml:Class" xmi:id="__0LJcEWrEeaB8vMnkFQLXQ" name="EthNodeEdgePointSpec">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IyOCgkWsEeaB8vMnkFQLXQ" name="_etyTerm" type="_fzLz0OxQEeGzwM2Uvwf5Xw" aggregation="composite" association="_IyE4kEWsEeaB8vMnkFQLXQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_EqOc8EWtEeaB8vMnkFQLXQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_EqOc8kWtEeaB8vMnkFQLXQ" value="1"/>
         </ownedAttribute>
@@ -1129,7 +1129,7 @@ DEI = Drop Eligibility Indicator</body>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_x3G-wDxBEeaRI-H69PghuA" name="Associations">
-      <packagedElement xmi:type="uml:Association" xmi:id="_ITi4QDN-Eea40e5DA9KE3w" name="LpSpecHasAdapterPac" memberEnd="_ITjfUjN-Eea40e5DA9KE3w _ITkGYDN-Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_ITi4QDN-Eea40e5DA9KE3w" name="EthCepSpecHasCtpPac" memberEnd="_ITjfUjN-Eea40e5DA9KE3w _ITkGYDN-Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ITjfUDN-Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ITjfUTN-Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
@@ -1147,28 +1147,29 @@ DEI = Drop Eligibility Indicator</body>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_AbzosDO6Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_AbxMcDO6Eea40e5DA9KE3w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="__17LsDN9Eea40e5DA9KE3w" name="LpSpecHasTerminationPac" memberEnd="__18Z0jN9Eea40e5DA9KE3w __19A4DN9Eea40e5DA9KE3w">
+      <packagedElement xmi:type="uml:Association" xmi:id="__17LsDN9Eea40e5DA9KE3w" name="EthCepSpecHasTermPac" memberEnd="__18Z0jN9Eea40e5DA9KE3w __19A4DN9Eea40e5DA9KE3w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__18Z0DN9Eea40e5DA9KE3w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__18Z0TN9Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="__19A4DN9Eea40e5DA9KE3w" name="_lpSpec" type="_T7cP0DN7Eea40e5DA9KE3w" association="__17LsDN9Eea40e5DA9KE3w"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_IyE4kEWsEeaB8vMnkFQLXQ" name="NodeEPSpecHasTerminationPac" memberEnd="_IyOCgkWsEeaB8vMnkFQLXQ _IyOChUWsEeaB8vMnkFQLXQ">
+      <packagedElement xmi:type="uml:Association" xmi:id="_IyE4kEWsEeaB8vMnkFQLXQ" name="EthNepSpecHasEtyTermPac" memberEnd="_IyOCgkWsEeaB8vMnkFQLXQ _IyOChUWsEeaB8vMnkFQLXQ">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IyOCgEWsEeaB8vMnkFQLXQ" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IyOCgUWsEeaB8vMnkFQLXQ" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_IyOChUWsEeaB8vMnkFQLXQ" name="_lpSpec" type="__0LJcEWrEeaB8vMnkFQLXQ" association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_3EC84BNJEeeQQtMBY9ly8w" name="CepLpSpecAugmentsLp" client="_T7cP0DN7Eea40e5DA9KE3w">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_7tiFUBh_Eeeaw_DVk4Yi2w" annotatedElement="_3EC84BNJEeeQQtMBY9ly8w">
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_earUAMivEees0-2jg5eWTg" name="EthNepSpecAugmentsNep" client="__0LJcEWrEeaB8vMnkFQLXQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Lvfx0MiwEees0-2jg5eWTg" annotatedElement="_earUAMivEees0-2jg5eWTg">
+          <body>Augments the base LayerProtocol information in NodeEndPoint with ETH-specific information</body>
+        </ownedComment>
+        <supplier xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Abstraction" xmi:id="_isDCkMivEees0-2jg5eWTg" name="EthCepSpecAugmentsCep" client="_T7cP0DN7Eea40e5DA9KE3w">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_MwHhUMiwEees0-2jg5eWTg" annotatedElement="_isDCkMivEees0-2jg5eWTg">
           <body>Augments the base LayerProtocol information in ConnectionEndPoint with ETH-specific information</body>
         </ownedComment>
-        <supplier xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Abstraction" xmi:id="_06Zv0BNJEeeQQtMBY9ly8w" name="NepLpSpecAugmentsLp" client="__0LJcEWrEeaB8vMnkFQLXQ" supplier="_MP5wgJKmEdybINoKQq_hfQ">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_I0pFgBiAEeeaw_DVk4Yi2w" annotatedElement="_06Zv0BNJEeeQQtMBY9ly8w">
-          <body>Augments the base LayerProtocol information in NodeEdgePoint with ETH-specific information</body>
-        </ownedComment>
+        <supplier xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_fhZtAEWoEeaB8vMnkFQLXQ" name="Imports">
@@ -4904,12 +4905,6 @@ DEI = Drop Eligibility Indicator</body>
   <InterfaceModel_Profile:InterfaceModelAttribute xmi:id="_zEB0IBM1Eee0L_IMWjydgQ" base_Property="_3D3B4DO5Eea40e5DA9KE3w"/>
   <InterfaceModel_Profile:InterfaceModelAttribute xmi:id="_zEB0IRM1Eee0L_IMWjydgQ" base_Property="_AbzosDO6Eea40e5DA9KE3w"/>
   <InterfaceModel_Profile:InterfaceModelAttribute xmi:id="_zEB0IhM1Eee0L_IMWjydgQ" base_Property="__19A4DN9Eea40e5DA9KE3w"/>
-  <OpenModel_Profile_3:Specify xmi:id="_95KakBNJEeeQQtMBY9ly8w" base_Abstraction="_06Zv0BNJEeeQQtMBY9ly8w">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiTopology:NodeEdgePoint:_layerProtocol</target>
-  </OpenModel_Profile_3:Specify>
-  <OpenModel_Profile_3:Specify xmi:id="__MfqsBNJEeeQQtMBY9ly8w" base_Abstraction="_3EC84BNJEeeQQtMBY9ly8w">
-    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:Connection:_connectionEndPoint/TapiConnectivity:ConnectionEndPoint:_layerProtocol</target>
-  </OpenModel_Profile_3:Specify>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7oghhsEeewCs0lkpWskw" base_Property="_IyOChUWsEeaB8vMnkFQLXQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7ogxhsEeewCs0lkpWskw" base_Property="_Osz7EOuHEeGZr5p9Vdkojw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jW7ohBhsEeewCs0lkpWskw" base_Property="_VAOosziEEeGKKvtWtO2aIg"/>
@@ -5021,4 +5016,10 @@ DEI = Drop Eligibility Indicator</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_A7kjw1qoEeexvMtO2oNM9g" base_Class="_8QR1UK4wEeGjbtFXtCFKWg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_A7lK0FqoEeexvMtO2oNM9g" base_Class="_8QIrYK4wEeGjbtFXtCFKWg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_A7lK0VqoEeexvMtO2oNM9g" base_Class="__0LJcEWrEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_3:Specify xmi:id="_l3j8UMivEees0-2jg5eWTg" base_Abstraction="_isDCkMivEees0-2jg5eWTg">
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint/TapiConnectivity:CepList:_connectionEndPoint</target>
+  </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:Specify xmi:id="_nAWJUMivEees0-2jg5eWTg" base_Abstraction="_earUAMivEees0-2jg5eWTg">
+    <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint</target>
+  </OpenModel_Profile_3:Specify>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -413,89 +413,47 @@
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_JS4dIDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="EdgePointDetails" measurementUnit="Pixel">
-    <children xmi:type="notation:Shape" xmi:id="_NPs4HTBDEea4fKwSGMr6CA" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4HjBDEea4fKwSGMr6CA" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4HzBDEea4fKwSGMr6CA" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4IDBDEea4fKwSGMr6CA" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_NPs4ITBDEea4fKwSGMr6CA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_NPs4QjBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pE76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4YTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_NPs4YjBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pH76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4gTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_NPs4gjBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_r01pI76nEeWRz-VHgA3LJQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4oTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_NPs4ojBDEea4fKwSGMr6CA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4wTBDEea4fKwSGMr6CA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_mYLU8BMnEee0L_IMWjydgQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_mYLU8RMnEee0L_IMWjydgQ"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_NPs4wjBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_NPs4wzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_NPs4xDBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NPs4xTBDEea4fKwSGMr6CA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_NPs4xjBDEea4fKwSGMr6CA" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_NPs4xzBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_NPs4yDBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_NPs4yTBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NPs4yjBDEea4fKwSGMr6CA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_NPs4yzBDEea4fKwSGMr6CA" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_NPs4zDBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_NPs4zTBDEea4fKwSGMr6CA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_NPs4zjBDEea4fKwSGMr6CA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NPs4zzBDEea4fKwSGMr6CA"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NPs4_TBDEea4fKwSGMr6CA" x="520" y="218" width="289" height="130"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_NPs5UzBDEea4fKwSGMr6CA" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_NPs5VDBDEea4fKwSGMr6CA" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_NPs5VTBDEea4fKwSGMr6CA" type="8510">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs5VjBDEea4fKwSGMr6CA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_NPs5VzBDEea4fKwSGMr6CA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_icq2QMFlEeaALJQAf08uAg" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_0rYyYtnXEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icq2QcFlEeaALJQAf08uAg"/>
+        <children xmi:type="notation:Shape" xmi:id="_EneVgMZbEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiTopology.uml#_qpAjEKg3EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EneVgcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icq2QsFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Ene8kMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_G1pfM9nfEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icq2Q8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ene8kcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icw84MFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Ene8ksZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_MM6iEEHBEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icw84cFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ene8k8ZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icw84sFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_EnfjoMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_STzYA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icw848FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EnfjocZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icw85sFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_EnfjosZbEeeAD9H5zOiMUQ" type="3012">
+          <element xmi:type="uml:Property" href="TapiTopology.uml#_UbQckqg5EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Enfjo8ZbEeeAD9H5zOiMUQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_EnfjpMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdVA2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icw858FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EnfjpcZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_icw86MFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_EngKsMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdU-2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_icw86cFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngKscZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_gxs0oBMnEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_EngKssZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gxs0oRMnEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngKs8ZbEeeAD9H5zOiMUQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_gxs0ohMnEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_EngxwMZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_gxs0oxMnEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngxwcZbEeeAD9H5zOiMUQ"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NPs5_zBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NPs6ADBDEea4fKwSGMr6CA"/>
@@ -554,14 +512,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NP2C5DBDEea4fKwSGMr6CA" x="524" y="69" height="93"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_EpDuLzBKEeaSroGqGbZ6jg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_EpDuMDBKEeaSroGqGbZ6jg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EpDuMjBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EpDuMTBKEeaSroGqGbZ6jg" x="626" y="240"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EpWpODBKEeaSroGqGbZ6jg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_EpWpOTBKEeaSroGqGbZ6jg" showTitle="true"/>
@@ -627,7 +577,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9hBpQ1SgEeacRKRpk6W3Lw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9hBpMVSgEeacRKRpk6W3Lw" x="168" y="395" width="164" height="82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9hBpMVSgEeacRKRpk6W3Lw" x="144" y="367" width="164" height="82"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9hUkI1SgEeacRKRpk6W3Lw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9hUkJFSgEeacRKRpk6W3Lw" showTitle="true"/>
@@ -645,14 +595,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jQd1VSgEeacRKRpk6W3Lw" x="409" y="315"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_mDzRXxMwEee0L_IMWjydgQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_mDzRYBMwEee0L_IMWjydgQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mDzRYhMwEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mDzRYRMwEee0L_IMWjydgQ" x="720" y="118"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_mEMTExMwEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_mEMTFBMwEee0L_IMWjydgQ" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mEMTFhMwEee0L_IMWjydgQ" name="BASE_ELEMENT">
@@ -661,37 +603,78 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mEMTFRMwEee0L_IMWjydgQ" x="188" y="-17"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_RnAzUKg5EeeAVfY3jqnvAA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_RnAzUqg5EeeAVfY3jqnvAA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_RnAzU6g5EeeAVfY3jqnvAA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_RnAzVKg5EeeAVfY3jqnvAA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RnAzVag5EeeAVfY3jqnvAA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_jJkrIKg5EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Ucqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jJkrIag5EeeAVfY3jqnvAA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jJlSMKg5EeeAVfY3jqnvAA" type="3012">
+          <element xmi:type="uml:Property" href="TapiCommon.uml#_7n4Udqg2EeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jJlSMag5EeeAVfY3jqnvAA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RnAzVqg5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RnAzV6g5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RnAzWKg5EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzWag5EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RnAzWqg5EeeAVfY3jqnvAA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RnAzW6g5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RnAzXKg5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RnAzXag5EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzXqg5EeeAVfY3jqnvAA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_RnAzX6g5EeeAVfY3jqnvAA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_RnAzYKg5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_RnAzYag5EeeAVfY3jqnvAA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_RnAzYqg5EeeAVfY3jqnvAA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzY6g5EeeAVfY3jqnvAA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnAzUag5EeeAVfY3jqnvAA" x="526" y="206" height="87"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_RnIIE6g5EeeAVfY3jqnvAA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_RnIIFKg5EeeAVfY3jqnvAA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RnIIFqg5EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RnIIFag5EeeAVfY3jqnvAA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_eDcusMZdEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eDcuscZdEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eDdVwMZdEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eDcussZdEeeAD9H5zOiMUQ" x="726" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_JR4K8MZiEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_JR4K8cZiEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JR4K88ZiEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JR4K8sZiEeeAD9H5zOiMUQ" x="726" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_oBGxAMZlEeeAD9H5zOiMUQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_oBGxAcZlEeeAD9H5zOiMUQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oBGxA8ZlEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oBGxAsZlEeeAD9H5zOiMUQ" x="726" y="106"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_JS4dITBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_JS4dIjBDEea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_JS4dIzBDEea4fKwSGMr6CA">
       <owner xmi:type="uml:Package" href="TapiTopology.uml#_SXc0sC5xEea0_JngOlSKcA"/>
     </styles>
     <element xmi:type="uml:Package" href="TapiTopology.uml#_SXc0sC5xEea0_JngOlSKcA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_NPs4BjBDEea4fKwSGMr6CA" type="4001" source="_NPs4HTBDEea4fKwSGMr6CA" target="_NPs5UzBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4BzBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4CDBDEea4fKwSGMr6CA" x="1" y="-12"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4CTBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4CjBDEea4fKwSGMr6CA" x="-1" y="14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4CzBDEea4fKwSGMr6CA" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4DDBDEea4fKwSGMr6CA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4DTBDEea4fKwSGMr6CA" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4DjBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4DzBDEea4fKwSGMr6CA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4EDBDEea4fKwSGMr6CA" x="12" y="-16"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_NPs4ETBDEea4fKwSGMr6CA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs4EjBDEea4fKwSGMr6CA" x="-9" y="-17"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_NPs4EzBDEea4fKwSGMr6CA"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NPs4GjBDEea4fKwSGMr6CA" points="[9, -54, -22, 119]$[31, -173, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs4GzBDEea4fKwSGMr6CA" id="(0.0,0.23076923076923078)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs4HDBDEea4fKwSGMr6CA" id="(1.0,0.8009708737864077)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_NPs5BDBDEea4fKwSGMr6CA" type="4001" source="_NPs5UzBDEea4fKwSGMr6CA" target="_NP2CRDBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_NPs5BTBDEea4fKwSGMr6CA" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs5BjBDEea4fKwSGMr6CA" x="5" y="8"/>
@@ -719,16 +702,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NPs5GjBDEea4fKwSGMr6CA" points="[-10, 24, 28, -74]$[-46, 79, -8, -19]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs5GzBDEea4fKwSGMr6CA" id="(1.0,0.14563106796116504)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NPs5HDBDEea4fKwSGMr6CA" id="(0.0,0.45161290322580644)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_EpDuMzBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_NPs4HTBDEea4fKwSGMr6CA" target="_EpDuLzBKEeaSroGqGbZ6jg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_EpDuNDBKEeaSroGqGbZ6jg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EpDuODBKEeaSroGqGbZ6jg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EpDuNTBKEeaSroGqGbZ6jg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EpDuNjBKEeaSroGqGbZ6jg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EpDuNzBKEeaSroGqGbZ6jg"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EpWpPDBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_NPs5UzBDEea4fKwSGMr6CA" target="_EpWpODBKEeaSroGqGbZ6jg">
       <styles xmi:type="notation:FontStyle" xmi:id="_EpWpPTBKEeaSroGqGbZ6jg"/>
@@ -771,9 +744,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_yLrhkVSgEeacRKRpk6W3Lw"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_G1pfMNnfEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yLrhklSgEeacRKRpk6W3Lw" points="[0, 0, 177, 0]$[0, 44, 177, 44]$[-177, 44, 0, 44]$[-177, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLrhn1SgEeacRKRpk6W3Lw" id="(0.5830388692579506,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLrhoFSgEeacRKRpk6W3Lw" id="(0.05653710247349823,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yLrhklSgEeacRKRpk6W3Lw" points="[0, 0, 139, 0]$[0, 44, 139, 44]$[-139, 44, 0, 44]$[-139, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLrhn1SgEeacRKRpk6W3Lw" id="(0.46865671641791046,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yLrhoFSgEeacRKRpk6W3Lw" id="(0.05373134328358209,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_yL-ch1SgEeacRKRpk6W3Lw" type="StereotypeCommentLink" source="_yLrhkFSgEeacRKRpk6W3Lw" target="_yL-cg1SgEeacRKRpk6W3Lw">
       <styles xmi:type="notation:FontStyle" xmi:id="_yL-ciFSgEeacRKRpk6W3Lw"/>
@@ -818,7 +791,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_MM4s4EHBEeWqPKyD1j6LMg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9ig28lSgEeacRKRpk6W3Lw" points="[0, 0, 12, -153]$[-12, 153, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ig2_1SgEeacRKRpk6W3Lw" id="(0.5365853658536586,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ig3AFSgEeacRKRpk6W3Lw" id="(0.8029850746268656,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ig3AFSgEeacRKRpk6W3Lw" id="(0.7283582089552239,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9jQd11SgEeacRKRpk6W3Lw" type="StereotypeCommentLink" source="_9ig28FSgEeacRKRpk6W3Lw" target="_9jQd01SgEeacRKRpk6W3Lw">
       <styles xmi:type="notation:FontStyle" xmi:id="_9jQd2FSgEeacRKRpk6W3Lw"/>
@@ -830,16 +803,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jQd2lSgEeacRKRpk6W3Lw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jQd21SgEeacRKRpk6W3Lw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mDzRYxMwEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_NPs4BjBDEea4fKwSGMr6CA" target="_mDzRXxMwEee0L_IMWjydgQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_mDzRZBMwEee0L_IMWjydgQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mDzRaBMwEee0L_IMWjydgQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_0rPocNnXEeWIOYiRCk5bbQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mDzRZRMwEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mDzRZhMwEee0L_IMWjydgQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mDzRZxMwEee0L_IMWjydgQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_mEMTFxMwEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_NPs5BDBDEea4fKwSGMr6CA" target="_mEMTExMwEee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_mEMTGBMwEee0L_IMWjydgQ"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mEMTHBMwEee0L_IMWjydgQ" name="BASE_ELEMENT">
@@ -849,6 +812,81 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mEMTGRMwEee0L_IMWjydgQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mEMTGhMwEee0L_IMWjydgQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mEMTGxMwEee0L_IMWjydgQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_RnIIF6g5EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_RnAzUKg5EeeAVfY3jqnvAA" target="_RnIIE6g5EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_RnIIGKg5EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_RnIIHKg5EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RnIIGag5EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RnIIGqg5EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RnIIG6g5EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Uco8oKg5EeeAVfY3jqnvAA" type="4001" source="_RnAzUKg5EeeAVfY3jqnvAA" target="_NPs5UzBDEea4fKwSGMr6CA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Uco8o6g5EeeAVfY3jqnvAA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Uco8pKg5EeeAVfY3jqnvAA" x="7" y="-7"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UcpjsKg5EeeAVfY3jqnvAA" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ucpjsag5EeeAVfY3jqnvAA" y="8"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ucpjsqg5EeeAVfY3jqnvAA" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ucpjs6g5EeeAVfY3jqnvAA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UcpjtKg5EeeAVfY3jqnvAA" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ucpjtag5EeeAVfY3jqnvAA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ucpjtqg5EeeAVfY3jqnvAA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ucpjt6g5EeeAVfY3jqnvAA" x="6" y="-18"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UcpjuKg5EeeAVfY3jqnvAA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Ucpjuag5EeeAVfY3jqnvAA" x="-8" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Uco8oag5EeeAVfY3jqnvAA"/>
+      <element xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uco8oqg5EeeAVfY3jqnvAA" points="[0, 0, 237, 72]$[-237, -9, 0, 63]$[-237, -72, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1PcKg5EeeAVfY3jqnvAA" id="(0.0,0.42528735632183906)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ud1Pcag5EeeAVfY3jqnvAA" id="(1.0,0.7766990291262136)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iWsctKg5EeeAVfY3jqnvAA" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iWsctag5EeeAVfY3jqnvAA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iWscuag5EeeAVfY3jqnvAA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iWsctqg5EeeAVfY3jqnvAA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWsct6g5EeeAVfY3jqnvAA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWscuKg5EeeAVfY3jqnvAA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eDdVwcZdEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_eDcusMZdEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eDdVwsZdEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eDdVxsZdEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eDdVw8ZdEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eDdVxMZdEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eDdVxcZdEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JR4K9MZiEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_JR4K8MZiEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JR4K9cZiEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JR4K-cZiEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JR4K9sZiEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JR4K98ZiEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JR4K-MZiEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oBGxBMZlEeeAD9H5zOiMUQ" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_oBGxAMZlEeeAD9H5zOiMUQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_oBGxBcZlEeeAD9H5zOiMUQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oBGxCcZlEeeAD9H5zOiMUQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oBGxBsZlEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oBGxB8ZlEeeAD9H5zOiMUQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oBGxCMZlEeeAD9H5zOiMUQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SFF5oDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceDetails" measurementUnit="Pixel">

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -56,12 +56,6 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="__EdnwN71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="__ET2wN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_0rPocNnXEeWIOYiRCk5bbQ" name="NodeEPIncludesLP" memberEnd="_0rYyYtnXEeWIOYiRCk5bbQ _0rYyZNnXEeWIOYiRCk5bbQ">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0rYyYNnXEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0rYyYdnXEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_0rYyZNnXEeWIOYiRCk5bbQ" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_0rPocNnXEeWIOYiRCk5bbQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_tOFAkN7rEeW-BtRsuJPbqg" name="NodeHasCapacityPac" memberEnd="_tOFAk97rEeW-BtRsuJPbqg _tOFAld7rEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tOFAkd7rEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tOFAkt7rEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
@@ -302,6 +296,12 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_Wi58shl6EeeV4o0osG5stg" name="noderulegroup" type="_xDuuoBk7EeeV4o0osG5stg" association="_Wiz2EBl6EeeV4o0osG5stg"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_UbP1gKg5EeeAVfY3jqnvAA" name="NEPHasTerminationPac" memberEnd="_UbQckqg5EeeAVfY3jqnvAA _UbRqsKg5EeeAVfY3jqnvAA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_UbQckKg5EeeAVfY3jqnvAA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_UbQckag5EeeAVfY3jqnvAA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_UbRqsKg5EeeAVfY3jqnvAA" name="nodeedgepoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_QOoHAC5xEea0_JngOlSKcA" name="Imports">
@@ -522,10 +522,8 @@ The structure of LTP supports all transport protocols including circuit and pack
         <generalization xmi:type="uml:Generalization" xmi:id="_3vF8gO_nEeWLlrwIF3w0vA">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rYyYtnXEeWIOYiRCk5bbQ" name="_layerProtocol" isReadOnly="true" aggregation="composite" association="_0rPocNnXEeWIOYiRCk5bbQ">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OlnfwNnYEeWIOYiRCk5bbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OlnfwdnYEeWIOYiRCk5bbQ" value="*"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qpAjEKg3EeeAVfY3jqnvAA" name="layerProtocolName" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_G1pfM9nfEeWIOYiRCk5bbQ" name="_aggregatedNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" aggregation="shared" association="_G1pfMNnfEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UMztkNnfEeWIOYiRCk5bbQ"/>
@@ -541,6 +539,9 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_STzYA-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_STzYAO_tEeWLlrwIF3w0vA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UbQckqg5EeeAVfY3jqnvAA" name="_termination" isReadOnly="true" aggregation="composite" association="_UbP1gKg5EeeAVfY3jqnvAA">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_7n4UcKg2EeeAVfY3jqnvAA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7vdVA2h_EeWZEqTYAF8eqA" name="linkPortDirection" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_7vdVBGh_EeWZEqTYAF8eqA" annotatedElement="_7vdVA2h_EeWZEqTYAF8eqA">
@@ -1016,8 +1017,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelParameter xmi:id="_qRQggbsEEeWYrqoqXLgguw" base_Parameter="_qRQggLsEEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_yctfAbsEEeWYrqoqXLgguw" base_Parameter="_yctfALsEEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_2nCKYbsEEeWYrqoqXLgguw" base_Parameter="_2nCKYLsEEeWYrqoqXLgguw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyY9nXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyYtnXEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyZdnXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyZNnXEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_G1pfNNnfEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfM9nfEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_G1pfNtnfEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfNdnfEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuYNv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRqw9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
@@ -1092,7 +1091,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelOperation xmi:id="_M2tARPVKEeWQB8HQFBfkJQ" base_Operation="_M2tAQPVKEeWQB8HQFBfkJQ"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_EGReIP5BEeSIs5T3yQwyyw" base_Operation="_taDjMPMvEeSb-q8_djA2ng"/>
   <OpenModel_Profile:OpenModelOperation xmi:id="_taDjMfMvEeSb-q8_djA2ng" base_Operation="_taDjMPMvEeSb-q8_djA2ng"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_IAP54C59Eea0_JngOlSKcA" base_Association="_0rPocNnXEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_xImb4-K4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_xImb6eK4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_xImb6uK4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
@@ -1135,7 +1133,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rUBhsEeewCs0lkpWskw" base_Property="_kZ4bhd71EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rURhsEeewCs0lkpWskw" base_Property="_CM28Fd72EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rUhhsEeewCs0lkpWskw" base_Property="__EdnwN71EeW-BtRsuJPbqg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rUxhsEeewCs0lkpWskw" base_Property="_0rYyZNnXEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rVBhsEeewCs0lkpWskw" base_Property="_tOFAld7rEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rVRhsEeewCs0lkpWskw" base_Property="_7DmpIN7vEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rVhhsEeewCs0lkpWskw" base_Property="_lqLYBd7wEeW-BtRsuJPbqg"/>
@@ -1178,7 +1175,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_MBhsEeewCs0lkpWskw" base_Property="_Gkdvkj_DEeWNAdBR30aJhw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_MRhsEeewCs0lkpWskw" base_Property="_ejyEhOKyEeSq5fATALSQkQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_MhhsEeewCs0lkpWskw" base_Property="_KjZW_9yKEeWXdJnxZxtFYA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_MxhsEeewCs0lkpWskw" base_Property="_0rYyYtnXEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NBhsEeewCs0lkpWskw" base_Property="_G1pfM9nfEeWIOYiRCk5bbQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NRhsEeewCs0lkpWskw" base_Property="_MM6iEEHBEeWqPKyD1j6LMg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PDI_NhhsEeewCs0lkpWskw" base_Property="_STzYA-_tEeWLlrwIF3w0vA"/>
@@ -1319,4 +1315,11 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_D8PqgIfOEeeirpBaj87qAw" base_Property="_D8PDcIfOEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_6TXH4YfREeeirpBaj87qAw" base_StructuralFeature="_6TXH4IfREeeirpBaj87qAw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_6TXu8IfREeeirpBaj87qAw" base_Property="_6TXH4IfREeeirpBaj87qAw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qpAjEag3EeeAVfY3jqnvAA" base_StructuralFeature="_qpAjEKg3EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_qpBxMKg3EeeAVfY3jqnvAA" base_Property="_qpAjEKg3EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UbQck6g5EeeAVfY3jqnvAA" base_StructuralFeature="_UbQckqg5EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UbRDoKg5EeeAVfY3jqnvAA" base_Property="_UbQckqg5EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UbRqsag5EeeAVfY3jqnvAA" base_StructuralFeature="_UbRqsKg5EeeAVfY3jqnvAA"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_UbRqsqg5EeeAVfY3jqnvAA" base_Property="_UbRqsKg5EeeAVfY3jqnvAA"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_iWm9IKg5EeeAVfY3jqnvAA" base_Association="_UbP1gKg5EeeAVfY3jqnvAA"/>
 </xmi:XMI>

--- a/YANG/tapi-common.tree
+++ b/YANG/tapi-common.tree
@@ -1,14 +1,7 @@
 module: tapi-common
     +--rw context!
        +--rw service-interface-point* [uuid]
-       |  +--rw layer-protocol* [local-id]
-       |  |  +--rw layer-protocol-name?     layer-protocol-name
-       |  |  +--rw termination-direction?   termination-direction
-       |  |  +--rw termination-state?       termination-state
-       |  |  +--rw local-id                 string
-       |  |  +--rw name* [value-name]
-       |  |     +--rw value-name    string
-       |  |     +--rw value?        string
+       |  +--ro layer-protocol-name*   layer-protocol-name
        |  +--rw state
        |  |  +--rw administrative-state?   administrative-state
        |  |  +--ro operational-state?      operational-state
@@ -54,7 +47,7 @@ module: tapi-common
        |  |        |  +--ro unit?    capacity-unit
        |  |        +--ro color-aware?                  boolean
        |  |        +--ro coupling-flag?                boolean
-       |  +--rw uuid              uuid
+       |  +--rw uuid                   uuid
        |  +--rw name* [value-name]
        |     +--rw value-name    string
        |     +--rw value?        string
@@ -69,14 +62,7 @@ module: tapi-common
     |  |  +---w sip-id-or-name?   string
     |  +--ro output
     |     +--ro sip
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
+    |        +--ro layer-protocol-name*   layer-protocol-name
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
@@ -122,21 +108,14 @@ module: tapi-common
     |        |        |  +--ro unit?    capacity-unit
     |        |        +--ro color-aware?                  boolean
     |        |        +--ro coupling-flag?                boolean
-    |        +--ro uuid?             uuid
+    |        +--ro uuid?                  uuid
     |        +--ro name* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string
     +---x get-service-interface-point-list
     |  +--ro output
     |     +--ro sip*
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
+    |        +--ro layer-protocol-name*   layer-protocol-name
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
@@ -182,7 +161,7 @@ module: tapi-common
     |        |        |  +--ro unit?    capacity-unit
     |        |        +--ro color-aware?                  boolean
     |        |        +--ro coupling-flag?                boolean
-    |        +--ro uuid?             uuid
+    |        +--ro uuid?                  uuid
     |        +--ro name* [value-name]
     |           +--ro value-name    string
     |           +--ro value?        string

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -47,27 +47,6 @@ module tapi-common {
             }
             description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
         }
-        grouping layer-protocol {
-            leaf layer-protocol-name {
-                type layer-protocol-name;
-                description "Indicate the specific layer-protocol described by the LayerProtocol entity.";
-            }
-            leaf termination-direction {
-                type termination-direction;
-                description "The overall directionality of the LP. 
-                    - A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.
-                    - A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows
-                    - A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows";
-            }
-            leaf termination-state {
-                type termination-state;
-                description "Indicates whether the layer is terminated and if so how.";
-            }
-            uses local-class;
-            description "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. 
-                It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. 
-                Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ";
-        }
         grouping lifecycle-state-pac {
             leaf lifecycle-state {
                 type lifecycle-state;
@@ -125,11 +104,11 @@ module tapi-common {
             description "none";
         }
         grouping service-interface-point {
-            list layer-protocol {
-                key 'local-id';
+            leaf-list layer-protocol-name {
+                type layer-protocol-name;
+                config false;
                 min-elements 1;
-                uses layer-protocol;
-                description "Usage of layerProtocol [>1]  in the ServiceInterfacePoint should be considered experimental";
+                description "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental";
             }
             container state {
                 uses admin-state-pac;
@@ -160,6 +139,24 @@ module tapi-common {
                 The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.
                 Represents the capacity available to user (client) along with client interaction and usage. 
                 A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
+        }
+        grouping termination-pac {
+            leaf termination-direction {
+                type termination-direction;
+                config false;
+                description "The overall directionality of the LP. 
+                    - A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.
+                    - A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows
+                    - A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows";
+            }
+            leaf termination-state {
+                type termination-state;
+                config false;
+                description "Indicates whether the layer is terminated and if so how.";
+            }
+            description "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. 
+                It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. 
+                Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ";
         }
 
     /***********************

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -4,14 +4,7 @@ module: tapi-connectivity
     |  +--rw end-point* [local-id]
     |  |  +--rw service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |  |  +--rw layer-protocol* [local-id]
-    |  |  |  +--rw layer-protocol-name?     layer-protocol-name
-    |  |  |  +--rw termination-direction?   termination-direction
-    |  |  |  +--rw termination-state?       termination-state
-    |  |  |  +--rw local-id                 string
-    |  |  |  +--rw name* [value-name]
-    |  |  |     +--rw value-name    string
-    |  |  |     +--rw value?        string
+    |  |  +--rw layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  +--rw state
     |  |  |  +--rw administrative-state?   administrative-state
     |  |  |  +--ro operational-state?      operational-state
@@ -209,14 +202,7 @@ module: tapi-connectivity
           +--ro value?        string
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
     +--ro connection-end-point* [uuid]
-       +--ro layer-protocol* [local-id]
-       |  +--ro layer-protocol-name?     layer-protocol-name
-       |  +--ro termination-direction?   termination-direction
-       |  +--ro termination-state?       termination-state
-       |  +--ro local-id                 string
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
+       +--ro layer-protocol-name?         tapi-common:layer-protocol-name
        +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
@@ -224,6 +210,9 @@ module: tapi-connectivity
        +--ro state
        |  +--ro operational-state?   operational-state
        |  +--ro lifecycle-state?     lifecycle-state
+       +--ro termination
+       |  +--ro termination-direction?   termination-direction
+       |  +--ro termination-state?       termination-state
        +--ro connection-port-direction?   tapi-common:port-direction
        +--ro connection-port-role?        tapi-common:port-role
        +--ro uuid                         uuid
@@ -297,14 +286,7 @@ module: tapi-connectivity
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
+    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro state
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
@@ -454,14 +436,7 @@ module: tapi-connectivity
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
+    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro state
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
@@ -608,14 +583,7 @@ module: tapi-connectivity
     |  |  +---w end-point*
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |  |  |  +---w layer-protocol* [local-id]
-    |  |  |  |  +---w layer-protocol-name?     layer-protocol-name
-    |  |  |  |  +---w termination-direction?   termination-direction
-    |  |  |  |  +---w termination-state?       termination-state
-    |  |  |  |  +---w local-id                 string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
+    |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  |  +---w state
     |  |  |  |  +---w administrative-state?   administrative-state
     |  |  |  |  +---w operational-state?      operational-state
@@ -752,14 +720,7 @@ module: tapi-connectivity
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
+    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro state
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
@@ -907,14 +868,7 @@ module: tapi-connectivity
     |  |  +---w end-point
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |  |  |  +---w layer-protocol* [local-id]
-    |  |  |  |  +---w layer-protocol-name?     layer-protocol-name
-    |  |  |  |  +---w termination-direction?   termination-direction
-    |  |  |  |  +---w termination-state?       termination-state
-    |  |  |  |  +---w local-id                 string
-    |  |  |  |  +---w name* [value-name]
-    |  |  |  |     +---w value-name    string
-    |  |  |  |     +---w value?        string
+    |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
     |  |  |  +---w state
     |  |  |  |  +---w administrative-state?   administrative-state
     |  |  |  |  +---w operational-state?      operational-state
@@ -1051,14 +1005,7 @@ module: tapi-connectivity
     |        +--ro end-point* [local-id]
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
+    |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
     |        |  +--ro state
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
@@ -1208,14 +1155,7 @@ module: tapi-connectivity
              +--ro end-point* [local-id]
              |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
              |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-             |  +--ro layer-protocol* [local-id]
-             |  |  +--ro layer-protocol-name?     layer-protocol-name
-             |  |  +--ro termination-direction?   termination-direction
-             |  |  +--ro termination-state?       termination-state
-             |  |  +--ro local-id                 string
-             |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
+             |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
              |  +--ro state
              |  |  +--ro administrative-state?   administrative-state
              |  |  +--ro operational-state?      operational-state

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -95,11 +95,9 @@ module tapi-connectivity {
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
         grouping connection-end-point {
-            list layer-protocol {
-                key 'local-id';
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
-                min-elements 1;
-                uses tapi-common:layer-protocol;
                 description "none";
             }
             leaf-list client-node-edge-point {
@@ -132,6 +130,10 @@ module tapi-connectivity {
             container state {
                 config false;
                 uses tapi-common:operational-state-pac;
+                description "none";
+            }
+            container termination {
+                uses tapi-common:termination-pac;
                 description "none";
             }
             leaf connection-port-direction {
@@ -263,10 +265,8 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
-            list layer-protocol {
-                key 'local-id';
-                min-elements 1;
-                uses tapi-common:layer-protocol;
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 description "none";
             }
             container state {

--- a/YANG/tapi-eth.tree
+++ b/YANG/tapi-eth.tree
@@ -1,6 +1,12 @@
 module: tapi-eth
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol:
-    +--ro termination-spec
+  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
+    +--ro ety-term
+       +--ro is-fts-enabled?        boolean
+       +--ro is-tx-pause-enabled?   boolean
+       +--ro phy-type?              ety-phy-type
+       +--ro phy-type-list*         ety-phy-type
+  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
+    +--ro eth-term
     |  +--ro priority-regenerate
     |  |  +--ro priority-0?   uint64
     |  |  +--ro priority-1?   uint64
@@ -15,7 +21,7 @@ module: tapi-eth
     |  +--ro frametype-config?             frame-type
     |  +--ro port-vid?                     vid
     |  +--ro priority-code-point-config?   pcp-coding
-    +--ro adapter-spec
+    +--ro eth-ctp
        +--ro auxiliary-function-position-sequence*   uint64
        +--ro vlan-config?                            uint64
        +--ro csf-rdi-fdi-enable?                     boolean
@@ -90,9 +96,3 @@ module: tapi-eth
           |  +--ro colour-mode?     colour-mode
           |  +--ro queue-id?        uint64
           +--ro codirectional?      boolean
-  augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol:
-    +--ro termination-spec
-       +--ro is-fts-enabled?        boolean
-       +--ro is-tx-pause-enabled?   boolean
-       +--ro phy-type?              ety-phy-type
-       +--ro phy-type-list*         ety-phy-type

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -21,18 +21,18 @@ module tapi-eth {
         description "TAPI SDK 2.0-alpha";
         reference "ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:layer-protocol" {
-        uses connection-end-point-lp-spec;
-        description "Augments the base LayerProtocol information in ConnectionEndPoint with ETH-specific information";
+    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point" {
+        uses eth-node-edge-point-spec;
+        description "Augments the base LayerProtocol information in NodeEndPoint with ETH-specific information";
     }
-    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:layer-protocol" {
-        uses node-edge-point-lp-spec;
-        description "Augments the base LayerProtocol information in NodeEdgePoint with ETH-specific information";
+    augment "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point" {
+        uses eth-connection-end-point-spec;
+        description "Augments the base LayerProtocol information in ConnectionEndPoint with ETH-specific information";
     }
     /***********************
     * package object-classes
     **********************/ 
-        grouping connection-point-and-adapter-pac {
+        grouping eth-ctp-pac {
             leaf-list auxiliary-function-position-sequence {
                 type uint64;
                 description "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.";
@@ -153,13 +153,13 @@ module tapi-eth {
             }
             description "none";
         }
-        grouping connection-end-point-lp-spec {
-            container termination-spec {
+        grouping eth-connection-end-point-spec {
+            container eth-term {
                 uses eth-termination-pac;
                 description "none";
             }
-            container adapter-spec {
-                uses connection-point-and-adapter-pac;
+            container eth-ctp {
+                uses eth-ctp-pac;
                 description "none";
             }
             description "none";
@@ -283,8 +283,8 @@ module tapi-eth {
             description "This object class models the ETH traffic shaping function as defined in G.8021.
                 Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
         }
-        grouping node-edge-point-lp-spec {
-            container termination-spec {
+        grouping eth-node-edge-point-spec {
+            container ety-term {
                 uses ety-termination-pac;
                 description "none";
             }

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -9,20 +9,16 @@ module: tapi-topology
     +--ro topology* [uuid]
        +--ro node* [uuid]
        |  +--ro owned-node-edge-point* [uuid]
-       |  |  +--ro layer-protocol* [local-id]
-       |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-       |  |  |  +--ro termination-direction?   termination-direction
-       |  |  |  +--ro termination-state?       termination-state
-       |  |  |  +--ro local-id                 string
-       |  |  |  +--ro name* [value-name]
-       |  |  |     +--ro value-name    string
-       |  |  |     +--ro value?        string
+       |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
        |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
        |  |  +--ro state
        |  |  |  +--ro administrative-state?   administrative-state
        |  |  |  +--ro operational-state?      operational-state
        |  |  |  +--ro lifecycle-state?        lifecycle-state
+       |  |  +--ro termination
+       |  |  |  +--ro termination-direction?   termination-direction
+       |  |  |  +--ro termination-state?       termination-state
        |  |  +--ro link-port-direction?              tapi-common:port-direction
        |  |  +--ro link-port-role?                   tapi-common:port-role
        |  |  +--ro uuid                              uuid
@@ -344,20 +340,16 @@ module: tapi-topology
     |     +--ro topology
     |        +--ro node* [uuid]
     |        |  +--ro owned-node-edge-point* [uuid]
-    |        |  |  +--ro layer-protocol* [local-id]
-    |        |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  |  +--ro termination-direction?   termination-direction
-    |        |  |  |  +--ro termination-state?       termination-state
-    |        |  |  |  +--ro local-id                 string
-    |        |  |  |  +--ro name* [value-name]
-    |        |  |  |     +--ro value-name    string
-    |        |  |  |     +--ro value?        string
+    |        |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
     |        |  |  +--ro state
     |        |  |  |  +--ro administrative-state?   administrative-state
     |        |  |  |  +--ro operational-state?      operational-state
     |        |  |  |  +--ro lifecycle-state?        lifecycle-state
+    |        |  |  +--ro termination
+    |        |  |  |  +--ro termination-direction?   termination-direction
+    |        |  |  |  +--ro termination-state?       termination-state
     |        |  |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  |  +--ro link-port-role?                   tapi-common:port-role
     |        |  |  +--ro uuid                              uuid
@@ -677,20 +669,16 @@ module: tapi-topology
     |  +--ro output
     |     +--ro node
     |        +--ro owned-node-edge-point* [uuid]
-    |        |  +--ro layer-protocol* [local-id]
-    |        |  |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
-    |        |  |  +--ro local-id                 string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
+    |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro state
     |        |  |  +--ro administrative-state?   administrative-state
     |        |  |  +--ro operational-state?      operational-state
     |        |  |  +--ro lifecycle-state?        lifecycle-state
+    |        |  +--ro termination
+    |        |  |  +--ro termination-direction?   termination-direction
+    |        |  |  +--ro termination-state?       termination-state
     |        |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  +--ro link-port-role?                   tapi-common:port-role
     |        |  +--ro uuid                              uuid
@@ -918,20 +906,16 @@ module: tapi-topology
     |  |  +---w ep-id-or-name?         string
     |  +--ro output
     |     +--ro node-edge-point
-    |        +--ro layer-protocol* [local-id]
-    |        |  +--ro layer-protocol-name?     layer-protocol-name
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
-    |        |  +--ro local-id                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
+    |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
     |        +--ro state
     |        |  +--ro administrative-state?   administrative-state
     |        |  +--ro operational-state?      operational-state
     |        |  +--ro lifecycle-state?        lifecycle-state
+    |        +--ro termination
+    |        |  +--ro termination-direction?   termination-direction
+    |        |  +--ro termination-state?       termination-state
     |        +--ro link-port-direction?              tapi-common:port-direction
     |        +--ro link-port-role?                   tapi-common:port-role
     |        +--ro uuid?                             uuid
@@ -1035,20 +1019,16 @@ module: tapi-topology
           +--ro topology*
              +--ro node* [uuid]
              |  +--ro owned-node-edge-point* [uuid]
-             |  |  +--ro layer-protocol* [local-id]
-             |  |  |  +--ro layer-protocol-name?     layer-protocol-name
-             |  |  |  +--ro termination-direction?   termination-direction
-             |  |  |  +--ro termination-state?       termination-state
-             |  |  |  +--ro local-id                 string
-             |  |  |  +--ro name* [value-name]
-             |  |  |     +--ro value-name    string
-             |  |  |     +--ro value?        string
+             |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
              |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
              |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
              |  |  +--ro state
              |  |  |  +--ro administrative-state?   administrative-state
              |  |  |  +--ro operational-state?      operational-state
              |  |  |  +--ro lifecycle-state?        lifecycle-state
+             |  |  +--ro termination
+             |  |  |  +--ro termination-direction?   termination-direction
+             |  |  |  +--ro termination-state?       termination-state
              |  |  +--ro link-port-direction?              tapi-common:port-direction
              |  |  +--ro link-port-role?                   tapi-common:port-role
              |  |  +--ro uuid                              uuid

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -196,11 +196,9 @@ module tapi-topology {
                 Links that included details in this Pac are often referred to as Transitional Links.";
         }
         grouping node-edge-point {
-            list layer-protocol {
-                key 'local-id';
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
                 config false;
-                min-elements 1;
-                uses tapi-common:layer-protocol;
                 description "none";
             }
             leaf-list aggregated-node-edge-point {
@@ -219,6 +217,11 @@ module tapi-topology {
             container state {
                 config false;
                 uses tapi-common:admin-state-pac;
+                description "none";
+            }
+            container termination {
+                config false;
+                uses tapi-common:termination-pac;
                 description "none";
             }
             leaf link-port-direction {


### PR DESCRIPTION
The following decisions (made in previous TAPI calls) allow for folding LayerProtocol attributes into the LTPs (as ExtendedComposite rather than StrictComposite)
- constrain the NEPs & CEPs as single layer entities (only one LayerProtocol per NEP/CEP)
- augment the NEP/CEP directly rather than its LayerProtocol attribute
The advantage in folding layerProtocol attributes (such as layerProtocolName) directly into NEP & CEP allow for simple conditional specification/augment constraints when these classes (NEP, CEP) are augmented by layer-specific spec model classes