### PR TITLE
 Changes due to Eagle Uml2Yang tool updates to preserve UML literal names and to handle <ExtendedComposite>

### DIFF
--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -1478,24 +1478,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1523,10 +1523,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1553,17 +1553,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1605,11 +1605,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -1644,23 +1644,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -1696,10 +1696,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -1731,9 +1731,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -1780,8 +1780,8 @@
                 "state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 }
             }

--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -1604,6 +1604,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },

--- a/SWAGGER/tapi-common.swagger
+++ b/SWAGGER/tapi-common.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1599,6 +1329,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -1613,12 +1349,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -15900,7 +15900,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -15915,7 +15922,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -16074,7 +16088,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "resilience-constraint": {
                             "type": "array",
@@ -16107,7 +16128,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -16334,6 +16362,13 @@
                         },
                         "layer-protocol": {
                             "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
                     }
@@ -16410,6 +16445,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
                         }
@@ -16586,6 +16628,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },
@@ -16771,7 +16820,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -16841,7 +16897,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -16873,7 +16936,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -16901,7 +16971,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -17339,7 +17416,14 @@
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -17437,7 +17521,14 @@
                         "path-layer": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "cost-characteristic": {

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -15894,19 +15894,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -15924,11 +15924,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "client-node-edge-point": {
@@ -15962,21 +15962,21 @@
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "connection-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         }
@@ -15995,10 +15995,10 @@
                         "service-type": {
                             "type": "string",
                             "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
                             ]
                         },
                         "service-level": {
@@ -16082,19 +16082,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "resilience-constraint": {
@@ -16130,11 +16130,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "state": {
@@ -16146,33 +16146,33 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "protection-role": {
                             "type": "string",
                             "enum": [
-                                "work",
-                                "protect",
-                                "protected",
-                                "na",
-                                "work-restore",
-                                "protect-restore"
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
                             ],
                             "description": "To specify the protection role of this Port when create or update ConnectivityService."
                         }
@@ -16242,33 +16242,33 @@
                         "selection-control": {
                             "type": "string",
                             "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
                             ],
                             "description": "Degree of administrative control applied to the switch selection."
                         },
                         "selection-reason": {
                             "type": "string",
                             "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
                             ],
                             "description": "The reason for the current switch selection."
                         },
                         "switch-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
                         }
@@ -16319,9 +16319,9 @@
                         "restoration-coordinate-type": {
                             "type": "string",
                             "enum": [
-                                "no-coordinate",
-                                "hold-off-time",
-                                "wait-for-notification"
+                                "NO_COORDINATE",
+                                "HOLD_OFF_TIME",
+                                "WAIT_FOR_NOTIFICATION"
                             ],
                             "description": " The coordination mechanism between multi-layers."
                         },
@@ -16331,8 +16331,8 @@
                         "reversion-mode": {
                             "type": "string",
                             "enum": [
-                                "revertive",
-                                "non-revertive"
+                                "REVERTIVE",
+                                "NON-REVERTIVE"
                             ],
                             "description": "Indcates whether the protection scheme is revertive or non-revertive."
                         },
@@ -16363,11 +16363,11 @@
                         "layer-protocol": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
@@ -16446,11 +16446,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
@@ -16475,23 +16475,23 @@
                 "route-objective-function": {
                     "type": "string",
                     "enum": [
-                        "min-work-route-hop",
-                        "min-work-route-cost",
-                        "min-work-route-latency",
-                        "min-sum-of-work-and-protection-route-hop",
-                        "min-sum-of-work-and-protection-route-cost",
-                        "min-sum-of-work-and-protection-route-latency",
-                        "load-balance-max-unused-capacity"
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
                     ]
                 },
                 "diversity-policy": {
                     "type": "string",
                     "enum": [
-                        "srlg",
-                        "srng",
-                        "sng",
-                        "node",
-                        "link"
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
                     ]
                 }
             }
@@ -16502,24 +16502,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -16547,10 +16547,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -16577,17 +16577,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -16629,11 +16629,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -16668,23 +16668,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -16720,10 +16720,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -16755,9 +16755,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -16822,20 +16822,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -16899,11 +16899,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -16938,11 +16938,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -16973,11 +16973,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -17004,21 +17004,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -17238,21 +17238,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -17342,21 +17342,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -17397,32 +17397,32 @@
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -17523,11 +17523,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },

--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1696,100 +1426,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1992,114 +1628,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/connection-end-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2899,1339 +2427,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -4351,58 +2546,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4428,6 +2576,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4446,11 +2601,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4476,6 +2631,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4494,11 +2656,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4524,6 +2686,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4541,11 +2710,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4573,6 +2742,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4588,11 +2764,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4620,6 +2796,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4635,11 +2818,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4667,6 +2850,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4682,11 +2872,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4712,6 +2902,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4729,11 +2926,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4759,6 +2956,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4777,11 +2981,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4807,6 +3011,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4825,11 +3036,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4855,6 +3066,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4872,11 +3090,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4904,6 +3122,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4919,11 +3144,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4951,6 +3176,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4966,11 +3198,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4998,6 +3230,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5013,11 +3252,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5043,6 +3282,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5060,58 +3306,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5137,6 +3336,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5147,7 +3353,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -5158,11 +3364,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5188,6 +3394,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5212,58 +3425,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5289,6 +3455,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5299,7 +3472,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -5310,11 +3483,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5340,6 +3513,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5364,58 +3544,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/": {
             "get": {
                 "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5441,6 +3574,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5451,7 +3591,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
                             },
                             "type": "array"
                         }
@@ -5462,11 +3602,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
                 "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5492,6 +3632,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5621,91 +3768,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5724,6 +3791,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5742,11 +3816,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5765,6 +3839,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5783,11 +3864,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5806,6 +3887,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5823,11 +3911,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5848,6 +3936,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5863,11 +3958,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5888,6 +3983,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5903,11 +4005,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5928,6 +4030,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5943,11 +4052,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5966,6 +4075,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5983,11 +4099,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -6006,6 +4122,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6024,11 +4147,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6047,6 +4170,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6065,11 +4195,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -6088,6 +4218,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6105,11 +4242,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6130,6 +4267,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6145,11 +4289,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6170,6 +4314,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6185,11 +4336,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6210,6 +4361,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6225,11 +4383,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6248,6 +4406,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6265,51 +4430,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6328,6 +4453,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6338,7 +4470,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -6349,11 +4481,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6372,6 +4504,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6396,91 +4535,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6499,6 +4558,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6509,7 +4575,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -6520,11 +4586,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6543,6 +4609,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6559,6 +4632,111 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
                         }
                     },
                     "400": {
@@ -6658,6 +4836,752 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/link/": {
             "get": {
                 "summary": "Retrieve link",
@@ -6727,1254 +5651,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_link_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
-            "get": {
-                "summary": "Retrieve validation",
-                "description": "Retrieve operation of resource: validation",
-                "operationId": "retrieve_context_topology_link_validation_validation",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism by ID",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "validation-mechanism",
-                        "description": "ID of validation-mechanism",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
-            "get": {
-                "summary": "Retrieve lp-transition",
-                "description": "Retrieve operation of resource: lp-transition",
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     },
                     "400": {
@@ -8106,6 +5782,934 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "validation-mechanism",
+                        "description": "ID of validation-mechanism",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
                         }
                     },
                     "400": {
@@ -11380,169 +9984,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connectivity-service_end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/end-point/{local-id}/capacity/": {
             "post": {
                 "summary": "Create capacity by ID",
@@ -12505,2065 +10946,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/": {
-            "post": {
-                "summary": "Create conn-constraint by ID",
-                "description": "Create operation of resource: conn-constraint",
-                "operationId": "create_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "conn-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "description": "conn-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve conn-constraint",
-                "description": "Retrieve operation of resource: conn-constraint",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_conn-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update conn-constraint by ID",
-                "description": "Update operation of resource: conn-constraint",
-                "operationId": "update_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "conn-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "description": "conn-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete conn-constraint by ID",
-                "description": "Delete operation of resource: conn-constraint",
-                "operationId": "delete_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/": {
-            "get": {
-                "summary": "Retrieve requested-capacity",
-                "description": "Retrieve operation of resource: requested-capacity",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_requested-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/schedule/": {
-            "post": {
-                "summary": "Create schedule by ID",
-                "description": "Create operation of resource: schedule",
-                "operationId": "create_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "schedule",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "description": "schedulebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve schedule",
-                "description": "Retrieve operation of resource: schedule",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_schedule_schedule",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update schedule by ID",
-                "description": "Update operation of resource: schedule",
-                "operationId": "update_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "schedule",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "description": "schedulebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete schedule by ID",
-                "description": "Delete operation of resource: schedule",
-                "operationId": "delete_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/route-compute-policy/": {
-            "post": {
-                "summary": "Create route-compute-policy by ID",
-                "description": "Create operation of resource: route-compute-policy",
-                "operationId": "create_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "route-compute-policy",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "description": "route-compute-policybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve route-compute-policy",
-                "description": "Retrieve operation of resource: route-compute-policy",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update route-compute-policy by ID",
-                "description": "Update operation of resource: route-compute-policy",
-                "operationId": "update_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "route-compute-policy",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "description": "route-compute-policybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete route-compute-policy by ID",
-                "description": "Delete operation of resource: route-compute-policy",
-                "operationId": "delete_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/": {
-            "post": {
-                "summary": "Create topo-constraint by ID",
-                "description": "Create operation of resource: topo-constraint",
-                "operationId": "create_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "topo-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "description": "topo-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve topo-constraint",
-                "description": "Retrieve operation of resource: topo-constraint",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_topo-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update topo-constraint by ID",
-                "description": "Update operation of resource: topo-constraint",
-                "operationId": "update_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "topo-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "description": "topo-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete topo-constraint by ID",
-                "description": "Delete operation of resource: topo-constraint",
-                "operationId": "delete_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/topo-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connectivity-service_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/": {
-            "get": {
-                "summary": "Retrieve resilience-constraint",
-                "description": "Retrieve operation of resource: resilience-constraint",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/": {
-            "post": {
-                "summary": "Create resilience-constraint by ID",
-                "description": "Create operation of resource: resilience-constraint",
-                "operationId": "create_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        },
-                        "description": "resilience-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve resilience-constraint by ID",
-                "description": "Retrieve operation of resource: resilience-constraint",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update resilience-constraint by ID",
-                "description": "Update operation of resource: resilience-constraint",
-                "operationId": "update_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        },
-                        "description": "resilience-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete resilience-constraint by ID",
-                "description": "Delete operation of resource: resilience-constraint",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/resilience-type/": {
-            "post": {
-                "summary": "Create resilience-type by ID",
-                "description": "Create operation of resource: resilience-type",
-                "operationId": "create_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-type",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "description": "resilience-typebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve resilience-type",
-                "description": "Retrieve operation of resource: resilience-type",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-type_resilience-type",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update resilience-type by ID",
-                "description": "Update operation of resource: resilience-type",
-                "operationId": "update_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-type",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "description": "resilience-typebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete resilience-type by ID",
-                "description": "Delete operation of resource: resilience-type",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -14750,6 +11132,662 @@
                         "in": "path",
                         "name": "value-name",
                         "description": "ID of value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "get": {
+                "summary": "Retrieve requested-capacity",
+                "description": "Retrieve operation of resource: requested-capacity",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_requested-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/schedule/": {
+            "post": {
+                "summary": "Create schedule by ID",
+                "description": "Create operation of resource: schedule",
+                "operationId": "create_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "schedule",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "description": "schedulebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve schedule",
+                "description": "Retrieve operation of resource: schedule",
+                "operationId": "retrieve_context_connectivity-service_schedule_schedule",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update schedule by ID",
+                "description": "Update operation of resource: schedule",
+                "operationId": "update_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "schedule",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "description": "schedulebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete schedule by ID",
+                "description": "Delete operation of resource: schedule",
+                "operationId": "delete_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_connectivity-service_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/connectivity-service/{uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_connectivity-service_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/connectivity-service/{uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/resilience-type/": {
+            "post": {
+                "summary": "Create resilience-type by ID",
+                "description": "Create operation of resource: resilience-type",
+                "operationId": "create_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "resilience-type",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        },
+                        "description": "resilience-typebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve resilience-type",
+                "description": "Retrieve operation of resource: resilience-type",
+                "operationId": "retrieve_context_connectivity-service_resilience-type_resilience-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update resilience-type by ID",
+                "description": "Update operation of resource: resilience-type",
+                "operationId": "update_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "resilience-type",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        },
+                        "description": "resilience-typebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete resilience-type by ID",
+                "description": "Delete operation of resource: resilience-type",
+                "operationId": "delete_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15267,177 +12305,6 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/": {
-            "get": {
-                "summary": "Retrieve control-parameters",
-                "description": "Retrieve operation of resource: control-parameters",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_control-parameters",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/resilience-type/": {
-            "get": {
-                "summary": "Retrieve resilience-type",
-                "description": "Retrieve operation of resource: resilience-type",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_resilience-type_resilience-type",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connection/{uuid}/switch-control/{local-id}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -15529,11 +12396,11 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/state/": {
+        "/config/context/connection/{uuid}/switch-control/{local-id}/resilience-type/": {
             "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connection_state_state",
+                "summary": "Retrieve resilience-type",
+                "description": "Retrieve operation of resource: resilience-type",
+                "operationId": "retrieve_context_connection_switch-control_resilience-type_resilience-type",
                 "produces": [
                     "application/json"
                 ],
@@ -15547,13 +12414,20 @@
                         "description": "ID of uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
+                            "$ref": "#/definitions/resilience-type"
                         }
                     },
                     "400": {
@@ -15846,6 +12720,9 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
                     "properties": {
                         "connection-end-point": {
                             "type": "array",
@@ -15888,9 +12765,6 @@
                             },
                             "x-key": "local-id"
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
                         "direction": {
                             "type": "string",
                             "enum": [
@@ -15918,6 +12792,12 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
                 },
                 {
                     "properties": {
@@ -15953,12 +12833,6 @@
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
                             }
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
@@ -15988,7 +12862,7 @@
         "connectivity-constraint": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/route-compute-policy"
                 },
                 {
                     "properties": {
@@ -16031,9 +12905,6 @@
                             },
                             "x-key": "traffic-property-name"
                         },
-                        "route-compute-policy": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
                         "coroute-inclusion": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
@@ -16055,6 +12926,18 @@
                     "$ref": "#/definitions/service-spec"
                 },
                 {
+                    "$ref": "#/definitions/connectivity-constraint"
+                },
+                {
+                    "$ref": "#/definitions/topology-constraint"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "end-point": {
                             "type": "array",
@@ -16069,15 +12952,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
                             }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "direction": {
                             "type": "string",
@@ -16096,13 +12970,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "resilience-constraint": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resilience-constraint"
-                            },
-                            "x-key": "local-id"
                         }
                     }
                 }
@@ -16113,6 +12980,9 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
                 },
                 {
                     "properties": {
@@ -16136,9 +13006,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -16283,6 +13150,9 @@
                     "$ref": "#/definitions/local-class"
                 },
                 {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "sub-switch-control": {
                             "type": "array",
@@ -16297,9 +13167,6 @@
                                 "$ref": "#/definitions/switch"
                             },
                             "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/resilience-constraint"
                         }
                     }
                 }
@@ -16307,157 +13174,143 @@
             "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
         },
         "resilience-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "resilience-type": {
+                    "$ref": "#/definitions/resilience-type"
                 },
-                {
-                    "properties": {
-                        "resilience-type": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "restoration-coordinate-type": {
-                            "type": "string",
-                            "enum": [
-                                "NO_COORDINATE",
-                                "HOLD_OFF_TIME",
-                                "WAIT_FOR_NOTIFICATION"
-                            ],
-                            "description": " The coordination mechanism between multi-layers."
-                        },
-                        "restore-priority": {
-                            "type": "string"
-                        },
-                        "reversion-mode": {
-                            "type": "string",
-                            "enum": [
-                                "REVERTIVE",
-                                "NON-REVERTIVE"
-                            ],
-                            "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                        },
-                        "wait-to-revert-time": {
-                            "type": "string",
-                            "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                        },
-                        "hold-off-time": {
-                            "type": "string",
-                            "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                        },
-                        "is-lock-out": {
-                            "type": "boolean",
-                            "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                        },
-                        "is-frozen": {
-                            "type": "boolean",
-                            "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                        },
-                        "is-coordinated-switching-both-ends": {
-                            "type": "boolean",
-                            "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                        },
-                        "max-switch-times": {
-                            "type": "string",
-                            "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
-                        },
-                        "layer-protocol": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ],
-                            "description": "Indicate which layer this resilience parameters package configured for."
-                        }
-                    }
+                "restoration-coordinate-type": {
+                    "type": "string",
+                    "enum": [
+                        "NO_COORDINATE",
+                        "HOLD_OFF_TIME",
+                        "WAIT_FOR_NOTIFICATION"
+                    ],
+                    "description": " The coordination mechanism between multi-layers."
+                },
+                "restore-priority": {
+                    "type": "string"
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "REVERTIVE",
+                        "NON-REVERTIVE"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                },
+                "max-switch-times": {
+                    "type": "string",
+                    "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
+                },
+                "layer-protocol": {
+                    "type": "string",
+                    "enum": [
+                        "OTSiA",
+                        "OTU",
+                        "ODU",
+                        "ETH",
+                        "ETY"
+                    ],
+                    "description": "Indicate which layer this resilience parameters package configured for."
                 }
-            ],
-            "description": "A list of control parameters to apply to a switch."
+            }
         },
         "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "properties": {
+                "include-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
                 },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
+                "avoid-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "include-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "exclude-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "include-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                    }
+                },
+                "exclude-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                    }
+                },
+                "include-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                    }
+                },
+                "exclude-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                    }
+                },
+                "preferred-transport-layer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "OTSiA",
+                            "OTU",
+                            "ODU",
+                            "ETH",
+                            "ETY"
+                        ],
+                        "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }
                 }
-            ]
+            }
         },
         "cep-list": {
             "properties": {
@@ -16623,6 +13476,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -16637,12 +13496,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }
@@ -16778,6 +13631,30 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
+                },
+                {
                     "properties": {
                         "node-edge-point": {
                             "type": "array",
@@ -16792,30 +13669,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -16853,6 +13706,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -16878,21 +13746,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -16969,6 +13822,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -16994,12 +13853,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -17146,6 +13999,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -17160,18 +14025,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -17181,6 +14034,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -17211,18 +14076,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -17696,6 +14549,52 @@
                                 "$ref": "#/definitions/name-and-value"
                             },
                             "x-key": "value-name"
+                        },
+                        "administrative-state": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKED",
+                                "UNLOCKED"
+                            ]
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
                         },
                         "connection-end-point": {
                             "type": "array",

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -102,100 +102,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -571,279 +477,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
-            "post": {
-                "summary": "Create termination by ID",
-                "description": "Create operation of resource: termination",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update termination by ID",
-                "description": "Update operation of resource: termination",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete termination by ID",
-                "description": "Delete operation of resource: termination",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1149,230 +782,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-term/": {
-            "post": {
-                "summary": "Create eth-term by ID",
-                "description": "Create operation of resource: eth-term",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "eth-term",
-                        "schema": {
-                            "$ref": "#/definitions/eth-termination-pac"
-                        },
-                        "description": "eth-termbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve eth-term",
-                "description": "Retrieve operation of resource: eth-term",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/eth-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update eth-term by ID",
-                "description": "Update operation of resource: eth-term",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "eth-term",
-                        "schema": {
-                            "$ref": "#/definitions/eth-termination-pac"
-                        },
-                        "description": "eth-termbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete eth-term by ID",
-                "description": "Delete operation of resource: eth-term",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_eth-term_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-term/priority-regenerate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/priority-regenerate/": {
             "post": {
                 "summary": "Create priority-regenerate by ID",
                 "description": "Create operation of resource: priority-regenerate",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1431,7 +845,7 @@
             "get": {
                 "summary": "Retrieve priority-regenerate",
                 "description": "Retrieve operation of resource: priority-regenerate",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate",
                 "produces": [
                     "application/json"
                 ],
@@ -1484,7 +898,7 @@
             "put": {
                 "summary": "Update priority-regenerate by ID",
                 "description": "Update operation of resource: priority-regenerate",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1543,7 +957,7 @@
             "delete": {
                 "summary": "Delete priority-regenerate by ID",
                 "description": "Delete operation of resource: priority-regenerate",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-term_priority-regenerate_priority-regenerate_by_id",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_priority-regenerate_priority-regenerate_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1590,230 +1004,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/": {
-            "post": {
-                "summary": "Create eth-ctp by ID",
-                "description": "Create operation of resource: eth-ctp",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "eth-ctp",
-                        "schema": {
-                            "$ref": "#/definitions/eth-ctp-pac"
-                        },
-                        "description": "eth-ctpbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve eth-ctp",
-                "description": "Retrieve operation of resource: eth-ctp",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/eth-ctp-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update eth-ctp by ID",
-                "description": "Update operation of resource: eth-ctp",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "eth-ctp",
-                        "schema": {
-                            "$ref": "#/definitions/eth-ctp-pac"
-                        },
-                        "description": "eth-ctpbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete eth-ctp by ID",
-                "description": "Delete operation of resource: eth-ctp",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_eth-ctp_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/filter-config/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/filter-config/": {
             "post": {
                 "summary": "Create filter-config by ID",
                 "description": "Create operation of resource: filter-config",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
+                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1872,7 +1067,7 @@
             "get": {
                 "summary": "Retrieve filter-config",
                 "description": "Retrieve operation of resource: filter-config",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config",
                 "produces": [
                     "application/json"
                 ],
@@ -1925,7 +1120,7 @@
             "put": {
                 "summary": "Update filter-config by ID",
                 "description": "Update operation of resource: filter-config",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
+                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -1984,7 +1179,7 @@
             "delete": {
                 "summary": "Delete filter-config by ID",
                 "description": "Delete operation of resource: filter-config",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_filter-config_filter-config_by_id",
+                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_filter-config_filter-config_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -2031,230 +1226,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/": {
-            "post": {
-                "summary": "Create traffic-shaping by ID",
-                "description": "Create operation of resource: traffic-shaping",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "traffic-shaping",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        },
-                        "description": "traffic-shapingbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve traffic-shaping",
-                "description": "Retrieve operation of resource: traffic-shaping",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update traffic-shaping by ID",
-                "description": "Update operation of resource: traffic-shaping",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "traffic-shaping",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-shaping-pac"
-                        },
-                        "description": "traffic-shapingbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete traffic-shaping by ID",
-                "description": "Delete operation of resource: traffic-shaping",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_traffic-shaping_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/prio-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/prio-config-list/": {
             "get": {
                 "summary": "Retrieve prio-config-list",
                 "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_prio-config-list_prio-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_prio-config-list_prio-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -2304,11 +1280,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-shaping/queue-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/queue-config-list/": {
             "get": {
                 "summary": "Retrieve queue-config-list",
                 "description": "Retrieve operation of resource: queue-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-shaping_queue-config-list_queue-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_queue-config-list_queue-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -2358,230 +1334,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/": {
-            "post": {
-                "summary": "Create traffic-conditioning by ID",
-                "description": "Create operation of resource: traffic-conditioning",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "traffic-conditioning",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        },
-                        "description": "traffic-conditioningbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/prio-config-list-1/": {
             "get": {
-                "summary": "Retrieve traffic-conditioning",
-                "description": "Retrieve operation of resource: traffic-conditioning",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update traffic-conditioning by ID",
-                "description": "Update operation of resource: traffic-conditioning",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "traffic-conditioning",
-                        "schema": {
-                            "$ref": "#/definitions/traffic-conditioning-pac"
-                        },
-                        "description": "traffic-conditioningbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete traffic-conditioning by ID",
-                "description": "Delete operation of resource: traffic-conditioning",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_traffic-conditioning_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/prio-config-list/": {
-            "get": {
-                "summary": "Retrieve prio-config-list",
-                "description": "Retrieve operation of resource: prio-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_prio-config-list_prio-config-list",
+                "summary": "Retrieve prio-config-list-1",
+                "description": "Retrieve operation of resource: prio-config-list-1",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_prio-config-list-1_prio-config-list-1",
                 "produces": [
                     "application/json"
                 ],
@@ -2631,11 +1388,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/eth-ctp/traffic-conditioning/cond-config-list/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/cond-config-list/": {
             "get": {
                 "summary": "Retrieve cond-config-list",
                 "description": "Retrieve operation of resource: cond-config-list",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_eth-ctp_traffic-conditioning_cond-config-list_cond-config-list",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_cond-config-list_cond-config-list",
                 "produces": [
                     "application/json"
                 ],
@@ -2684,160 +1441,110 @@
                     }
                 }
             }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/ety-term/": {
-            "get": {
-                "summary": "Retrieve ety-term",
-                "description": "Retrieve operation of resource: ety-term",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_ety-term_ety-term",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/ety-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
         }
     },
     "definitions": {
         "eth-ctp-pac": {
-            "properties": {
-                "auxiliary-function-position-sequence": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
-                    }
-                },
-                "vlan-config": {
-                    "type": "string",
-                    "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
-                },
-                "csf-rdi-fdi-enable": {
-                    "type": "boolean",
-                    "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
-                },
-                "csf-report": {
-                    "type": "boolean",
-                    "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
-                },
-                "filter-config-snk": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
-                    }
-                },
-                "mac-length": {
-                    "type": "string",
-                    "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
-                },
-                "filter-config": {
-                    "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
-                    "$ref": "#/definitions/control-frame-filter"
-                },
-                "is-ssf-reported": {
-                    "type": "boolean",
-                    "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
-                },
-                "pll-thr": {
-                    "type": "string",
-                    "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
-                },
-                "actor-oper-key": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
-                },
-                "actor-system-id": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
-                },
-                "actor-system-priority": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
-                },
-                "collector-max-delay": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
-                },
-                "data-rate": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
-                },
-                "partner-oper-key": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
-                },
-                "partner-system-id": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
-                },
-                "partner-system-priority": {
-                    "type": "string",
-                    "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
-                },
-                "csf-config": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED",
-                        "ENABLED_WITH_RDI_FDI",
-                        "ENABLED_WITH_RDI_FDI_DCI",
-                        "ENABLED_WITH_DCI"
-                    ],
-                    "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
-                },
-                "traffic-shaping": {
+            "allOf": [
+                {
                     "$ref": "#/definitions/traffic-shaping-pac"
                 },
-                "traffic-conditioning": {
+                {
                     "$ref": "#/definitions/traffic-conditioning-pac"
+                },
+                {
+                    "properties": {
+                        "auxiliary-function-position-sequence": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
+                            }
+                        },
+                        "vlan-config": {
+                            "type": "string",
+                            "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
+                        },
+                        "csf-rdi-fdi-enable": {
+                            "type": "boolean",
+                            "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
+                        },
+                        "csf-report": {
+                            "type": "boolean",
+                            "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
+                        },
+                        "filter-config-snk": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
+                            }
+                        },
+                        "mac-length": {
+                            "type": "string",
+                            "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
+                        },
+                        "filter-config": {
+                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
+                            "$ref": "#/definitions/control-frame-filter"
+                        },
+                        "is-ssf-reported": {
+                            "type": "boolean",
+                            "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
+                        },
+                        "pll-thr": {
+                            "type": "string",
+                            "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
+                        },
+                        "actor-oper-key": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
+                        },
+                        "actor-system-id": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
+                        },
+                        "actor-system-priority": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
+                        },
+                        "collector-max-delay": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
+                        },
+                        "data-rate": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
+                        },
+                        "partner-oper-key": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
+                        },
+                        "partner-system-id": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
+                        },
+                        "partner-system-priority": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
+                        },
+                        "csf-config": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED",
+                                "ENABLED_WITH_RDI_FDI",
+                                "ENABLED_WITH_RDI_FDI_DCI",
+                                "ENABLED_WITH_DCI"
+                            ],
+                            "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
+                        }
+                    }
                 }
-            }
+            ]
         },
         "eth-connection-end-point-spec": {
-            "properties": {
-                "eth-term": {
-                    "$ref": "#/definitions/eth-termination-pac"
-                },
-                "eth-ctp": {
-                    "$ref": "#/definitions/eth-ctp-pac"
-                }
-            }
+            "$ref": "#/definitions/eth-ctp-pac"
         },
         "eth-termination-pac": {
             "description": "This object class models the Ethernet Flow Termination function located at a layer boundary.",
@@ -2855,7 +1562,7 @@
                     ],
                     "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021."
                 },
-                "filter-config": {
+                "filter-config-1": {
                     "type": "array",
                     "items": {
                         "type": "string",
@@ -2946,7 +1653,7 @@
         "traffic-conditioning-pac": {
             "description": "This object class models the ETH traffic conditioning function as defined in G.8021.\nBasic attributes: codirectional, condConfigList, prioConfigList",
             "properties": {
-                "prio-config-list": {
+                "prio-config-list-1": {
                     "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
                     "type": "array",
                     "items": {
@@ -2960,7 +1667,7 @@
                         "$ref": "#/definitions/traffic-conditioning-configuration"
                     }
                 },
-                "codirectional": {
+                "codirectional-1": {
                     "type": "boolean",
                     "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
                 }
@@ -2994,11 +1701,7 @@
             }
         },
         "eth-node-edge-point-spec": {
-            "properties": {
-                "ety-term": {
-                    "$ref": "#/definitions/ety-termination-pac"
-                }
-            }
+            "$ref": "#/definitions/ety-termination-pac"
         },
         "priority-configuration": {
             "properties": {
@@ -3273,92 +1976,17 @@
                 }
             }
         },
-        "context_schema": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/context"
-                },
-                {
-                    "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
-                        "nw-topology-service": {
-                            "$ref": "#/definitions/network-topology-service"
-                        },
-                        "topology": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/topology"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path-comp-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path-computation-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connectivity-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connection"
-                            },
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
         "admin-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
             "properties": {
                 "administrative-state": {
-                    "type": "string",
-                    "enum": [
-                        "LOCKED",
-                        "UNLOCKED"
-                    ]
+                    "type": "string"
                 },
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3383,13 +2011,7 @@
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3413,20 +2035,10 @@
             "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
             "properties": {
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3461,26 +2073,19 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }
@@ -3505,25 +2110,10 @@
             "properties": {
                 "termination-direction": {
                     "type": "string",
-                    "enum": [
-                        "BIDIRECTIONAL",
-                        "SINK",
-                        "SOURCE",
-                        "UNDEFINED_OR_UNKNOWN"
-                    ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
-                    "enum": [
-                        "LP_CAN_NEVER_TERMINATE",
-                        "LT_NOT_TERMINATED",
-                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
-                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
-                        "TERMINATED_BIDIRECTIONAL",
-                        "LT_PERMENANTLY_TERMINATED",
-                        "TERMINATION_STATE_UNKNOWN"
-                    ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
@@ -3556,13 +2146,7 @@
         "bandwidth-profile": {
             "properties": {
                 "bw-profile-type": {
-                    "type": "string",
-                    "enum": [
-                        "MEF_10.x",
-                        "RFC_2697",
-                        "RFC_2698",
-                        "RFC_4115"
-                    ]
+                    "type": "string"
                 },
                 "committed-information-rate": {
                     "$ref": "#/definitions/capacity-value"
@@ -3591,12 +2175,7 @@
                     "type": "string"
                 },
                 "unit": {
-                    "type": "string",
-                    "enum": [
-                        "GBPS",
-                        "MBPS",
-                        "KBPS"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3610,43 +2189,34 @@
                 }
             }
         },
-        "owned-node-edge-point_schema": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/node-edge-point"
-                },
-                {
-                    "properties": {
-                        "owned-node-edge-point_uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connection-end-point"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "ety-term": {
-                            "$ref": "#/definitions/ety-termination-pac"
-                        }
-                    }
-                }
-            ]
-        },
         "link": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
                 },
                 {
                     "properties": {
@@ -3663,30 +2233,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -3724,6 +2270,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -3749,21 +2310,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -3840,6 +2386,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -3865,12 +2417,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -4017,6 +2563,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -4031,18 +2589,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -4052,6 +2598,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -4082,18 +2640,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -4232,155 +2778,13 @@
                 }
             }
         },
-        "get-topology-detailsRPC_input_schema": {
-            "properties": {
-                "topology-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-topology-detailsRPC_output_schema": {
-            "properties": {
-                "topology": {
-                    "$ref": "#/definitions/topology"
-                }
-            }
-        },
-        "get-node-detailsRPC_input_schema": {
-            "properties": {
-                "topology-id-or-name": {
-                    "type": "string"
-                },
-                "node-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-node-detailsRPC_output_schema": {
-            "properties": {
-                "node": {
-                    "$ref": "#/definitions/node"
-                }
-            }
-        },
-        "get-node-edge-point-detailsRPC_input_schema": {
-            "properties": {
-                "topology-id-or-name": {
-                    "type": "string"
-                },
-                "node-id-or-name": {
-                    "type": "string"
-                },
-                "ep-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-node-edge-point-detailsRPC_output_schema": {
-            "properties": {
-                "node-edge-point": {
-                    "$ref": "#/definitions/node-edge-point"
-                }
-            }
-        },
-        "get-link-detailsRPC_input_schema": {
-            "properties": {
-                "topology-id-or-name": {
-                    "type": "string"
-                },
-                "link-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-link-detailsRPC_output_schema": {
-            "properties": {
-                "link": {
-                    "$ref": "#/definitions/link"
-                }
-            }
-        },
-        "get-topology-listRPC_output_schema": {
-            "properties": {
-                "topology": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/topology"
-                    }
-                }
-            }
-        },
-        "get-service-interface-point-detailsRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-service-interface-point-detailsRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "$ref": "#/definitions/service-interface-point"
-                }
-            }
-        },
-        "get-service-interface-point-listRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/service-interface-point"
-                    }
-                }
-            }
-        },
-        "update-service-interface-pointRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                },
-                "state": {
-                    "type": "string",
-                    "enum": [
-                        "LOCKED",
-                        "UNLOCKED"
-                    ]
-                }
-            }
-        },
-        "connection-end-point_schema": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/connection-end-point"
-                },
-                {
-                    "properties": {
-                        "connection-end-point_uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
-                        "eth-term": {
-                            "$ref": "#/definitions/eth-termination-pac"
-                        },
-                        "eth-ctp": {
-                            "$ref": "#/definitions/eth-ctp-pac"
-                        }
-                    }
-                }
-            ]
-        },
         "connection": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
                 },
                 {
                     "properties": {
@@ -4425,9 +2829,6 @@
                             },
                             "x-key": "local-id"
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
                         "direction": {
                             "type": "string",
                             "enum": [
@@ -4455,6 +2856,12 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
                 },
                 {
                     "properties": {
@@ -4490,12 +2897,6 @@
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
                             }
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
@@ -4525,7 +2926,7 @@
         "connectivity-constraint": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/route-compute-policy"
                 },
                 {
                     "properties": {
@@ -4568,9 +2969,6 @@
                             },
                             "x-key": "traffic-property-name"
                         },
-                        "route-compute-policy": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
                         "coroute-inclusion": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
@@ -4592,6 +2990,18 @@
                     "$ref": "#/definitions/service-spec"
                 },
                 {
+                    "$ref": "#/definitions/connectivity-constraint"
+                },
+                {
+                    "$ref": "#/definitions/topology-constraint"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "end-point": {
                             "type": "array",
@@ -4606,15 +3016,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
                             }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "direction": {
                             "type": "string",
@@ -4633,13 +3034,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "resilience-constraint": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resilience-constraint"
-                            },
-                            "x-key": "local-id"
                         }
                     }
                 }
@@ -4650,6 +3044,9 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
                 },
                 {
                     "properties": {
@@ -4673,9 +3070,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -4820,6 +3214,9 @@
                     "$ref": "#/definitions/local-class"
                 },
                 {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "sub-switch-control": {
                             "type": "array",
@@ -4834,9 +3231,6 @@
                                 "$ref": "#/definitions/switch"
                             },
                             "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/resilience-constraint"
                         }
                     }
                 }
@@ -4844,157 +3238,143 @@
             "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
         },
         "resilience-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "resilience-type": {
+                    "$ref": "#/definitions/resilience-type"
                 },
-                {
-                    "properties": {
-                        "resilience-type": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "restoration-coordinate-type": {
-                            "type": "string",
-                            "enum": [
-                                "NO_COORDINATE",
-                                "HOLD_OFF_TIME",
-                                "WAIT_FOR_NOTIFICATION"
-                            ],
-                            "description": " The coordination mechanism between multi-layers."
-                        },
-                        "restore-priority": {
-                            "type": "string"
-                        },
-                        "reversion-mode": {
-                            "type": "string",
-                            "enum": [
-                                "REVERTIVE",
-                                "NON-REVERTIVE"
-                            ],
-                            "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                        },
-                        "wait-to-revert-time": {
-                            "type": "string",
-                            "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                        },
-                        "hold-off-time": {
-                            "type": "string",
-                            "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                        },
-                        "is-lock-out": {
-                            "type": "boolean",
-                            "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                        },
-                        "is-frozen": {
-                            "type": "boolean",
-                            "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                        },
-                        "is-coordinated-switching-both-ends": {
-                            "type": "boolean",
-                            "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                        },
-                        "max-switch-times": {
-                            "type": "string",
-                            "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
-                        },
-                        "layer-protocol": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ],
-                            "description": "Indicate which layer this resilience parameters package configured for."
-                        }
-                    }
+                "restoration-coordinate-type": {
+                    "type": "string",
+                    "enum": [
+                        "NO_COORDINATE",
+                        "HOLD_OFF_TIME",
+                        "WAIT_FOR_NOTIFICATION"
+                    ],
+                    "description": " The coordination mechanism between multi-layers."
+                },
+                "restore-priority": {
+                    "type": "string"
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "REVERTIVE",
+                        "NON-REVERTIVE"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                },
+                "max-switch-times": {
+                    "type": "string",
+                    "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
+                },
+                "layer-protocol": {
+                    "type": "string",
+                    "enum": [
+                        "OTSiA",
+                        "OTU",
+                        "ODU",
+                        "ETH",
+                        "ETY"
+                    ],
+                    "description": "Indicate which layer this resilience parameters package configured for."
                 }
-            ],
-            "description": "A list of control parameters to apply to a switch."
+            }
         },
         "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "properties": {
+                "include-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
                 },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
+                "avoid-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "include-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "exclude-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "include-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                    }
+                },
+                "exclude-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                    }
+                },
+                "include-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                    }
+                },
+                "exclude-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                    }
+                },
+                "preferred-transport-layer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "OTSiA",
+                            "OTU",
+                            "ODU",
+                            "ETH",
+                            "ETY"
+                        ],
+                        "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }
                 }
-            ]
+            }
         },
         "cep-list": {
             "properties": {
@@ -5032,6 +3412,736 @@
                     ]
                 }
             }
+        },
+        "path": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                            }
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        }
+                    }
+                }
+            ],
+            "description": "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes"
+        },
+        "path-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "service-layer": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "path-computation-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                            }
+                        },
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "objective-function": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "optimization-constraint": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-objective-function": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "bandwidth-optimization": {
+                            "type": "string"
+                        },
+                        "concurrent-paths": {
+                            "type": "string"
+                        },
+                        "cost-optimization": {
+                            "type": "string"
+                        },
+                        "link-utilization": {
+                            "type": "string"
+                        },
+                        "resource-sharing": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-optimization-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "traffic-interruption": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "routing-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "path-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name"
+                        },
+                        "include-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        },
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "path-computation-context": {
+            "properties": {
+                "path-comp-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path-computation-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "path": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "context_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/context"
+                },
+                {
+                    "properties": {
+                        "uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "nw-topology-service": {
+                            "$ref": "#/definitions/network-topology-service"
+                        },
+                        "topology": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/topology"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path-comp-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-computation-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connectivity-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection"
+                            },
+                            "x-key": "uuid"
+                        }
+                    }
+                }
+            ]
+        },
+        "owned-node-edge-point_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/node-edge-point"
+                },
+                {
+                    "properties": {
+                        "owned-node-edge-point_uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "administrative-state": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKED",
+                                "UNLOCKED"
+                            ]
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection-end-point"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "is-fts-enabled": {
+                            "type": "boolean",
+                            "description": "This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information."
+                        },
+                        "is-tx-pause-enabled": {
+                            "type": "boolean",
+                            "description": "This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021."
+                        },
+                        "phy-type": {
+                            "type": "string",
+                            "enum": [
+                                "OTHER",
+                                "UNKNOWN",
+                                "NONE",
+                                "2BASE_TL",
+                                "10MBIT_S",
+                                "10PASS_TS",
+                                "100BASE_T4",
+                                "100BASE_X",
+                                "100BASE_T2",
+                                "1000BASE_X",
+                                "1000BASE_T",
+                                "10GBASE-X",
+                                "10GBASE_R",
+                                "10GBASE_W"
+                            ],
+                            "description": "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2."
+                        },
+                        "phy-type-list": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "OTHER",
+                                    "UNKNOWN",
+                                    "NONE",
+                                    "2BASE_TL",
+                                    "10MBIT_S",
+                                    "10PASS_TS",
+                                    "100BASE_T4",
+                                    "100BASE_X",
+                                    "100BASE_T2",
+                                    "1000BASE_X",
+                                    "1000BASE_T",
+                                    "10GBASE-X",
+                                    "10GBASE_R",
+                                    "10GBASE_W"
+                                ],
+                                "description": "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3."
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "get-topology-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-topology-detailsRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "$ref": "#/definitions/topology"
+                }
+            }
+        },
+        "get-node-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-detailsRPC_output_schema": {
+            "properties": {
+                "node": {
+                    "$ref": "#/definitions/node"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "node-id-or-name": {
+                    "type": "string"
+                },
+                "ep-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-node-edge-point-detailsRPC_output_schema": {
+            "properties": {
+                "node-edge-point": {
+                    "$ref": "#/definitions/node-edge-point"
+                }
+            }
+        },
+        "get-link-detailsRPC_input_schema": {
+            "properties": {
+                "topology-id-or-name": {
+                    "type": "string"
+                },
+                "link-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-link-detailsRPC_output_schema": {
+            "properties": {
+                "link": {
+                    "$ref": "#/definitions/link"
+                }
+            }
+        },
+        "get-topology-listRPC_output_schema": {
+            "properties": {
+                "topology": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/topology"
+                    }
+                }
+            }
+        },
+        "get-service-interface-point-detailsRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-service-interface-point-detailsRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "$ref": "#/definitions/service-interface-point"
+                }
+            }
+        },
+        "get-service-interface-point-listRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service-interface-point"
+                    }
+                }
+            }
+        },
+        "update-service-interface-pointRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "LOCKED",
+                        "UNLOCKED"
+                    ]
+                }
+            }
+        },
+        "connection-end-point_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/connection-end-point"
+                },
+                {
+                    "properties": {
+                        "connection-end-point_uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "priority-regenerate": {
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.",
+                            "$ref": "#/definitions/priority-mapping"
+                        },
+                        "ether-type": {
+                            "type": "string",
+                            "enum": [
+                                "C_Tag",
+                                "S_Tag",
+                                "I_Tag"
+                            ],
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021."
+                        },
+                        "filter-config-1": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.\nIt indicates the configured filter action for each of the 33 group MAC addresses for control frames.\nThe 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.\nrange of type : MacAddress: \n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to \n01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to \n01-80-C2-00-00-2F;\nActionEnum:\nPASS, BLOCK"
+                            }
+                        },
+                        "frametype-config": {
+                            "type": "string",
+                            "enum": [
+                                "ADMIT_ONLY_VLAN_TAGGED_FRAMES",
+                                "ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES",
+                                "ADMIT_ALL_FRAMES"
+                            ],
+                            "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.\nrange of type : see Enumeration"
+                        },
+                        "port-vid": {
+                            "type": "string",
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021."
+                        },
+                        "priority-code-point-config": {
+                            "type": "string",
+                            "enum": [
+                                "8P0D",
+                                "7P1D",
+                                "6P2D",
+                                "5P3D",
+                                "DEI"
+                            ],
+                            "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.\nrange of type : see Enumeration"
+                        },
+                        "auxiliary-function-position-sequence": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP."
+                            }
+                        },
+                        "vlan-config": {
+                            "type": "string",
+                            "description": "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.\nrange of type : -1, 0, 1..4094"
+                        },
+                        "csf-rdi-fdi-enable": {
+                            "type": "boolean",
+                            "description": "This attribute models the MI_CSFrdifdiEnable information defined in G.8021."
+                        },
+                        "csf-report": {
+                            "type": "boolean",
+                            "description": "This attribute models the MI_CSF_Reported information defined in G.8021.\nrange of type : true, false"
+                        },
+                        "filter-config-snk": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n01-80-C2-00-00-10, \n01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and \n01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed."
+                            }
+                        },
+                        "mac-length": {
+                            "type": "string",
+                            "description": "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.\nrange of type : 1518, 1522, 2000"
+                        },
+                        "filter-config": {
+                            "description": "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:\n- All bridges address: 01-80-C2-00-00-10,\n- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,\n- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.\nThe filter action is Pass or Block. \nIf the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. \nIf none of the above addresses match, the ETH_CI_D is passed.",
+                            "$ref": "#/definitions/control-frame-filter"
+                        },
+                        "is-ssf-reported": {
+                            "type": "boolean",
+                            "description": "This attribute provisions whether the SSF defect should be reported as fault cause or not.\nIt models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021."
+                        },
+                        "pll-thr": {
+                            "type": "string",
+                            "description": "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.\nrange of type : 0..number of ports"
+                        },
+                        "actor-oper-key": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.\nThe meaning of particular Key values is of local significance.\nrange of type : 16 bit"
+                        },
+                        "actor-system-id": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nA MAC address used as a unique identifier for the System that contains this Aggregator."
+                        },
+                        "actor-system-priority": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nIndicating the priority associated with the Actor\u2019s System ID.\nrange of type : 2-octet"
+                        },
+                        "collector-max-delay": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).\nrange of type : 16-bit"
+                        },
+                        "data-rate": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links."
+                        },
+                        "partner-oper-key": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nThe current operational value of the Key for the Aggregator\u2019s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.\nrange of type : 16-bit"
+                        },
+                        "partner-system-id": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nA MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System."
+                        },
+                        "partner-system-priority": {
+                            "type": "string",
+                            "description": "See 802.1AX:\nIndicates the priority associated with the Partner\u2019s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.\nrange of type : 2-octet"
+                        },
+                        "csf-config": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED",
+                                "ENABLED_WITH_RDI_FDI",
+                                "ENABLED_WITH_RDI_FDI_DCI",
+                                "ENABLED_WITH_DCI"
+                            ],
+                            "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
+                        },
+                        "prio-config-list": {
+                            "description": "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/priority-configuration"
+                            }
+                        },
+                        "queue-config-list": {
+                            "description": "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/queue-configuration"
+                            }
+                        },
+                        "sched-config": {
+                            "type": "string",
+                            "description": "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.\nScheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).\nNote that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute."
+                        },
+                        "codirectional": {
+                            "type": "boolean",
+                            "description": "This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP."
+                        },
+                        "prio-config-list-1": {
+                            "description": "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/priority-configuration"
+                            }
+                        },
+                        "cond-config-list": {
+                            "description": "This attribute indicates for the conditioner process the conditioning parameters:\n- Queue ID: Indicates the Queue ID\n- Committed Information Rate (CIR): number of bits per second\n- Committed Burst Size (CBS): number of bytes\n- Excess Information Rate (EIR): number of bits per second\n- Excess Burst Size (EBS): number of bytes\n- Coupling flag (CF): 0 or 1\n- Color mode (CM): color-blind and color-aware.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/traffic-conditioning-configuration"
+                            }
+                        },
+                        "codirectional-1": {
+                            "type": "boolean",
+                            "description": "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP."
+                        }
+                    }
+                }
+            ]
         }
     }
 }

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -2813,11 +2813,11 @@
                 "csf-config": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled",
-                        "enabled-with-rdi-fdi",
-                        "enabled-with-rdi-fdi-dci",
-                        "enabled-with-dci"
+                        "DISABLED",
+                        "ENABLED",
+                        "ENABLED_WITH_RDI_FDI",
+                        "ENABLED_WITH_RDI_FDI_DCI",
+                        "ENABLED_WITH_DCI"
                     ],
                     "description": "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.\nrange of type : true, false"
                 },
@@ -2849,9 +2849,9 @@
                 "ether-type": {
                     "type": "string",
                     "enum": [
-                        "c-tag",
-                        "s-tag",
-                        "i-tag"
+                        "C_Tag",
+                        "S_Tag",
+                        "I_Tag"
                     ],
                     "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021."
                 },
@@ -2865,9 +2865,9 @@
                 "frametype-config": {
                     "type": "string",
                     "enum": [
-                        "admit-only-vlan-tagged-frames",
-                        "admit-only-untagged-and-priority-tagged-frames",
-                        "admit-all-frames"
+                        "ADMIT_ONLY_VLAN_TAGGED_FRAMES",
+                        "ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES",
+                        "ADMIT_ALL_FRAMES"
                     ],
                     "description": "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.\nrange of type : see Enumeration"
                 },
@@ -2878,11 +2878,11 @@
                 "priority-code-point-config": {
                     "type": "string",
                     "enum": [
-                        "8-p-0-d",
-                        "7-p-1-d",
-                        "6-p-2-d",
-                        "5-p-3-d",
-                        "dei"
+                        "8P0D",
+                        "7P1D",
+                        "6P2D",
+                        "5P3D",
+                        "DEI"
                     ],
                     "description": "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.\nrange of type : see Enumeration"
                 }
@@ -2901,20 +2901,20 @@
                 "phy-type": {
                     "type": "string",
                     "enum": [
-                        "other",
-                        "unknown",
-                        "none",
-                        "2-base-tl",
-                        "10-mbit-s",
-                        "10-pass-ts",
-                        "100-base-t-4",
-                        "100-base-x",
-                        "100-base-t-2",
-                        "1000-base-x",
-                        "1000-base-t",
-                        "10-gbase-x",
-                        "10-gbase-r",
-                        "10-gbase-w"
+                        "OTHER",
+                        "UNKNOWN",
+                        "NONE",
+                        "2BASE_TL",
+                        "10MBIT_S",
+                        "10PASS_TS",
+                        "100BASE_T4",
+                        "100BASE_X",
+                        "100BASE_T2",
+                        "1000BASE_X",
+                        "1000BASE_T",
+                        "10GBASE-X",
+                        "10GBASE_R",
+                        "10GBASE_W"
                     ],
                     "description": "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2."
                 },
@@ -2923,20 +2923,20 @@
                     "items": {
                         "type": "string",
                         "enum": [
-                            "other",
-                            "unknown",
-                            "none",
-                            "2-base-tl",
-                            "10-mbit-s",
-                            "10-pass-ts",
-                            "100-base-t-4",
-                            "100-base-x",
-                            "100-base-t-2",
-                            "1000-base-x",
-                            "1000-base-t",
-                            "10-gbase-x",
-                            "10-gbase-r",
-                            "10-gbase-w"
+                            "OTHER",
+                            "UNKNOWN",
+                            "NONE",
+                            "2BASE_TL",
+                            "10MBIT_S",
+                            "10PASS_TS",
+                            "100BASE_T4",
+                            "100BASE_X",
+                            "100BASE_T2",
+                            "1000BASE_X",
+                            "1000BASE_T",
+                            "10GBASE-X",
+                            "10GBASE_R",
+                            "10GBASE_W"
                         ],
                         "description": "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3."
                     }
@@ -3051,8 +3051,8 @@
                 "colour-mode": {
                     "type": "string",
                     "enum": [
-                        "colour-blind",
-                        "colour-aware"
+                        "COLOUR_BLIND",
+                        "COLOUR_AWARE"
                     ],
                     "description": "This attribute indicates the colour mode."
                 },
@@ -3340,24 +3340,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3385,10 +3385,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3415,17 +3415,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3467,11 +3467,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -3506,23 +3506,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -3558,10 +3558,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -3593,9 +3593,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -3693,20 +3693,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -3770,11 +3770,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -3809,11 +3809,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -3844,11 +3844,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -3875,21 +3875,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -4109,21 +4109,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -4213,21 +4213,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -4342,8 +4342,8 @@
                 "state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 }
             }
@@ -4431,19 +4431,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -4461,11 +4461,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "client-node-edge-point": {
@@ -4499,21 +4499,21 @@
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "connection-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         }
@@ -4532,10 +4532,10 @@
                         "service-type": {
                             "type": "string",
                             "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
                             ]
                         },
                         "service-level": {
@@ -4619,19 +4619,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "resilience-constraint": {
@@ -4667,11 +4667,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "state": {
@@ -4683,33 +4683,33 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "protection-role": {
                             "type": "string",
                             "enum": [
-                                "work",
-                                "protect",
-                                "protected",
-                                "na",
-                                "work-restore",
-                                "protect-restore"
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
                             ],
                             "description": "To specify the protection role of this Port when create or update ConnectivityService."
                         }
@@ -4779,33 +4779,33 @@
                         "selection-control": {
                             "type": "string",
                             "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
                             ],
                             "description": "Degree of administrative control applied to the switch selection."
                         },
                         "selection-reason": {
                             "type": "string",
                             "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
                             ],
                             "description": "The reason for the current switch selection."
                         },
                         "switch-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
                         }
@@ -4856,9 +4856,9 @@
                         "restoration-coordinate-type": {
                             "type": "string",
                             "enum": [
-                                "no-coordinate",
-                                "hold-off-time",
-                                "wait-for-notification"
+                                "NO_COORDINATE",
+                                "HOLD_OFF_TIME",
+                                "WAIT_FOR_NOTIFICATION"
                             ],
                             "description": " The coordination mechanism between multi-layers."
                         },
@@ -4868,8 +4868,8 @@
                         "reversion-mode": {
                             "type": "string",
                             "enum": [
-                                "revertive",
-                                "non-revertive"
+                                "REVERTIVE",
+                                "NON-REVERTIVE"
                             ],
                             "description": "Indcates whether the protection scheme is revertive or non-revertive."
                         },
@@ -4900,11 +4900,11 @@
                         "layer-protocol": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
@@ -4983,11 +4983,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
@@ -5012,23 +5012,23 @@
                 "route-objective-function": {
                     "type": "string",
                     "enum": [
-                        "min-work-route-hop",
-                        "min-work-route-cost",
-                        "min-work-route-latency",
-                        "min-sum-of-work-and-protection-route-hop",
-                        "min-sum-of-work-and-protection-route-cost",
-                        "min-sum-of-work-and-protection-route-latency",
-                        "load-balance-max-unused-capacity"
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
                     ]
                 },
                 "diversity-policy": {
                     "type": "string",
                     "enum": [
-                        "srlg",
-                        "srng",
-                        "sng",
-                        "node",
-                        "link"
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
                     ]
                 }
             }

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -3466,6 +3466,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },
@@ -3684,7 +3691,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -3754,7 +3768,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -3786,7 +3807,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -3814,7 +3842,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -4402,7 +4437,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -4417,7 +4459,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -4576,7 +4625,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "resilience-constraint": {
                             "type": "array",
@@ -4609,7 +4665,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -4836,6 +4899,13 @@
                         },
                         "layer-protocol": {
                             "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
                     }
@@ -4912,6 +4982,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
                         }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -4076,6 +3806,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -4090,12 +3826,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -3645,8 +3645,8 @@
                         "subscription-state": {
                             "type": "string",
                             "enum": [
-                                "suspended",
-                                "active"
+                                "SUSPENDED",
+                                "ACTIVE"
                             ]
                         },
                         "supported-notification-types": {
@@ -3654,11 +3654,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "object-creation",
-                                    "object-deletion",
-                                    "attribute-value-change",
-                                    "alarm-event",
-                                    "threshold-crossing-alert"
+                                    "OBJECT_CREATION",
+                                    "OBJECT_DELETION",
+                                    "ATTRIBUTE_VALUE_CHANGE",
+                                    "ALARM_EVENT",
+                                    "THRESHOLD_CROSSING_ALERT"
                                 ]
                             }
                         },
@@ -3667,17 +3667,17 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "topology",
-                                    "node",
-                                    "link",
-                                    "connection",
-                                    "path",
-                                    "connectivity-service",
-                                    "virtual-network-service",
-                                    "path-computation-service",
-                                    "node-edge-point",
-                                    "service-interface-point",
-                                    "connection-end-point"
+                                    "TOPOLOGY",
+                                    "NODE",
+                                    "LINK",
+                                    "CONNECTION",
+                                    "PATH",
+                                    "CONNECTIVITY_SERVICE",
+                                    "VIRTUAL_NETWORK_SERVICE",
+                                    "PATH_COMPUTATION_SERVICE",
+                                    "NODE_EDGE_POINT",
+                                    "SERVICE_INTERFACE_POINT",
+                                    "CONNECTION_END_POINT"
                                 ]
                             }
                         }
@@ -3697,11 +3697,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "object-creation",
-                                    "object-deletion",
-                                    "attribute-value-change",
-                                    "alarm-event",
-                                    "threshold-crossing-alert"
+                                    "OBJECT_CREATION",
+                                    "OBJECT_DELETION",
+                                    "ATTRIBUTE_VALUE_CHANGE",
+                                    "ALARM_EVENT",
+                                    "THRESHOLD_CROSSING_ALERT"
                                 ]
                             }
                         },
@@ -3710,17 +3710,17 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "topology",
-                                    "node",
-                                    "link",
-                                    "connection",
-                                    "path",
-                                    "connectivity-service",
-                                    "virtual-network-service",
-                                    "path-computation-service",
-                                    "node-edge-point",
-                                    "service-interface-point",
-                                    "connection-end-point"
+                                    "TOPOLOGY",
+                                    "NODE",
+                                    "LINK",
+                                    "CONNECTION",
+                                    "PATH",
+                                    "CONNECTIVITY_SERVICE",
+                                    "VIRTUAL_NETWORK_SERVICE",
+                                    "PATH_COMPUTATION_SERVICE",
+                                    "NODE_EDGE_POINT",
+                                    "SERVICE_INTERFACE_POINT",
+                                    "CONNECTION_END_POINT"
                                 ]
                             }
                         },
@@ -3729,11 +3729,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
@@ -3761,27 +3761,27 @@
                         "notification-type": {
                             "type": "string",
                             "enum": [
-                                "object-creation",
-                                "object-deletion",
-                                "attribute-value-change",
-                                "alarm-event",
-                                "threshold-crossing-alert"
+                                "OBJECT_CREATION",
+                                "OBJECT_DELETION",
+                                "ATTRIBUTE_VALUE_CHANGE",
+                                "ALARM_EVENT",
+                                "THRESHOLD_CROSSING_ALERT"
                             ]
                         },
                         "target-object-type": {
                             "type": "string",
                             "enum": [
-                                "topology",
-                                "node",
-                                "link",
-                                "connection",
-                                "path",
-                                "connectivity-service",
-                                "virtual-network-service",
-                                "path-computation-service",
-                                "node-edge-point",
-                                "service-interface-point",
-                                "connection-end-point"
+                                "TOPOLOGY",
+                                "NODE",
+                                "LINK",
+                                "CONNECTION",
+                                "PATH",
+                                "CONNECTIVITY_SERVICE",
+                                "VIRTUAL_NETWORK_SERVICE",
+                                "PATH_COMPUTATION_SERVICE",
+                                "NODE_EDGE_POINT",
+                                "SERVICE_INTERFACE_POINT",
+                                "CONNECTION_END_POINT"
                             ]
                         },
                         "target-object-identifier": {
@@ -3804,19 +3804,19 @@
                         "source-indicator": {
                             "type": "string",
                             "enum": [
-                                "resource-operation",
-                                "management-operation",
-                                "unknown"
+                                "RESOURCE_OPERATION",
+                                "MANAGEMENT_OPERATION",
+                                "UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "changed-attributes": {
@@ -3891,11 +3891,11 @@
                 "pervceived-severity": {
                     "type": "string",
                     "enum": [
-                        "critical",
-                        "major",
-                        "minor",
-                        "warning",
-                        "cleared"
+                        "CRITICAL",
+                        "MAJOR",
+                        "MINOR",
+                        "WARNING",
+                        "CLEARED"
                     ]
                 },
                 "probable-cause": {
@@ -3904,9 +3904,9 @@
                 "service-affecting": {
                     "type": "string",
                     "enum": [
-                        "service-affecting",
-                        "not-service-affecting",
-                        "unknown"
+                        "SERVICE_AFFECTING",
+                        "NOT_SERVICE_AFFECTING",
+                        "UNKNOWN"
                     ]
                 }
             }
@@ -3919,9 +3919,9 @@
                 "threshold-crossing": {
                     "type": "string",
                     "enum": [
-                        "threshold-above",
-                        "threshold-below",
-                        "cleared"
+                        "THRESHOLD_ABOVE",
+                        "THRESHOLD_BELOW",
+                        "CLEARED"
                     ]
                 },
                 "threshold-parameter": {
@@ -3955,24 +3955,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -4000,10 +4000,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -4030,17 +4030,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -4082,11 +4082,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -4121,23 +4121,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -4173,10 +4173,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -4208,9 +4208,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -4269,11 +4269,11 @@
                     "items": {
                         "type": "string",
                         "enum": [
-                            "object-creation",
-                            "object-deletion",
-                            "attribute-value-change",
-                            "alarm-event",
-                            "threshold-crossing-alert"
+                            "OBJECT_CREATION",
+                            "OBJECT_DELETION",
+                            "ATTRIBUTE_VALUE_CHANGE",
+                            "ALARM_EVENT",
+                            "THRESHOLD_CROSSING_ALERT"
                         ]
                     }
                 },
@@ -4282,17 +4282,17 @@
                     "items": {
                         "type": "string",
                         "enum": [
-                            "topology",
-                            "node",
-                            "link",
-                            "connection",
-                            "path",
-                            "connectivity-service",
-                            "virtual-network-service",
-                            "path-computation-service",
-                            "node-edge-point",
-                            "service-interface-point",
-                            "connection-end-point"
+                            "TOPOLOGY",
+                            "NODE",
+                            "LINK",
+                            "CONNECTION",
+                            "PATH",
+                            "CONNECTIVITY_SERVICE",
+                            "VIRTUAL_NETWORK_SERVICE",
+                            "PATH_COMPUTATION_SERVICE",
+                            "NODE_EDGE_POINT",
+                            "SERVICE_INTERFACE_POINT",
+                            "CONNECTION_END_POINT"
                         ]
                     }
                 }
@@ -4306,8 +4306,8 @@
                 "subscription-state": {
                     "type": "string",
                     "enum": [
-                        "suspended",
-                        "active"
+                        "SUSPENDED",
+                        "ACTIVE"
                     ]
                 }
             }
@@ -4330,8 +4330,8 @@
                 "subscription-state": {
                     "type": "string",
                     "enum": [
-                        "suspended",
-                        "active"
+                        "SUSPENDED",
+                        "ACTIVE"
                     ]
                 }
             }

--- a/SWAGGER/tapi-notification.swagger
+++ b/SWAGGER/tapi-notification.swagger
@@ -3727,7 +3727,14 @@
                         "requested-layer-protocols": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "requested-object-identifier": {
@@ -3803,7 +3810,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "changed-attributes": {
                             "type": "array",
@@ -4067,6 +4081,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -19160,7 +19160,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "meg-identifier": {
                             "type": "string"
@@ -19289,7 +19296,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -19531,6 +19545,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },
@@ -19728,7 +19749,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -19743,7 +19771,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -19902,7 +19937,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "resilience-constraint": {
                             "type": "array",
@@ -19935,7 +19977,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -20162,6 +20211,13 @@
                         },
                         "layer-protocol": {
                             "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
                     }
@@ -20238,6 +20294,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
                         }
@@ -20330,7 +20393,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -20400,7 +20470,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -20432,7 +20509,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -20460,7 +20544,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -20891,7 +20982,14 @@
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -20989,7 +21087,14 @@
                         "path-layer": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "cost-characteristic": {

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1696,100 +1426,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -2119,279 +1755,6 @@
                 "summary": "Delete connection-end-point by ID",
                 "description": "Delete operation of resource: connection-end-point",
                 "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_connection-end-point_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
-            "post": {
-                "summary": "Create termination by ID",
-                "description": "Create operation of resource: termination",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update termination by ID",
-                "description": "Update operation of resource: termination",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete termination by ID",
-                "description": "Delete operation of resource: termination",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -3415,1339 +2778,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -4867,58 +2897,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4944,6 +2927,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4962,11 +2952,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4992,6 +2982,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5010,11 +3007,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5040,6 +3037,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5057,11 +3061,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5089,6 +3093,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5104,11 +3115,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5136,6 +3147,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5151,11 +3169,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5183,6 +3201,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5198,11 +3223,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5228,6 +3253,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5245,11 +3277,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5275,6 +3307,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5293,11 +3332,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5323,6 +3362,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5341,11 +3387,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5371,6 +3417,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5388,11 +3441,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5420,6 +3473,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5435,11 +3495,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5467,6 +3527,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5482,11 +3549,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5514,6 +3581,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5529,11 +3603,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5559,6 +3633,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5576,58 +3657,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5653,6 +3687,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5663,7 +3704,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -5674,11 +3715,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5704,6 +3745,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5728,58 +3776,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5805,6 +3806,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5815,7 +3823,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -5826,11 +3834,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5856,6 +3864,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5880,58 +3895,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/": {
             "get": {
                 "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5957,6 +3925,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5967,7 +3942,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
                             },
                             "type": "array"
                         }
@@ -5978,11 +3953,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
                 "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6008,6 +3983,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6137,91 +4119,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -6240,6 +4142,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6258,11 +4167,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6281,6 +4190,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6299,11 +4215,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -6322,6 +4238,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6339,11 +4262,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6364,6 +4287,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6379,11 +4309,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6404,6 +4334,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6419,11 +4356,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6444,6 +4381,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6459,11 +4403,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6482,6 +4426,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6499,11 +4450,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -6522,6 +4473,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6540,11 +4498,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6563,6 +4521,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6581,11 +4546,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -6604,6 +4569,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6621,11 +4593,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6646,6 +4618,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6661,11 +4640,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6686,6 +4665,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6701,11 +4687,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -6726,6 +4712,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6741,11 +4734,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -6764,6 +4757,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6781,51 +4781,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6844,6 +4804,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6854,7 +4821,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -6865,11 +4832,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6888,6 +4855,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6912,91 +4886,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -7015,6 +4909,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -7025,7 +4926,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -7036,11 +4937,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -7059,6 +4960,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -7075,6 +4983,111 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
                         }
                     },
                     "400": {
@@ -7174,6 +5187,752 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/link/": {
             "get": {
                 "summary": "Retrieve link",
@@ -7243,1254 +6002,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_link_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
-            "get": {
-                "summary": "Retrieve validation",
-                "description": "Retrieve operation of resource: validation",
-                "operationId": "retrieve_context_topology_link_validation_validation",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism by ID",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "validation-mechanism",
-                        "description": "ID of validation-mechanism",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
-            "get": {
-                "summary": "Retrieve lp-transition",
-                "description": "Retrieve operation of resource: lp-transition",
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     },
                     "400": {
@@ -8622,6 +6133,934 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "validation-mechanism",
+                        "description": "ID of validation-mechanism",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
                         }
                     },
                     "400": {
@@ -11896,169 +10335,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/end-point/{local-id}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connectivity-service_end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_connectivity-service_end-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/end-point/{local-id}/capacity/": {
             "post": {
                 "summary": "Create capacity by ID",
@@ -13021,2065 +11297,6 @@
                 }
             }
         },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/": {
-            "post": {
-                "summary": "Create conn-constraint by ID",
-                "description": "Create operation of resource: conn-constraint",
-                "operationId": "create_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "conn-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "description": "conn-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve conn-constraint",
-                "description": "Retrieve operation of resource: conn-constraint",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_conn-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update conn-constraint by ID",
-                "description": "Update operation of resource: conn-constraint",
-                "operationId": "update_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "conn-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "description": "conn-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete conn-constraint by ID",
-                "description": "Delete operation of resource: conn-constraint",
-                "operationId": "delete_context_connectivity-service_conn-constraint_conn-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/": {
-            "get": {
-                "summary": "Retrieve requested-capacity",
-                "description": "Retrieve operation of resource: requested-capacity",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_requested-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/requested-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/schedule/": {
-            "post": {
-                "summary": "Create schedule by ID",
-                "description": "Create operation of resource: schedule",
-                "operationId": "create_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "schedule",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "description": "schedulebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve schedule",
-                "description": "Retrieve operation of resource: schedule",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_schedule_schedule",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update schedule by ID",
-                "description": "Update operation of resource: schedule",
-                "operationId": "update_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "schedule",
-                        "schema": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "description": "schedulebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete schedule by ID",
-                "description": "Delete operation of resource: schedule",
-                "operationId": "delete_context_connectivity-service_conn-constraint_schedule_schedule_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/route-compute-policy/": {
-            "post": {
-                "summary": "Create route-compute-policy by ID",
-                "description": "Create operation of resource: route-compute-policy",
-                "operationId": "create_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "route-compute-policy",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "description": "route-compute-policybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve route-compute-policy",
-                "description": "Retrieve operation of resource: route-compute-policy",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update route-compute-policy by ID",
-                "description": "Update operation of resource: route-compute-policy",
-                "operationId": "update_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "route-compute-policy",
-                        "schema": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "description": "route-compute-policybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete route-compute-policy by ID",
-                "description": "Delete operation of resource: route-compute-policy",
-                "operationId": "delete_context_connectivity-service_conn-constraint_route-compute-policy_route-compute-policy_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/conn-constraint/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_conn-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/": {
-            "post": {
-                "summary": "Create topo-constraint by ID",
-                "description": "Create operation of resource: topo-constraint",
-                "operationId": "create_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "topo-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "description": "topo-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve topo-constraint",
-                "description": "Retrieve operation of resource: topo-constraint",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_topo-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update topo-constraint by ID",
-                "description": "Update operation of resource: topo-constraint",
-                "operationId": "update_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "topo-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "description": "topo-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete topo-constraint by ID",
-                "description": "Delete operation of resource: topo-constraint",
-                "operationId": "delete_context_connectivity-service_topo-constraint_topo-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/topo-constraint/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/topo-constraint/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_topo-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connectivity-service_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_connectivity-service_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/": {
-            "get": {
-                "summary": "Retrieve resilience-constraint",
-                "description": "Retrieve operation of resource: resilience-constraint",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-constraint",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/": {
-            "post": {
-                "summary": "Create resilience-constraint by ID",
-                "description": "Create operation of resource: resilience-constraint",
-                "operationId": "create_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        },
-                        "description": "resilience-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve resilience-constraint by ID",
-                "description": "Retrieve operation of resource: resilience-constraint",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update resilience-constraint by ID",
-                "description": "Update operation of resource: resilience-constraint",
-                "operationId": "update_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-constraint",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        },
-                        "description": "resilience-constraintbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete resilience-constraint by ID",
-                "description": "Delete operation of resource: resilience-constraint",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_resilience-constraint_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/resilience-type/": {
-            "post": {
-                "summary": "Create resilience-type by ID",
-                "description": "Create operation of resource: resilience-type",
-                "operationId": "create_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-type",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "description": "resilience-typebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve resilience-type",
-                "description": "Retrieve operation of resource: resilience-type",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_resilience-type_resilience-type",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update resilience-type by ID",
-                "description": "Update operation of resource: resilience-type",
-                "operationId": "update_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "resilience-type",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "description": "resilience-typebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete resilience-type by ID",
-                "description": "Delete operation of resource: resilience-type",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_resilience-type_resilience-type_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connectivity-service/{uuid}/resilience-constraint/{local-id}/name/{value-name}/": {
-            "post": {
-                "summary": "Create name by ID",
-                "description": "Create operation of resource: name",
-                "operationId": "create_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update name by ID",
-                "description": "Update operation of resource: name",
-                "operationId": "update_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "name",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        },
-                        "description": "namebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete name by ID",
-                "description": "Delete operation of resource: name",
-                "operationId": "delete_context_connectivity-service_resilience-constraint_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connectivity-service/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -15266,6 +11483,662 @@
                         "in": "path",
                         "name": "value-name",
                         "description": "ID of value-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/": {
+            "get": {
+                "summary": "Retrieve requested-capacity",
+                "description": "Retrieve operation of resource: requested-capacity",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_requested-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/requested-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_connectivity-service_requested-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/schedule/": {
+            "post": {
+                "summary": "Create schedule by ID",
+                "description": "Create operation of resource: schedule",
+                "operationId": "create_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "schedule",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "description": "schedulebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve schedule",
+                "description": "Retrieve operation of resource: schedule",
+                "operationId": "retrieve_context_connectivity-service_schedule_schedule",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update schedule by ID",
+                "description": "Update operation of resource: schedule",
+                "operationId": "update_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "schedule",
+                        "schema": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "description": "schedulebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete schedule by ID",
+                "description": "Delete operation of resource: schedule",
+                "operationId": "delete_context_connectivity-service_schedule_schedule_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_connectivity-service_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/connectivity-service/{uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_connectivity-service_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_connectivity-service_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/connectivity-service/{uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_connectivity-service_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/connectivity-service/{uuid}/resilience-type/": {
+            "post": {
+                "summary": "Create resilience-type by ID",
+                "description": "Create operation of resource: resilience-type",
+                "operationId": "create_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "resilience-type",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        },
+                        "description": "resilience-typebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "get": {
+                "summary": "Retrieve resilience-type",
+                "description": "Retrieve operation of resource: resilience-type",
+                "operationId": "retrieve_context_connectivity-service_resilience-type_resilience-type",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update resilience-type by ID",
+                "description": "Update operation of resource: resilience-type",
+                "operationId": "update_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "resilience-type",
+                        "schema": {
+                            "$ref": "#/definitions/resilience-type"
+                        },
+                        "description": "resilience-typebody object",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete resilience-type by ID",
+                "description": "Delete operation of resource: resilience-type",
+                "operationId": "delete_context_connectivity-service_resilience-type_resilience-type_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -15783,177 +12656,6 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/": {
-            "get": {
-                "summary": "Retrieve control-parameters",
-                "description": "Retrieve operation of resource: control-parameters",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_control-parameters",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/resilience-type/": {
-            "get": {
-                "summary": "Retrieve resilience-type",
-                "description": "Retrieve operation of resource: resilience-type",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_resilience-type_resilience-type",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/resilience-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/": {
-            "get": {
-                "summary": "Retrieve name",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_name_name",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/{value-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/connection/{uuid}/switch-control/{local-id}/control-parameters/name/{value-name}/": {
-            "get": {
-                "summary": "Retrieve name by ID",
-                "description": "Retrieve operation of resource: name",
-                "operationId": "retrieve_context_connection_switch-control_control-parameters_name_name_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "value-name",
-                        "description": "ID of value-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/name-and-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/connection/{uuid}/switch-control/{local-id}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -16045,11 +12747,11 @@
                 }
             }
         },
-        "/config/context/connection/{uuid}/state/": {
+        "/config/context/connection/{uuid}/switch-control/{local-id}/resilience-type/": {
             "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_connection_state_state",
+                "summary": "Retrieve resilience-type",
+                "description": "Retrieve operation of resource: resilience-type",
+                "operationId": "retrieve_context_connection_switch-control_resilience-type_resilience-type",
                 "produces": [
                     "application/json"
                 ],
@@ -16063,13 +12765,20 @@
                         "description": "ID of uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "local-id",
+                        "description": "ID of local-id",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
+                            "$ref": "#/definitions/resilience-type"
                         }
                     },
                     "400": {
@@ -16754,197 +13463,6 @@
                 }
             }
         },
-        "/config/context/oam-service/{uuid}/end-point/{local-id}/pro-active-measurement-job/{local-id}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_oam-service_end-point_pro-active-measurement-job_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_oam-service_end-point_pro-active-measurement-job_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_oam-service_end-point_pro-active-measurement-job_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_oam-service_end-point_pro-active-measurement-job_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/oam-service/{uuid}/end-point/{local-id}/pro-active-measurement-job/{local-id}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -17411,197 +13929,6 @@
                 "summary": "Delete on-demand-measurement-job by ID",
                 "description": "Delete operation of resource: on-demand-measurement-job",
                 "operationId": "delete_context_oam-service_end-point_on-demand-measurement-job_on-demand-measurement-job_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/oam-service/{uuid}/end-point/{local-id}/on-demand-measurement-job/{local-id}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_oam-service_end-point_on-demand-measurement-job_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_oam-service_end-point_on-demand-measurement-job_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_oam-service_end-point_on-demand-measurement-job_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_oam-service_end-point_on-demand-measurement-job_state_state_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -19195,32 +15522,10 @@
             ]
         },
         "on-demand-measurement-job": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    }
-                }
-            ]
+            "$ref": "#/definitions/admin-state-pac"
         },
         "pro-active-measurement-job": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    }
-                }
-            ]
+            "$ref": "#/definitions/admin-state-pac"
         },
         "meg": {
             "allOf": [
@@ -19540,6 +15845,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -19554,12 +15865,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }
@@ -19695,6 +16000,9 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
                     "properties": {
                         "connection-end-point": {
                             "type": "array",
@@ -19737,9 +16045,6 @@
                             },
                             "x-key": "local-id"
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
                         "direction": {
                             "type": "string",
                             "enum": [
@@ -19767,6 +16072,12 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
                 },
                 {
                     "properties": {
@@ -19802,12 +16113,6 @@
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
                             }
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
@@ -19837,7 +16142,7 @@
         "connectivity-constraint": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/local-class"
+                    "$ref": "#/definitions/route-compute-policy"
                 },
                 {
                     "properties": {
@@ -19880,9 +16185,6 @@
                             },
                             "x-key": "traffic-property-name"
                         },
-                        "route-compute-policy": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
                         "coroute-inclusion": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
@@ -19904,6 +16206,18 @@
                     "$ref": "#/definitions/service-spec"
                 },
                 {
+                    "$ref": "#/definitions/connectivity-constraint"
+                },
+                {
+                    "$ref": "#/definitions/topology-constraint"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "end-point": {
                             "type": "array",
@@ -19918,15 +16232,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
                             }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "direction": {
                             "type": "string",
@@ -19945,13 +16250,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "resilience-constraint": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resilience-constraint"
-                            },
-                            "x-key": "local-id"
                         }
                     }
                 }
@@ -19962,6 +16260,9 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
                 },
                 {
                     "properties": {
@@ -19985,9 +16286,6 @@
                                 "ETH",
                                 "ETY"
                             ]
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -20132,6 +16430,9 @@
                     "$ref": "#/definitions/local-class"
                 },
                 {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
                     "properties": {
                         "sub-switch-control": {
                             "type": "array",
@@ -20146,9 +16447,6 @@
                                 "$ref": "#/definitions/switch"
                             },
                             "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/resilience-constraint"
                         }
                     }
                 }
@@ -20156,157 +16454,143 @@
             "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
         },
         "resilience-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "resilience-type": {
+                    "$ref": "#/definitions/resilience-type"
                 },
-                {
-                    "properties": {
-                        "resilience-type": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "restoration-coordinate-type": {
-                            "type": "string",
-                            "enum": [
-                                "NO_COORDINATE",
-                                "HOLD_OFF_TIME",
-                                "WAIT_FOR_NOTIFICATION"
-                            ],
-                            "description": " The coordination mechanism between multi-layers."
-                        },
-                        "restore-priority": {
-                            "type": "string"
-                        },
-                        "reversion-mode": {
-                            "type": "string",
-                            "enum": [
-                                "REVERTIVE",
-                                "NON-REVERTIVE"
-                            ],
-                            "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                        },
-                        "wait-to-revert-time": {
-                            "type": "string",
-                            "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                        },
-                        "hold-off-time": {
-                            "type": "string",
-                            "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                        },
-                        "is-lock-out": {
-                            "type": "boolean",
-                            "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                        },
-                        "is-frozen": {
-                            "type": "boolean",
-                            "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                        },
-                        "is-coordinated-switching-both-ends": {
-                            "type": "boolean",
-                            "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                        },
-                        "max-switch-times": {
-                            "type": "string",
-                            "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
-                        },
-                        "layer-protocol": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ],
-                            "description": "Indicate which layer this resilience parameters package configured for."
-                        }
-                    }
+                "restoration-coordinate-type": {
+                    "type": "string",
+                    "enum": [
+                        "NO_COORDINATE",
+                        "HOLD_OFF_TIME",
+                        "WAIT_FOR_NOTIFICATION"
+                    ],
+                    "description": " The coordination mechanism between multi-layers."
+                },
+                "restore-priority": {
+                    "type": "string"
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "REVERTIVE",
+                        "NON-REVERTIVE"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                },
+                "max-switch-times": {
+                    "type": "string",
+                    "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
+                },
+                "layer-protocol": {
+                    "type": "string",
+                    "enum": [
+                        "OTSiA",
+                        "OTU",
+                        "ODU",
+                        "ETH",
+                        "ETY"
+                    ],
+                    "description": "Indicate which layer this resilience parameters package configured for."
                 }
-            ],
-            "description": "A list of control parameters to apply to a switch."
+            }
         },
         "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
+            "properties": {
+                "include-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
                 },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
+                "avoid-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "include-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "exclude-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "include-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                    }
+                },
+                "exclude-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                    }
+                },
+                "include-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                    }
+                },
+                "exclude-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                    }
+                },
+                "preferred-transport-layer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "OTSiA",
+                            "OTU",
+                            "ODU",
+                            "ETH",
+                            "ETY"
+                        ],
+                        "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                     }
                 }
-            ]
+            }
         },
         "cep-list": {
             "properties": {
@@ -20351,6 +16635,30 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
+                },
+                {
                     "properties": {
                         "node-edge-point": {
                             "type": "array",
@@ -20365,30 +16673,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -20426,6 +16710,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -20451,21 +16750,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -20542,6 +16826,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -20567,12 +16857,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -20719,6 +17003,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -20733,18 +17029,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -20754,6 +17038,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -20784,18 +17080,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -21277,6 +17561,52 @@
                             },
                             "x-key": "value-name"
                         },
+                        "administrative-state": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKED",
+                                "UNLOCKED"
+                            ]
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
@@ -21398,6 +17728,45 @@
                                 "$ref": "#/definitions/name-and-value"
                             },
                             "x-key": "value-name"
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
                         },
                         "mip": {
                             "type": "array",

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -19162,11 +19162,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "meg-identifier": {
@@ -19184,10 +19184,10 @@
                         "monitored-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "sink",
-                                "source",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         }
                     }
@@ -19298,11 +19298,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -19385,10 +19385,10 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ]
                         }
                     }
@@ -19419,24 +19419,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -19464,10 +19464,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -19494,17 +19494,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -19546,11 +19546,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -19585,23 +19585,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -19637,10 +19637,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -19672,9 +19672,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -19743,19 +19743,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -19773,11 +19773,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "client-node-edge-point": {
@@ -19811,21 +19811,21 @@
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "connection-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         }
@@ -19844,10 +19844,10 @@
                         "service-type": {
                             "type": "string",
                             "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
                             ]
                         },
                         "service-level": {
@@ -19931,19 +19931,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "resilience-constraint": {
@@ -19979,11 +19979,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "state": {
@@ -19995,33 +19995,33 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "protection-role": {
                             "type": "string",
                             "enum": [
-                                "work",
-                                "protect",
-                                "protected",
-                                "na",
-                                "work-restore",
-                                "protect-restore"
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
                             ],
                             "description": "To specify the protection role of this Port when create or update ConnectivityService."
                         }
@@ -20091,33 +20091,33 @@
                         "selection-control": {
                             "type": "string",
                             "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
                             ],
                             "description": "Degree of administrative control applied to the switch selection."
                         },
                         "selection-reason": {
                             "type": "string",
                             "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
                             ],
                             "description": "The reason for the current switch selection."
                         },
                         "switch-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
                         }
@@ -20168,9 +20168,9 @@
                         "restoration-coordinate-type": {
                             "type": "string",
                             "enum": [
-                                "no-coordinate",
-                                "hold-off-time",
-                                "wait-for-notification"
+                                "NO_COORDINATE",
+                                "HOLD_OFF_TIME",
+                                "WAIT_FOR_NOTIFICATION"
                             ],
                             "description": " The coordination mechanism between multi-layers."
                         },
@@ -20180,8 +20180,8 @@
                         "reversion-mode": {
                             "type": "string",
                             "enum": [
-                                "revertive",
-                                "non-revertive"
+                                "REVERTIVE",
+                                "NON-REVERTIVE"
                             ],
                             "description": "Indcates whether the protection scheme is revertive or non-revertive."
                         },
@@ -20212,11 +20212,11 @@
                         "layer-protocol": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
@@ -20295,11 +20295,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
@@ -20324,23 +20324,23 @@
                 "route-objective-function": {
                     "type": "string",
                     "enum": [
-                        "min-work-route-hop",
-                        "min-work-route-cost",
-                        "min-work-route-latency",
-                        "min-sum-of-work-and-protection-route-hop",
-                        "min-sum-of-work-and-protection-route-cost",
-                        "min-sum-of-work-and-protection-route-latency",
-                        "load-balance-max-unused-capacity"
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
                     ]
                 },
                 "diversity-policy": {
                     "type": "string",
                     "enum": [
-                        "srlg",
-                        "srng",
-                        "sng",
-                        "node",
-                        "link"
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
                     ]
                 }
             }
@@ -20395,20 +20395,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -20472,11 +20472,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -20511,11 +20511,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -20546,11 +20546,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -20577,21 +20577,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -20811,21 +20811,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -20915,21 +20915,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -20974,21 +20974,21 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -21089,11 +21089,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -2596,10 +2596,20 @@
                 {
                     "properties": {
                         "tcm-extension": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "normal",
+                                "pass-through",
+                                "erase"
+                            ]
                         },
                         "tcm-mode": {
                             "type": "string",
+                            "enum": [
+                                "operational",
+                                "transparent",
+                                "monitor"
+                            ],
                             "description": "This attribute specifies the TCM mode at the entity. Valid values are: Operational, Monitor, and Transparent."
                         },
                         "codirectional": {
@@ -2608,10 +2618,30 @@
                         },
                         "ac-status-source": {
                             "type": "string",
+                            "enum": [
+                                "no-source-tc",
+                                "in-use-without-iae",
+                                "in-use-with-iae",
+                                "reserved-1",
+                                "reserved-2",
+                                "lck",
+                                "oci",
+                                "ais"
+                            ],
                             "description": "This attribute indicates the status of the accepted TCM. "
                         },
                         "ac-status-sink": {
                             "type": "string",
+                            "enum": [
+                                "no-source-tc",
+                                "in-use-without-iae",
+                                "in-use-with-iae",
+                                "reserved-1",
+                                "reserved-2",
+                                "lck",
+                                "oci",
+                                "ais"
+                            ],
                             "description": "This attribute indicates the status of the accepted TCM. "
                         },
                         "admin-state-source": {
@@ -2825,10 +2855,20 @@
                 },
                 "deg-thr-type": {
                     "type": "string",
+                    "enum": [
+                        "percentage",
+                        "number-errored-blocks"
+                    ],
                     "description": "Number of errored blocks"
                 },
                 "percentage-granularity": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "ones",
+                        "one-tenths",
+                        "one-hundredths",
+                        "one-thousandths"
+                    ]
                 }
             }
         },
@@ -3056,6 +3096,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },
@@ -3288,7 +3335,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -3358,7 +3412,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -3390,7 +3451,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -3418,7 +3486,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -4026,7 +4101,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -4041,7 +4123,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -4200,7 +4289,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "resilience-constraint": {
                             "type": "array",
@@ -4233,7 +4329,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -4460,6 +4563,13 @@
                         },
                         "layer-protocol": {
                             "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
                     }
@@ -4536,6 +4646,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
                         }

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -102,100 +102,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -571,279 +477,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
-            "post": {
-                "summary": "Create termination by ID",
-                "description": "Create operation of resource: termination",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update termination by ID",
-                "description": "Update operation of resource: termination",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "termination",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "description": "terminationbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete termination by ID",
-                "description": "Delete operation of resource: termination",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1149,284 +782,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/odu-common/": {
-            "post": {
-                "summary": "Create odu-common by ID",
-                "description": "Create operation of resource: odu-common",
-                "operationId": "create_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "odu-common",
-                        "schema": {
-                            "$ref": "#/definitions/odu-common-pac"
-                        },
-                        "description": "odu-commonbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve odu-common",
-                "description": "Retrieve operation of resource: odu-common",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-common-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update odu-common by ID",
-                "description": "Update operation of resource: odu-common",
-                "operationId": "update_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "odu-common",
-                        "schema": {
-                            "$ref": "#/definitions/odu-common-pac"
-                        },
-                        "description": "odu-commonbody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete odu-common by ID",
-                "description": "Delete operation of resource: odu-common",
-                "operationId": "delete_context_topology_node_owned-node-edge-point_connection-end-point_odu-common_odu-common_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/odu-term-and-adapter/": {
-            "get": {
-                "summary": "Retrieve odu-term-and-adapter",
-                "description": "Retrieve operation of resource: odu-term-and-adapter",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-term-and-adapter_odu-term-and-adapter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/odu-term-and-adapter/accepted-payload-type/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/accepted-payload-type/": {
             "get": {
                 "summary": "Retrieve accepted-payload-type",
                 "description": "Retrieve operation of resource: accepted-payload-type",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-term-and-adapter_accepted-payload-type_accepted-payload-type",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_accepted-payload-type_accepted-payload-type",
                 "produces": [
                     "application/json"
                 ],
@@ -1469,161 +829,6 @@
                         "schema": {
                             "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
                             "$ref": "#/definitions/odu-payload-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/odu-ctp/": {
-            "get": {
-                "summary": "Retrieve odu-ctp",
-                "description": "Retrieve operation of resource: odu-ctp",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-ctp_odu-ctp",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-ctp-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/odu-protection/": {
-            "get": {
-                "summary": "Retrieve odu-protection",
-                "description": "Retrieve operation of resource: odu-protection",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_odu-protection_odu-protection",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-protection-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/odu-pool/": {
-            "get": {
-                "summary": "Retrieve odu-pool",
-                "description": "Retrieve operation of resource: odu-pool",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_odu-pool_odu-pool",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-pool-pac"
                         }
                     },
                     "400": {
@@ -1800,91 +1005,11 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mep/{local-id}/odu-common/": {
-            "get": {
-                "summary": "Retrieve odu-common",
-                "description": "Retrieve operation of resource: odu-common",
-                "operationId": "retrieve_context_meg_mep_odu-common_odu-common",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-common-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mep/{local-id}/odu-term-and-adapter/": {
-            "get": {
-                "summary": "Retrieve odu-term-and-adapter",
-                "description": "Retrieve operation of resource: odu-term-and-adapter",
-                "operationId": "retrieve_context_meg_mep_odu-term-and-adapter_odu-term-and-adapter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mep/{local-id}/odu-term-and-adapter/accepted-payload-type/": {
+        "/config/context/meg/{uuid}/mep/{local-id}/accepted-payload-type/": {
             "get": {
                 "summary": "Retrieve accepted-payload-type",
                 "description": "Retrieve operation of resource: accepted-payload-type",
-                "operationId": "retrieve_context_meg_mep_odu-term-and-adapter_accepted-payload-type_accepted-payload-type",
+                "operationId": "retrieve_context_meg_mep_accepted-payload-type_accepted-payload-type",
                 "produces": [
                     "application/json"
                 ],
@@ -1913,86 +1038,6 @@
                         "schema": {
                             "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
                             "$ref": "#/definitions/odu-payload-type"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mep/{local-id}/odu-ctp/": {
-            "get": {
-                "summary": "Retrieve odu-ctp",
-                "description": "Retrieve operation of resource: odu-ctp",
-                "operationId": "retrieve_context_meg_mep_odu-ctp_odu-ctp",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-ctp-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mep/{local-id}/odu-protection/": {
-            "get": {
-                "summary": "Retrieve odu-protection",
-                "description": "Retrieve operation of resource: odu-protection",
-                "operationId": "retrieve_context_meg_mep_odu-protection_odu-protection",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-protection-pac"
                         }
                     },
                     "400": {
@@ -2169,51 +1214,11 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-mip/": {
-            "get": {
-                "summary": "Retrieve odu-mip",
-                "description": "Retrieve operation of resource: odu-mip",
-                "operationId": "retrieve_context_meg_mip_odu-mip_odu-mip",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-mip-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-mip/deg-thr/": {
+        "/config/context/meg/{uuid}/mip/{local-id}/deg-thr/": {
             "get": {
                 "summary": "Retrieve deg-thr",
                 "description": "Retrieve operation of resource: deg-thr",
-                "operationId": "retrieve_context_meg_mip_odu-mip_deg-thr_deg-thr",
+                "operationId": "retrieve_context_meg_mip_deg-thr_deg-thr",
                 "produces": [
                     "application/json"
                 ],
@@ -2250,131 +1255,11 @@
                 }
             }
         },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-ncm/": {
-            "get": {
-                "summary": "Retrieve odu-ncm",
-                "description": "Retrieve operation of resource: odu-ncm",
-                "operationId": "retrieve_context_meg_mip_odu-ncm_odu-ncm",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-ncm-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-tcm/": {
-            "get": {
-                "summary": "Retrieve odu-tcm",
-                "description": "Retrieve operation of resource: odu-tcm",
-                "operationId": "retrieve_context_meg_mip_odu-tcm_odu-tcm",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-tcm-mip-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-pm/": {
-            "get": {
-                "summary": "Retrieve odu-pm",
-                "description": "Retrieve operation of resource: odu-pm",
-                "operationId": "retrieve_context_meg_mip_odu-pm_odu-pm",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-pm-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-pm/uas/": {
+        "/config/context/meg/{uuid}/mip/{local-id}/uas/": {
             "get": {
                 "summary": "Retrieve uas",
                 "description": "Retrieve operation of resource: uas",
-                "operationId": "retrieve_context_meg_mip_odu-pm_uas_uas",
+                "operationId": "retrieve_context_meg_mip_uas_uas",
                 "produces": [
                     "application/json"
                 ],
@@ -2403,46 +1288,6 @@
                         "schema": {
                             "description": "UnAvailable Second",
                             "$ref": "#/definitions/uas-choice"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/meg/{uuid}/mip/{local-id}/odu-defect/": {
-            "get": {
-                "summary": "Retrieve odu-defect",
-                "description": "Retrieve operation of resource: odu-defect",
-                "operationId": "retrieve_context_meg_mip_odu-defect_odu-defect",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "local-id",
-                        "description": "ID of local-id",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/odu-defect-pac"
                         }
                     },
                     "400": {
@@ -2491,20 +1336,7 @@
             }
         },
         "odu-connection-end-point-spec": {
-            "properties": {
-                "odu-common": {
-                    "$ref": "#/definitions/odu-common-pac"
-                },
-                "odu-term-and-adapter": {
-                    "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
-                },
-                "odu-ctp": {
-                    "$ref": "#/definitions/odu-ctp-pac"
-                },
-                "odu-protection": {
-                    "$ref": "#/definitions/odu-protection-pac"
-                }
-            }
+            "$ref": "#/definitions/odu-protection-pac"
         },
         "odu-pool-pac": {
             "properties": {
@@ -2520,11 +1352,7 @@
             }
         },
         "odu-node-edge-point-spec": {
-            "properties": {
-                "odu-pool": {
-                    "$ref": "#/definitions/odu-pool-pac"
-                }
-            }
+            "$ref": "#/definitions/odu-pool-pac"
         },
         "odu-ctp-pac": {
             "description": "This Pac contains the attributes associated with the CTP\nIt is present only if the CEP contains a CTP",
@@ -2547,23 +1375,7 @@
             }
         },
         "odu-mep-spec": {
-            "properties": {
-                "odu-mep": {
-                    "$ref": "#/definitions/odu-mep-pac"
-                },
-                "odu-ncm": {
-                    "$ref": "#/definitions/odu-ncm-pac"
-                },
-                "odu-tcm": {
-                    "$ref": "#/definitions/odu-tcm-mep-pac"
-                },
-                "odu-defect": {
-                    "$ref": "#/definitions/odu-defect-pac"
-                },
-                "odu-pm": {
-                    "$ref": "#/definitions/odu-pm-pac"
-                }
-            }
+            "$ref": "#/definitions/odu-pm-pac"
         },
         "odu-protection-pac": {
             "properties": {
@@ -2665,23 +1477,7 @@
             ]
         },
         "odu-mip-spec": {
-            "properties": {
-                "odu-mip": {
-                    "$ref": "#/definitions/odu-mip-pac"
-                },
-                "odu-ncm": {
-                    "$ref": "#/definitions/odu-ncm-pac"
-                },
-                "odu-tcm": {
-                    "$ref": "#/definitions/odu-tcm-mip-pac"
-                },
-                "odu-pm": {
-                    "$ref": "#/definitions/odu-pm-pac"
-                },
-                "odu-defect": {
-                    "$ref": "#/definitions/odu-defect-pac"
-                }
-            }
+            "$ref": "#/definitions/odu-defect-pac"
         },
         "odu-mip-pac": {
             "properties": {
@@ -2889,81 +1685,6 @@
                 }
             }
         },
-        "context_schema": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/context"
-                },
-                {
-                    "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
-                        "nw-topology-service": {
-                            "$ref": "#/definitions/network-topology-service"
-                        },
-                        "topology": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/topology"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path-comp-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path-computation-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connectivity-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connection"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "oam-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/oam-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "meg": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/meg"
-                            },
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
         "admin-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
             "properties": {
@@ -2975,20 +1696,10 @@
                     ]
                 },
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3013,13 +1724,7 @@
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3043,20 +1748,10 @@
             "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
             "properties": {
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3091,26 +1786,19 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }
@@ -3135,25 +1823,10 @@
             "properties": {
                 "termination-direction": {
                     "type": "string",
-                    "enum": [
-                        "BIDIRECTIONAL",
-                        "SINK",
-                        "SOURCE",
-                        "UNDEFINED_OR_UNKNOWN"
-                    ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
-                    "enum": [
-                        "LP_CAN_NEVER_TERMINATE",
-                        "LT_NOT_TERMINATED",
-                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
-                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
-                        "TERMINATED_BIDIRECTIONAL",
-                        "LT_PERMENANTLY_TERMINATED",
-                        "TERMINATION_STATE_UNKNOWN"
-                    ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
@@ -3186,13 +1859,7 @@
         "bandwidth-profile": {
             "properties": {
                 "bw-profile-type": {
-                    "type": "string",
-                    "enum": [
-                        "MEF_10.x",
-                        "RFC_2697",
-                        "RFC_2698",
-                        "RFC_4115"
-                    ]
+                    "type": "string"
                 },
                 "committed-information-rate": {
                     "$ref": "#/definitions/capacity-value"
@@ -3221,12 +1888,7 @@
                     "type": "string"
                 },
                 "unit": {
-                    "type": "string",
-                    "enum": [
-                        "GBPS",
-                        "MBPS",
-                        "KBPS"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -3240,57 +1902,669 @@
                 }
             }
         },
-        "owned-node-edge-point_schema": {
+        "connection": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/node-edge-point"
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
                 },
                 {
                     "properties": {
-                        "owned-node-edge-point_uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/connection-end-point"
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "lower-connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
+                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
+                            }
+                        },
+                        "supported-link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
+                            }
+                        },
+                        "container-node": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                        },
+                        "route": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/route"
                             },
-                            "x-key": "uuid"
+                            "x-key": "local-id"
                         },
-                        "mip": {
+                        "switch-control": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch-control"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connection-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "properties": {
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        },
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "mep": {
+                        "server-node-edge-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                        },
+                        "peer-connection-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                        },
+                        "associated-route": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
                             }
                         },
-                        "odu-pool": {
-                            "$ref": "#/definitions/odu-pool-pac"
+                        "connection-port-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "connection-port-role": {
+                            "type": "string",
+                            "enum": [
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        }
+                    }
+                }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "connectivity-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/route-compute-policy"
+                },
+                {
+                    "properties": {
+                        "service-type": {
+                            "type": "string",
+                            "enum": [
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
+                            ]
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "is-exclusive": {
+                            "type": "boolean",
+                            "description": "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)"
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "schedule": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name"
+                        },
+                        "coroute-inclusion": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                        },
+                        "diversity-exclusion": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                            }
                         }
                     }
                 }
             ]
         },
+        "connectivity-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "$ref": "#/definitions/connectivity-constraint"
+                },
+                {
+                    "$ref": "#/definitions/topology-constraint"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
+                    "properties": {
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+                            }
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connectivity-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        },
+                        "capacity": {
+                            "$ref": "#/definitions/capacity-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": [
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        },
+                        "protection-role": {
+                            "type": "string",
+                            "enum": [
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
+                            ],
+                            "description": "To specify the protection role of this Port when create or update ConnectivityService."
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "route": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
+        },
+        "connectivity-context": {
+            "properties": {
+                "connectivity-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connectivity-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "connection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "switch": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "selected-connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "selected-route": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                            }
+                        },
+                        "selection-control": {
+                            "type": "string",
+                            "enum": [
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
+                            ],
+                            "description": "Degree of administrative control applied to the switch selection."
+                        },
+                        "selection-reason": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
+                            ],
+                            "description": "The reason for the current switch selection."
+                        },
+                        "switch-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
+                        }
+                    }
+                }
+            ],
+            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
+        },
+        "switch-control": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
+                    "properties": {
+                        "sub-switch-control": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                            }
+                        },
+                        "switch": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch"
+                            },
+                            "x-key": "local-id"
+                        }
+                    }
+                }
+            ],
+            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
+        },
+        "resilience-constraint": {
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "resilience-type": {
+                    "$ref": "#/definitions/resilience-type"
+                },
+                "restoration-coordinate-type": {
+                    "type": "string",
+                    "enum": [
+                        "NO_COORDINATE",
+                        "HOLD_OFF_TIME",
+                        "WAIT_FOR_NOTIFICATION"
+                    ],
+                    "description": " The coordination mechanism between multi-layers."
+                },
+                "restore-priority": {
+                    "type": "string"
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "REVERTIVE",
+                        "NON-REVERTIVE"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                },
+                "max-switch-times": {
+                    "type": "string",
+                    "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
+                },
+                "layer-protocol": {
+                    "type": "string",
+                    "enum": [
+                        "OTSiA",
+                        "OTU",
+                        "ODU",
+                        "ETH",
+                        "ETY"
+                    ],
+                    "description": "Indicate which layer this resilience parameters package configured for."
+                }
+            }
+        },
+        "topology-constraint": {
+            "properties": {
+                "include-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "avoid-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "include-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "exclude-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "include-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                    }
+                },
+                "exclude-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                    }
+                },
+                "include-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                    }
+                },
+                "exclude-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                    }
+                },
+                "preferred-transport-layer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "OTSiA",
+                            "OTU",
+                            "ODU",
+                            "ETH",
+                            "ETY"
+                        ],
+                        "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
+                    }
+                }
+            }
+        },
+        "cep-list": {
+            "properties": {
+                "connection-end-point": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection-end-point"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "route-compute-policy": {
+            "properties": {
+                "route-objective-function": {
+                    "type": "string",
+                    "enum": [
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
+                    ]
+                },
+                "diversity-policy": {
+                    "type": "string",
+                    "enum": [
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
+                    ]
+                }
+            }
+        },
         "link": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
                 },
                 {
                     "properties": {
@@ -3307,30 +2581,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -3368,6 +2618,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -3393,21 +2658,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -3484,6 +2734,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -3509,12 +2765,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -3661,6 +2911,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -3675,18 +2937,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -3696,6 +2946,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -3726,18 +2988,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -3876,6 +3126,602 @@
                 }
             }
         },
+        "path": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                            }
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        }
+                    }
+                }
+            ],
+            "description": "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes"
+        },
+        "path-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "service-layer": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "path-computation-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                            }
+                        },
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "objective-function": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "optimization-constraint": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-objective-function": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "bandwidth-optimization": {
+                            "type": "string"
+                        },
+                        "concurrent-paths": {
+                            "type": "string"
+                        },
+                        "cost-optimization": {
+                            "type": "string"
+                        },
+                        "link-utilization": {
+                            "type": "string"
+                        },
+                        "resource-sharing": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-optimization-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "traffic-interruption": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "routing-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "path-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name"
+                        },
+                        "include-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        },
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "path-computation-context": {
+            "properties": {
+                "path-comp-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path-computation-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "path": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "mep": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "on-demand-measurement-job": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:on-demand-measurement-job/tapi-oam:local-id"
+                            }
+                        },
+                        "pro-active-measurement-job": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:oam-service/tapi-oam:end-point/tapi-oam:pro-active-measurement-job/tapi-oam:local-id"
+                            }
+                        },
+                        "layer-protocol-name": {
+                            "type": "string"
+                        },
+                        "meg-identifier": {
+                            "type": "string"
+                        },
+                        "mep-identifier": {
+                            "type": "string"
+                        },
+                        "peer-mep-identifier": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "monitored-direction": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "on-demand-measurement-job": {
+            "$ref": "#/definitions/admin-state-pac"
+        },
+        "pro-active-measurement-job": {
+            "$ref": "#/definitions/admin-state-pac"
+        },
+        "meg": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "me": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/me"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "mep": {
+                            "description": "1. ME may have 0 MEPs (case of transit domains where at least 1 MIP is present)\n2. ME may have 1 MEP (case of edge domaind, where the peer MEP is ouside the managed domain)\n3. ME may have 2 MEPs",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/mep"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "mip": {
+                            "description": "ME may 0, 1, or more MIPs",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/mip"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "meg-level": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "me": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "mep": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+                            }
+                        },
+                        "mip": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+                            }
+                        },
+                        "connection-route": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                        }
+                    }
+                }
+            ]
+        },
+        "mip": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "layer-protocol-name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "oam-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "meg": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:uuid"
+                        },
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/oam-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        }
+                    }
+                }
+            ]
+        },
+        "oam-context": {
+            "properties": {
+                "oam-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/oam-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "meg": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meg"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "oam-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "pro-active-measurement-job": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/pro-active-measurement-job"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "on-demand-measurement-job": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/on-demand-measurement-job"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "associated-mep": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+                        },
+                        "direction": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "mep-mip-list": {
+            "properties": {
+                "mip": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+                    }
+                },
+                "mep": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+                    }
+                }
+            }
+        },
+        "context_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/context"
+                },
+                {
+                    "properties": {
+                        "uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "nw-topology-service": {
+                            "$ref": "#/definitions/network-topology-service"
+                        },
+                        "topology": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/topology"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path-comp-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-computation-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connectivity-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "oam-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/oam-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "meg": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/meg"
+                            },
+                            "x-key": "uuid"
+                        }
+                    }
+                }
+            ]
+        },
+        "owned-node-edge-point_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/node-edge-point"
+                },
+                {
+                    "properties": {
+                        "owned-node-edge-point_uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "administrative-state": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKED",
+                                "UNLOCKED"
+                            ]
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection-end-point"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "mip": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mip/tapi-oam:local-id"
+                            }
+                        },
+                        "mep": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
+                            }
+                        },
+                        "client-capacity": {
+                            "type": "string"
+                        },
+                        "max-client-instances": {
+                            "type": "string"
+                        },
+                        "max-client-size": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
         "get-topology-detailsRPC_input_schema": {
             "properties": {
                 "topology-id-or-name": {
@@ -4011,6 +3857,45 @@
                             },
                             "x-key": "value-name"
                         },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
                         "mip": {
                             "type": "array",
                             "items": {
@@ -4025,677 +3910,86 @@
                                 "x-path": "/tapi-common:context/tapi-oam:meg/tapi-oam:mep/tapi-oam:local-id"
                             }
                         },
-                        "odu-common": {
-                            "$ref": "#/definitions/odu-common-pac"
+                        "odu-type": {
+                            "type": "string",
+                            "enum": [
+                                "ODU0",
+                                "ODU1",
+                                "ODU2",
+                                "ODU2E",
+                                "ODU3",
+                                "ODU4",
+                                "ODU_FLEX",
+                                "ODU_CN"
+                            ],
+                            "description": "This attribute specifies the type of the ODU termination point."
                         },
-                        "odu-term-and-adapter": {
-                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
+                        "odu-rate": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
                         },
-                        "odu-ctp": {
-                            "$ref": "#/definitions/odu-ctp-pac"
+                        "odu-rate-tolerance": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
                         },
-                        "odu-protection": {
-                            "$ref": "#/definitions/odu-protection-pac"
+                        "opu-tributary-slot-size": {
+                            "type": "string",
+                            "enum": [
+                                "1G25",
+                                "2G5"
+                            ],
+                            "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
+                        },
+                        "auto-payload-type": {
+                            "type": "boolean",
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
+                        },
+                        "configured-client-type": {
+                            "type": "string",
+                            "description": "This attribute configures the type of the client CTP of the server ODU TTP."
+                        },
+                        "configured-mapping-type": {
+                            "type": "string",
+                            "enum": [
+                                "AMP",
+                                "BMP",
+                                "GFP-F",
+                                "GMP",
+                                "TTP_GFP_BMP",
+                                "NULL"
+                            ],
+                            "description": "This attributes indicates the configured mapping type."
+                        },
+                        "accepted-payload-type": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
+                        },
+                        "tributary-slot-list": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \nThis attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. \nIt will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). \nThe upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). \nThus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
+                            }
+                        },
+                        "tributary-port-number": {
+                            "type": "string",
+                            "description": "This attribute identifies the tributary port number that is associated with the ODU CTP.\nrange of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.\nIn case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.\nIn case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.\nIn case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.\nIn case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\n"
+                        },
+                        "accepted-m-si": {
+                            "type": "string",
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
+                        },
+                        "aps-enable": {
+                            "type": "boolean",
+                            "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
+                        },
+                        "aps-level": {
+                            "type": "string",
+                            "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
                         }
                     }
                 }
             ]
-        },
-        "connection": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "lower-connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
-                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
-                            }
-                        },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
-                        "route": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/route"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "switch-control": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch-control"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "UNIDIRECTIONAL",
-                                "UNDEFINED_OR_UNKNOWN"
-                            ]
-                        },
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connection-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        },
-                        "client-node-edge-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
-                            }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "connection-port-direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "connection-port-role": {
-                            "type": "string",
-                            "enum": [
-                                "SYMMETRIC",
-                                "ROOT",
-                                "LEAF",
-                                "TRUNK",
-                                "UNKNOWN"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ],
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
-        },
-        "connectivity-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-type": {
-                            "type": "string",
-                            "enum": [
-                                "POINT_TO_POINT_CONNECTIVITY",
-                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
-                                "MULTIPOINT_CONNECTIVITY",
-                                "ROOTED_MULTIPOINT_CONNECTIVITY"
-                            ]
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "is-exclusive": {
-                            "type": "boolean",
-                            "description": "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "schedule": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "cost-characteristic": {
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "x-key": "cost-name"
-                        },
-                        "latency-characteristic": {
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "x-key": "traffic-property-name"
-                        },
-                        "route-compute-policy": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "coroute-inclusion": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                        },
-                        "diversity-exclusion": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        "connectivity-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "end-point": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service-end-point"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
-                            }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "UNIDIRECTIONAL",
-                                "UNDEFINED_OR_UNKNOWN"
-                            ]
-                        },
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        },
-                        "resilience-constraint": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resilience-constraint"
-                            },
-                            "x-key": "local-id"
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connectivity-service-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "role": {
-                            "type": "string",
-                            "enum": [
-                                "SYMMETRIC",
-                                "ROOT",
-                                "LEAF",
-                                "TRUNK",
-                                "UNKNOWN"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        },
-                        "protection-role": {
-                            "type": "string",
-                            "enum": [
-                                "WORK",
-                                "PROTECT",
-                                "PROTECTED",
-                                "NA",
-                                "WORK_RESTORE",
-                                "PROTECT_RESTORE"
-                            ],
-                            "description": "To specify the protection role of this Port when create or update ConnectivityService."
-                        }
-                    }
-                }
-            ],
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
-        },
-        "route": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        }
-                    }
-                }
-            ],
-            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
-        },
-        "connectivity-context": {
-            "properties": {
-                "connectivity-service": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    },
-                    "x-key": "uuid"
-                },
-                "connection": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connection"
-                    },
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "switch": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "selected-connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "selected-route": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
-                            }
-                        },
-                        "selection-control": {
-                            "type": "string",
-                            "enum": [
-                                "LOCK_OUT",
-                                "NORMAL",
-                                "MANUAL",
-                                "FORCED"
-                            ],
-                            "description": "Degree of administrative control applied to the switch selection."
-                        },
-                        "selection-reason": {
-                            "type": "string",
-                            "enum": [
-                                "LOCKOUT",
-                                "NORMAL",
-                                "MANUAL",
-                                "FORCED",
-                                "WAIT_TO_REVERT",
-                                "SIGNAL_DEGRADE",
-                                "SIGNAL_FAIL"
-                            ],
-                            "description": "The reason for the current switch selection."
-                        },
-                        "switch-direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
-                        }
-                    }
-                }
-            ],
-            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
-        },
-        "switch-control": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "sub-switch-control": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
-                            }
-                        },
-                        "switch": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    }
-                }
-            ],
-            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
-        },
-        "resilience-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "resilience-type": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "restoration-coordinate-type": {
-                            "type": "string",
-                            "enum": [
-                                "NO_COORDINATE",
-                                "HOLD_OFF_TIME",
-                                "WAIT_FOR_NOTIFICATION"
-                            ],
-                            "description": " The coordination mechanism between multi-layers."
-                        },
-                        "restore-priority": {
-                            "type": "string"
-                        },
-                        "reversion-mode": {
-                            "type": "string",
-                            "enum": [
-                                "REVERTIVE",
-                                "NON-REVERTIVE"
-                            ],
-                            "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                        },
-                        "wait-to-revert-time": {
-                            "type": "string",
-                            "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                        },
-                        "hold-off-time": {
-                            "type": "string",
-                            "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                        },
-                        "is-lock-out": {
-                            "type": "boolean",
-                            "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                        },
-                        "is-frozen": {
-                            "type": "boolean",
-                            "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                        },
-                        "is-coordinated-switching-both-ends": {
-                            "type": "boolean",
-                            "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                        },
-                        "max-switch-times": {
-                            "type": "string",
-                            "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
-                        },
-                        "layer-protocol": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ],
-                            "description": "Indicate which layer this resilience parameters package configured for."
-                        }
-                    }
-                }
-            ],
-            "description": "A list of control parameters to apply to a switch."
-        },
-        "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        "cep-list": {
-            "properties": {
-                "connection-end-point": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connection-end-point"
-                    },
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "route-compute-policy": {
-            "properties": {
-                "route-objective-function": {
-                    "type": "string",
-                    "enum": [
-                        "MIN_WORK_ROUTE_HOP",
-                        "MIN_WORK_ROUTE_COST",
-                        "MIN_WORK_ROUTE_LATENCY",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
-                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
-                    ]
-                },
-                "diversity-policy": {
-                    "type": "string",
-                    "enum": [
-                        "SRLG",
-                        "SRNG",
-                        "SNG",
-                        "NODE",
-                        "LINK"
-                    ]
-                }
-            }
         },
         "get-connection-detailsRPC_input_schema": {
             "properties": {
@@ -4834,17 +4128,82 @@
                             },
                             "x-key": "value-name"
                         },
-                        "odu-common": {
-                            "$ref": "#/definitions/odu-common-pac"
+                        "odu-type": {
+                            "type": "string",
+                            "enum": [
+                                "ODU0",
+                                "ODU1",
+                                "ODU2",
+                                "ODU2E",
+                                "ODU3",
+                                "ODU4",
+                                "ODU_FLEX",
+                                "ODU_CN"
+                            ],
+                            "description": "This attribute specifies the type of the ODU termination point."
                         },
-                        "odu-term-and-adapter": {
-                            "$ref": "#/definitions/odu-termination-and-client-adaptation-pac"
+                        "odu-rate": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate of the ODU terminatino point. \nThis attribute is Set at create; i.e., once created it cannot be changed directly. \nIn case of resizable ODU flex, its value can be changed via HAO (not directly on the attribute). \n"
                         },
-                        "odu-ctp": {
-                            "$ref": "#/definitions/odu-ctp-pac"
+                        "odu-rate-tolerance": {
+                            "type": "string",
+                            "description": "This attribute indicates the rate tolerance of the ODU termination point. \nValid values are real value in the unit of ppm. \nStandardized values are defined in Table 7-2/G.709."
                         },
-                        "odu-protection": {
-                            "$ref": "#/definitions/odu-protection-pac"
+                        "opu-tributary-slot-size": {
+                            "type": "string",
+                            "enum": [
+                                "1G25",
+                                "2G5"
+                            ],
+                            "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
+                        },
+                        "auto-payload-type": {
+                            "type": "boolean",
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. "
+                        },
+                        "configured-client-type": {
+                            "type": "string",
+                            "description": "This attribute configures the type of the client CTP of the server ODU TTP."
+                        },
+                        "configured-mapping-type": {
+                            "type": "string",
+                            "enum": [
+                                "AMP",
+                                "BMP",
+                                "GFP-F",
+                                "GMP",
+                                "TTP_GFP_BMP",
+                                "NULL"
+                            ],
+                            "description": "This attributes indicates the configured mapping type."
+                        },
+                        "accepted-payload-type": {
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU CTP Sink at the client layer of the ODUP/ODU[i]j or ODUP/ODUj-21 adaptation function. \nThis attribute is a 2-digit Hex code that indicates the new accepted payload type.\nValid values are defined in Table 15-8 of ITU-T Recommendation G.709 with one additional value UN_INTERPRETABLE.",
+                            "$ref": "#/definitions/odu-payload-type"
+                        },
+                        "tributary-slot-list": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODU Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). \nThis attribute applies when the LO ODU_ ConnectionTerminationPoint connects with an HO ODU_TrailTerminationPoint object. \nIt will not apply if this ODU_ ConnectionTerminationPoint object directly connects to an OTU_TrailTerminationPoint object (i.e. OTU has no trib slots). \nThe upper bound of the integer allowed in this set is a function of the HO-ODU server layer to which the ODU connection has been mapped (adapted). \nThus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly)."
+                            }
+                        },
+                        "tributary-port-number": {
+                            "type": "string",
+                            "description": "This attribute identifies the tributary port number that is associated with the ODU CTP.\nrange of type : The value range depends on the size of the Tributary Port Number (TPN) field used which depends on th server-layer ODU or OTU.\nIn case of ODUk mapping into OTUk, there is no TPN field, so the tributaryPortNumber shall be zero.\nIn case of LO ODUj mapping over ODU1, ODU2 or ODU3, the TPN is encoded in a 6-bit field so the value range is 0-63. See clause 14.4.1/G.709-2016.\nIn case of LO ODUj mapping over ODU4, the TPN is encoded in a 7-bit field so the value range is 0-127. See clause 14.4.1.4/G.709-2016.\nIn case of ODUk mapping over ODUCn, the TPN is encoded in a 14-bit field so the value range is 0-16383. See clause 20.4.1.1/G.709-2016.\n"
+                        },
+                        "accepted-m-si": {
+                            "type": "string",
+                            "description": "This attribute is applicable when the ODU CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. "
+                        },
+                        "aps-enable": {
+                            "type": "boolean",
+                            "description": "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function."
+                        },
+                        "aps-level": {
+                            "type": "string",
+                            "description": "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODU_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively."
                         }
                     }
                 }
@@ -4868,20 +4227,94 @@
                             },
                             "x-key": "value-name"
                         },
-                        "odu-mip": {
-                            "$ref": "#/definitions/odu-mip-pac"
+                        "acti": {
+                            "type": "string",
+                            "description": "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail."
                         },
-                        "odu-ncm": {
-                            "$ref": "#/definitions/odu-ncm-pac"
+                        "ex-dapi": {
+                            "type": "string",
+                            "description": "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity."
                         },
-                        "odu-tcm": {
-                            "$ref": "#/definitions/odu-tcm-mip-pac"
+                        "ex-sapi": {
+                            "type": "string",
+                            "description": "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.\n"
                         },
-                        "odu-pm": {
-                            "$ref": "#/definitions/odu-pm-pac"
+                        "tim-act-disabled": {
+                            "type": "boolean",
+                            "description": "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink."
                         },
-                        "odu-defect": {
-                            "$ref": "#/definitions/odu-defect-pac"
+                        "tim-det-mode": {
+                            "type": "string",
+                            "enum": [
+                                "DAPI",
+                                "SAPI",
+                                "BOTH",
+                                "OFF"
+                            ],
+                            "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI"
+                        },
+                        "deg-m": {
+                            "type": "string",
+                            "description": "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected."
+                        },
+                        "deg-thr": {
+                            "description": "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.",
+                            "$ref": "#/definitions/deg-thr"
+                        },
+                        "tcm-fields-in-use": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "This attribute indicates the used TCM fields of the ODU OH."
+                            }
+                        },
+                        "tcm-field": {
+                            "type": "string",
+                            "description": "This attribute indicates the tandem connection monitoring field of the ODU OH."
+                        },
+                        "n-bbe": {
+                            "type": "string",
+                            "description": "Near-end Background Block Error"
+                        },
+                        "f-bbe": {
+                            "type": "string",
+                            "description": "Far-end Background Block Error"
+                        },
+                        "n-ses": {
+                            "type": "string",
+                            "description": "Near-end Severely Errored Second"
+                        },
+                        "f-ses": {
+                            "type": "string",
+                            "description": "Far-end Severely Errored Second"
+                        },
+                        "uas": {
+                            "description": "UnAvailable Second",
+                            "$ref": "#/definitions/uas-choice"
+                        },
+                        "bdi": {
+                            "type": "boolean",
+                            "description": "Backward Defect Indication"
+                        },
+                        "deg": {
+                            "type": "boolean",
+                            "description": "Signal Degraded"
+                        },
+                        "lck": {
+                            "type": "boolean",
+                            "description": "Locked"
+                        },
+                        "oci": {
+                            "type": "boolean",
+                            "description": "Open Connection Indicator"
+                        },
+                        "ssf": {
+                            "type": "boolean",
+                            "description": "Server Signal Failure"
+                        },
+                        "tim": {
+                            "type": "boolean",
+                            "description": "Trail Trace Identifier Mismatch"
                         }
                     }
                 }

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -2459,8 +2459,8 @@
                 "opu-tributary-slot-size": {
                     "type": "string",
                     "enum": [
-                        "1-g-25",
-                        "2-g-5"
+                        "1G25",
+                        "2G5"
                     ],
                     "description": "This attribute is applicable for ODU2 and ODU3 CTP only. It indicates the slot size of the ODU CTP."
                 },
@@ -2475,12 +2475,12 @@
                 "configured-mapping-type": {
                     "type": "string",
                     "enum": [
-                        "amp",
-                        "bmp",
-                        "gfp-f",
-                        "gmp",
-                        "ttp-gfp-bmp",
-                        "null"
+                        "AMP",
+                        "BMP",
+                        "GFP-F",
+                        "GMP",
+                        "TTP_GFP_BMP",
+                        "NULL"
                     ],
                     "description": "This attributes indicates the configured mapping type."
                 },
@@ -2598,17 +2598,17 @@
                         "tcm-extension": {
                             "type": "string",
                             "enum": [
-                                "normal",
-                                "pass-through",
-                                "erase"
+                                "NORMAL",
+                                "PASS-THROUGH",
+                                "ERASE"
                             ]
                         },
                         "tcm-mode": {
                             "type": "string",
                             "enum": [
-                                "operational",
-                                "transparent",
-                                "monitor"
+                                "OPERATIONAL",
+                                "TRANSPARENT",
+                                "MONITOR"
                             ],
                             "description": "This attribute specifies the TCM mode at the entity. Valid values are: Operational, Monitor, and Transparent."
                         },
@@ -2619,44 +2619,44 @@
                         "ac-status-source": {
                             "type": "string",
                             "enum": [
-                                "no-source-tc",
-                                "in-use-without-iae",
-                                "in-use-with-iae",
-                                "reserved-1",
-                                "reserved-2",
-                                "lck",
-                                "oci",
-                                "ais"
+                                "NO_SOURCE_TC",
+                                "IN_USE_WITHOUT_IAE",
+                                "IN_USE_WITH_IAE",
+                                "RESERVED_1",
+                                "RESERVED_2",
+                                "LCK",
+                                "OCI",
+                                "AIS"
                             ],
                             "description": "This attribute indicates the status of the accepted TCM. "
                         },
                         "ac-status-sink": {
                             "type": "string",
                             "enum": [
-                                "no-source-tc",
-                                "in-use-without-iae",
-                                "in-use-with-iae",
-                                "reserved-1",
-                                "reserved-2",
-                                "lck",
-                                "oci",
-                                "ais"
+                                "NO_SOURCE_TC",
+                                "IN_USE_WITHOUT_IAE",
+                                "IN_USE_WITH_IAE",
+                                "RESERVED_1",
+                                "RESERVED_2",
+                                "LCK",
+                                "OCI",
+                                "AIS"
                             ],
                             "description": "This attribute indicates the status of the accepted TCM. "
                         },
                         "admin-state-source": {
                             "type": "string",
                             "enum": [
-                                "locked",
-                                "unlocked"
+                                "LOCKED",
+                                "UNLOCKED"
                             ],
                             "description": "This attribute provides the capability to provision the LOCK signal at the source, which is one of the ODU maintenance signals.  When a Tandem Connection endpoint is set to admin state locked, it will insert the ODU-LCK signal in the source direction."
                         },
                         "admin-state-sink": {
                             "type": "string",
                             "enum": [
-                                "locked",
-                                "unlocked"
+                                "LOCKED",
+                                "UNLOCKED"
                             ],
                             "description": "This attribute provides the capability to provision the LOCK signal at the sink, which is one of the ODU maintenance signals. When a Tandem Connection endpoint is set to admin state locked, it will insert the ODU-LCK signal in the downstream direction."
                         }
@@ -2704,10 +2704,10 @@
                 "tim-det-mode": {
                     "type": "string",
                     "enum": [
-                        "dapi",
-                        "sapi",
-                        "both",
-                        "off"
+                        "DAPI",
+                        "SAPI",
+                        "BOTH",
+                        "OFF"
                     ],
                     "description": "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection function allowed values: OFF, SAPIonly, DAPIonly, SAPIandDAPI"
                 },
@@ -2757,14 +2757,14 @@
                 "odu-type": {
                     "type": "string",
                     "enum": [
-                        "odu-0",
-                        "odu-1",
-                        "odu-2",
-                        "odu-2-e",
-                        "odu-3",
-                        "odu-4",
-                        "odu-flex",
-                        "odu-cn"
+                        "ODU0",
+                        "ODU1",
+                        "ODU2",
+                        "ODU2E",
+                        "ODU3",
+                        "ODU4",
+                        "ODU_FLEX",
+                        "ODU_CN"
                     ],
                     "description": "This attribute specifies the type of the ODU termination point."
                 },
@@ -2837,8 +2837,8 @@
                 "named-payload-type": {
                     "type": "string",
                     "enum": [
-                        "unknown",
-                        "uninterpretable"
+                        "UNKNOWN",
+                        "UNINTERPRETABLE"
                     ]
                 },
                 "hex-payload-type": {
@@ -2856,18 +2856,18 @@
                 "deg-thr-type": {
                     "type": "string",
                     "enum": [
-                        "percentage",
-                        "number-errored-blocks"
+                        "PERCENTAGE",
+                        "NUMBER_ERRORED_BLOCKS"
                     ],
                     "description": "Number of errored blocks"
                 },
                 "percentage-granularity": {
                     "type": "string",
                     "enum": [
-                        "ones",
-                        "one-tenths",
-                        "one-hundredths",
-                        "one-thousandths"
+                        "ONES",
+                        "ONE_TENTHS",
+                        "ONE_HUNDREDTHS",
+                        "ONE_THOUSANDTHS"
                     ]
                 }
             }
@@ -2970,24 +2970,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3015,10 +3015,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3045,17 +3045,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -3097,11 +3097,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -3136,23 +3136,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -3188,10 +3188,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -3223,9 +3223,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -3337,20 +3337,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -3414,11 +3414,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -3453,11 +3453,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -3488,11 +3488,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -3519,21 +3519,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -3753,21 +3753,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -3857,21 +3857,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -3986,8 +3986,8 @@
                 "state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 }
             }
@@ -4095,19 +4095,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -4125,11 +4125,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "client-node-edge-point": {
@@ -4163,21 +4163,21 @@
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "connection-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         }
@@ -4196,10 +4196,10 @@
                         "service-type": {
                             "type": "string",
                             "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
                             ]
                         },
                         "service-level": {
@@ -4283,19 +4283,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "resilience-constraint": {
@@ -4331,11 +4331,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "state": {
@@ -4347,33 +4347,33 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "protection-role": {
                             "type": "string",
                             "enum": [
-                                "work",
-                                "protect",
-                                "protected",
-                                "na",
-                                "work-restore",
-                                "protect-restore"
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
                             ],
                             "description": "To specify the protection role of this Port when create or update ConnectivityService."
                         }
@@ -4443,33 +4443,33 @@
                         "selection-control": {
                             "type": "string",
                             "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
                             ],
                             "description": "Degree of administrative control applied to the switch selection."
                         },
                         "selection-reason": {
                             "type": "string",
                             "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
                             ],
                             "description": "The reason for the current switch selection."
                         },
                         "switch-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
                         }
@@ -4520,9 +4520,9 @@
                         "restoration-coordinate-type": {
                             "type": "string",
                             "enum": [
-                                "no-coordinate",
-                                "hold-off-time",
-                                "wait-for-notification"
+                                "NO_COORDINATE",
+                                "HOLD_OFF_TIME",
+                                "WAIT_FOR_NOTIFICATION"
                             ],
                             "description": " The coordination mechanism between multi-layers."
                         },
@@ -4532,8 +4532,8 @@
                         "reversion-mode": {
                             "type": "string",
                             "enum": [
-                                "revertive",
-                                "non-revertive"
+                                "REVERTIVE",
+                                "NON-REVERTIVE"
                             ],
                             "description": "Indcates whether the protection scheme is revertive or non-revertive."
                         },
@@ -4564,11 +4564,11 @@
                         "layer-protocol": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
@@ -4647,11 +4647,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
@@ -4676,23 +4676,23 @@
                 "route-objective-function": {
                     "type": "string",
                     "enum": [
-                        "min-work-route-hop",
-                        "min-work-route-cost",
-                        "min-work-route-latency",
-                        "min-sum-of-work-and-protection-route-hop",
-                        "min-sum-of-work-and-protection-route-cost",
-                        "min-sum-of-work-and-protection-route-latency",
-                        "load-balance-max-unused-capacity"
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
                     ]
                 },
                 "diversity-policy": {
                     "type": "string",
                     "enum": [
-                        "srlg",
-                        "srng",
-                        "sng",
-                        "node",
-                        "link"
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
                     ]
                 }
             }

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -1478,11 +1478,11 @@
                 "optical-routing-strategy": {
                     "type": "string",
                     "enum": [
-                        "optimal-osnr",
-                        "no-relay",
-                        "min-relay",
-                        "preferred-no-change-wavelength-as-restore",
-                        "preferred-no-skipping-wavelength"
+                        "OPTIMAL_OSNR",
+                        "NO_RELAY",
+                        "MIN_RELAY",
+                        "PREFERRED_NO_CHANGE_WAVELENGTH_AS_RESTORE",
+                        "PREFERRED_NO_SKIPPING_WAVELENGTH"
                     ]
                 }
             }
@@ -1502,12 +1502,12 @@
                 "application-identifier-type": {
                     "type": "string",
                     "enum": [
-                        "proprietary",
-                        "itut-g-959-1",
-                        "itut-g-698-1",
-                        "itut-g-698-2",
-                        "itut-g-696-1",
-                        "itut-g-695"
+                        "PROPRIETARY",
+                        "ITUT_G959_1",
+                        "ITUT_G698_1",
+                        "ITUT_G698_2",
+                        "ITUT_G696_1",
+                        "ITUT_G695"
                     ]
                 },
                 "application-identifier-value": {
@@ -1521,21 +1521,21 @@
                 "grid-type": {
                     "type": "string",
                     "enum": [
-                        "dwdm",
-                        "cwdm",
-                        "flex",
-                        "unspecified"
+                        "DWDM",
+                        "CWDM",
+                        "FLEX",
+                        "UNSPECIFIED"
                     ],
                     "description": "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width"
                 },
                 "adjustment-granularity": {
                     "type": "string",
                     "enum": [
-                        "g-100-ghz",
-                        "g-50-ghz",
-                        "g-25-ghz",
-                        "g-12-5-ghz",
-                        "g-6-25-ghz"
+                        "G_100GHZ",
+                        "G_50GHZ",
+                        "G_25GHZ",
+                        "G_12_5GHZ",
+                        "G_6_25GHZ"
                     ],
                     "description": "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)"
                 },
@@ -1624,24 +1624,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1669,10 +1669,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1699,17 +1699,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -1751,11 +1751,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -1790,23 +1790,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -1842,10 +1842,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -1877,9 +1877,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }
@@ -2043,20 +2043,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -2120,11 +2120,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -2159,11 +2159,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -2194,11 +2194,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -2225,21 +2225,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -2459,21 +2459,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -2563,21 +2563,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -2671,19 +2671,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -2701,11 +2701,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "client-node-edge-point": {
@@ -2739,21 +2739,21 @@
                         "connection-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "connection-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         }
@@ -2772,10 +2772,10 @@
                         "service-type": {
                             "type": "string",
                             "enum": [
-                                "point-to-point-connectivity",
-                                "point-to-multipoint-connectivity",
-                                "multipoint-connectivity",
-                                "rooted-multipoint-connectivity"
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
                             ]
                         },
                         "service-level": {
@@ -2859,19 +2859,19 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ]
                         },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "resilience-constraint": {
@@ -2907,11 +2907,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "state": {
@@ -2923,33 +2923,33 @@
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "protection-role": {
                             "type": "string",
                             "enum": [
-                                "work",
-                                "protect",
-                                "protected",
-                                "na",
-                                "work-restore",
-                                "protect-restore"
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
                             ],
                             "description": "To specify the protection role of this Port when create or update ConnectivityService."
                         }
@@ -3019,33 +3019,33 @@
                         "selection-control": {
                             "type": "string",
                             "enum": [
-                                "lock-out",
-                                "normal",
-                                "manual",
-                                "forced"
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
                             ],
                             "description": "Degree of administrative control applied to the switch selection."
                         },
                         "selection-reason": {
                             "type": "string",
                             "enum": [
-                                "lockout",
-                                "normal",
-                                "manual",
-                                "forced",
-                                "wait-to-revert",
-                                "signal-degrade",
-                                "signal-fail"
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
                             ],
                             "description": "The reason for the current switch selection."
                         },
                         "switch-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
                         }
@@ -3096,9 +3096,9 @@
                         "restoration-coordinate-type": {
                             "type": "string",
                             "enum": [
-                                "no-coordinate",
-                                "hold-off-time",
-                                "wait-for-notification"
+                                "NO_COORDINATE",
+                                "HOLD_OFF_TIME",
+                                "WAIT_FOR_NOTIFICATION"
                             ],
                             "description": " The coordination mechanism between multi-layers."
                         },
@@ -3108,8 +3108,8 @@
                         "reversion-mode": {
                             "type": "string",
                             "enum": [
-                                "revertive",
-                                "non-revertive"
+                                "REVERTIVE",
+                                "NON-REVERTIVE"
                             ],
                             "description": "Indcates whether the protection scheme is revertive or non-revertive."
                         },
@@ -3140,11 +3140,11 @@
                         "layer-protocol": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
@@ -3223,11 +3223,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
@@ -3252,23 +3252,23 @@
                 "route-objective-function": {
                     "type": "string",
                     "enum": [
-                        "min-work-route-hop",
-                        "min-work-route-cost",
-                        "min-work-route-latency",
-                        "min-sum-of-work-and-protection-route-hop",
-                        "min-sum-of-work-and-protection-route-cost",
-                        "min-sum-of-work-and-protection-route-latency",
-                        "load-balance-max-unused-capacity"
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
                     ]
                 },
                 "diversity-policy": {
                     "type": "string",
                     "enum": [
-                        "srlg",
-                        "srng",
-                        "sng",
-                        "node",
-                        "link"
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
                     ]
                 }
             }

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -1500,7 +1500,15 @@
         "application-identifier": {
             "properties": {
                 "application-identifier-type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "proprietary",
+                        "itut-g-959-1",
+                        "itut-g-698-1",
+                        "itut-g-698-2",
+                        "itut-g-696-1",
+                        "itut-g-695"
+                    ]
                 },
                 "application-identifier-value": {
                     "type": "string"
@@ -1512,10 +1520,23 @@
             "properties": {
                 "grid-type": {
                     "type": "string",
+                    "enum": [
+                        "dwdm",
+                        "cwdm",
+                        "flex",
+                        "unspecified"
+                    ],
                     "description": "Specifies the frequency grid standard used to determine the nominal central frequency and frequency slot width"
                 },
                 "adjustment-granularity": {
                     "type": "string",
+                    "enum": [
+                        "g-100-ghz",
+                        "g-50-ghz",
+                        "g-25-ghz",
+                        "g-12-5-ghz",
+                        "g-6-25-ghz"
+                    ],
                     "description": "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)"
                 },
                 "channel-number": {
@@ -1729,6 +1750,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },
@@ -2013,7 +2041,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -2083,7 +2118,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -2115,7 +2157,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -2143,7 +2192,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -2621,7 +2677,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -2636,7 +2699,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "client-node-edge-point": {
                             "type": "array",
@@ -2795,7 +2865,14 @@
                             ]
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "resilience-constraint": {
                             "type": "array",
@@ -2828,7 +2905,14 @@
                             }
                         },
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "state": {
                             "$ref": "#/definitions/admin-state-pac"
@@ -3055,6 +3139,13 @@
                         },
                         "layer-protocol": {
                             "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ],
                             "description": "Indicate which layer this resilience parameters package configured for."
                         }
                     }
@@ -3131,6 +3222,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
                             }
                         }

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -116,114 +116,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -343,119 +235,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-adapter/": {
-            "get": {
-                "summary": "Retrieve otsi-adapter",
-                "description": "Retrieve operation of resource: otsi-adapter",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-adapter_otsi-adapter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/otsi-a-client-adaptation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/": {
-            "get": {
-                "summary": "Retrieve otsi-termination",
-                "description": "Retrieve operation of resource: otsi-termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_otsi-termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/otsi-termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/selected-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/selected-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve selected-nominal-central-frequency",
                 "description": "Retrieve operation of resource: selected-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_selected-nominal-central-frequency_selected-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-nominal-central-frequency_selected-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -496,7 +280,6 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
                             "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
                         }
                     },
@@ -506,11 +289,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/supportable-lower-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/supportable-lower-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve supportable-lower-nominal-central-frequency",
                 "description": "Retrieve operation of resource: supportable-lower-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-lower-nominal-central-frequency_supportable-lower-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-lower-nominal-central-frequency_supportable-lower-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -560,11 +343,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/supportable-upper-nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/supportable-upper-nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve supportable-upper-nominal-central-frequency",
                 "description": "Retrieve operation of resource: supportable-upper-nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-upper-nominal-central-frequency_supportable-upper-nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-upper-nominal-central-frequency_supportable-upper-nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -614,11 +397,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/selected-application-identifier/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/selected-application-identifier/": {
             "get": {
                 "summary": "Retrieve selected-application-identifier",
                 "description": "Retrieve operation of resource: selected-application-identifier",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_selected-application-identifier_selected-application-identifier",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-application-identifier_selected-application-identifier",
                 "produces": [
                     "application/json"
                 ],
@@ -659,7 +442,6 @@
                     "200": {
                         "description": "Successful operation",
                         "schema": {
-                            "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
                             "$ref": "#/definitions/application-identifier"
                         }
                     },
@@ -669,11 +451,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-termination/supportable-application-identifier/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/supportable-application-identifier/": {
             "get": {
                 "summary": "Retrieve supportable-application-identifier",
                 "description": "Retrieve operation of resource: supportable-application-identifier",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-termination_supportable-application-identifier_supportable-application-identifier",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_supportable-application-identifier_supportable-application-identifier",
                 "produces": [
                     "application/json"
                 ],
@@ -723,65 +505,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-ctp/": {
-            "get": {
-                "summary": "Retrieve otsi-ctp",
-                "description": "Retrieve operation of resource: otsi-ctp",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_otsi-ctp",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "connection-end-point_uuid",
-                        "description": "ID of connection-end-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/otsi-g-ctp-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-ctp/selected-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/selected-frequency-slot/": {
             "get": {
                 "summary": "Retrieve selected-frequency-slot",
                 "description": "Retrieve operation of resource: selected-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_selected-frequency-slot_selected-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-frequency-slot_selected-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -831,11 +559,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/otsi-ctp/selected-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/connection-end-point/{connection-end-point_uuid}/selected-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_otsi-ctp_selected-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_connection-end-point_selected-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -976,100 +704,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1175,58 +809,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/otsi-pool/": {
-            "get": {
-                "summary": "Retrieve otsi-pool",
-                "description": "Retrieve operation of resource: otsi-pool",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_otsi-pool",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/otsi-a-pool-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/otsi-pool/available-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/available-frequency-slot/": {
             "get": {
                 "summary": "Retrieve available-frequency-slot",
                 "description": "Retrieve operation of resource: available-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_available-frequency-slot_available-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-frequency-slot_available-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -1269,11 +856,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/otsi-pool/available-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/available-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_available-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_available-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -1316,11 +903,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/otsi-pool/occupied-frequency-slot/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/occupied-frequency-slot/": {
             "get": {
                 "summary": "Retrieve occupied-frequency-slot",
                 "description": "Retrieve operation of resource: occupied-frequency-slot",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_occupied-frequency-slot_occupied-frequency-slot",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_occupied-frequency-slot_occupied-frequency-slot",
                 "produces": [
                     "application/json"
                 ],
@@ -1363,11 +950,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/otsi-pool/occupied-frequency-slot/nominal-central-frequency/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/occupied-frequency-slot/nominal-central-frequency/": {
             "get": {
                 "summary": "Retrieve nominal-central-frequency",
                 "description": "Retrieve operation of resource: nominal-central-frequency",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_otsi-pool_occupied-frequency-slot_nominal-central-frequency_nominal-central-frequency",
+                "operationId": "retrieve_context_topology_node_owned-node-edge-point_occupied-frequency-slot_nominal-central-frequency_nominal-central-frequency",
                 "produces": [
                     "application/json"
                 ],
@@ -1414,39 +1001,41 @@
     "definitions": {
         "otsi-a-client-adaptation-pac": {},
         "otsi-connection-end-point-spec": {
-            "properties": {
-                "otsi-adapter": {
-                    "$ref": "#/definitions/otsi-a-client-adaptation-pac"
-                },
-                "otsi-termination": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/otsi-termination-pac"
-                    }
-                },
-                "otsi-ctp": {
-                    "$ref": "#/definitions/otsi-g-ctp-pac"
-                }
-            }
+            "$ref": "#/definitions/otsi-g-ctp-pac"
         },
         "otsi-termination-pac": {
             "properties": {
                 "selected-nominal-central-frequency": {
                     "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
-                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    }
                 },
                 "supportable-lower-nominal-central-frequency": {
-                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    }
                 },
                 "supportable-upper-nominal-central-frequency": {
-                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                    }
                 },
                 "selected-application-identifier": {
                     "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
-                    "$ref": "#/definitions/application-identifier"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/application-identifier"
+                    }
                 },
                 "supportable-application-identifier": {
-                    "$ref": "#/definitions/application-identifier"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/application-identifier"
+                    }
                 }
             }
         },
@@ -1467,11 +1056,7 @@
             }
         },
         "otsi-node-edge-point-spec": {
-            "properties": {
-                "otsi-pool": {
-                    "$ref": "#/definitions/otsi-a-pool-pac"
-                }
-            }
+            "$ref": "#/definitions/otsi-a-pool-pac"
         },
         "otsi-routing-spec": {
             "properties": {
@@ -1557,92 +1142,17 @@
                 }
             }
         },
-        "context_schema": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/context"
-                },
-                {
-                    "properties": {
-                        "uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
-                        "nw-topology-service": {
-                            "$ref": "#/definitions/network-topology-service"
-                        },
-                        "topology": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/topology"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path-comp-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path-computation-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "path": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/path"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connectivity-service": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service"
-                            },
-                            "x-key": "uuid"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connection"
-                            },
-                            "x-key": "uuid"
-                        }
-                    }
-                }
-            ]
-        },
         "admin-state-pac": {
             "description": "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.",
             "properties": {
                 "administrative-state": {
-                    "type": "string",
-                    "enum": [
-                        "LOCKED",
-                        "UNLOCKED"
-                    ]
+                    "type": "string"
                 },
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1667,13 +1177,7 @@
             "description": "Provides state attributes for an entity that has lifeccycle aspects only.",
             "properties": {
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1697,20 +1201,10 @@
             "description": "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.",
             "properties": {
                 "operational-state": {
-                    "type": "string",
-                    "enum": [
-                        "DISABLED",
-                        "ENABLED"
-                    ]
+                    "type": "string"
                 },
                 "lifecycle-state": {
-                    "type": "string",
-                    "enum": [
-                        "PLANNED",
-                        "POTENTIAL",
-                        "INSTALLED",
-                        "PENDING_REMOVAL"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1745,26 +1239,19 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }
@@ -1789,25 +1276,10 @@
             "properties": {
                 "termination-direction": {
                     "type": "string",
-                    "enum": [
-                        "BIDIRECTIONAL",
-                        "SINK",
-                        "SOURCE",
-                        "UNDEFINED_OR_UNKNOWN"
-                    ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
-                    "enum": [
-                        "LP_CAN_NEVER_TERMINATE",
-                        "LT_NOT_TERMINATED",
-                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
-                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
-                        "TERMINATED_BIDIRECTIONAL",
-                        "LT_PERMENANTLY_TERMINATED",
-                        "TERMINATION_STATE_UNKNOWN"
-                    ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
             }
@@ -1840,13 +1312,7 @@
         "bandwidth-profile": {
             "properties": {
                 "bw-profile-type": {
-                    "type": "string",
-                    "enum": [
-                        "MEF_10.x",
-                        "RFC_2697",
-                        "RFC_2698",
-                        "RFC_4115"
-                    ]
+                    "type": "string"
                 },
                 "committed-information-rate": {
                     "$ref": "#/definitions/capacity-value"
@@ -1875,12 +1341,7 @@
                     "type": "string"
                 },
                 "unit": {
-                    "type": "string",
-                    "enum": [
-                        "GBPS",
-                        "MBPS",
-                        "KBPS"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1894,109 +1355,669 @@
                 }
             }
         },
-        "get-service-interface-point-detailsRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                }
-            }
-        },
-        "get-service-interface-point-detailsRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "$ref": "#/definitions/service-interface-point"
-                }
-            }
-        },
-        "get-service-interface-point-listRPC_output_schema": {
-            "properties": {
-                "sip": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/service-interface-point"
-                    }
-                }
-            }
-        },
-        "update-service-interface-pointRPC_input_schema": {
-            "properties": {
-                "sip-id-or-name": {
-                    "type": "string"
-                },
-                "state": {
-                    "type": "string"
-                }
-            }
-        },
-        "owned-node-edge-point_schema": {
+        "connection": {
             "allOf": [
                 {
-                    "$ref": "#/definitions/node-edge-point"
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
                 },
                 {
                     "properties": {
-                        "owned-node-edge-point_uuid": {
-                            "type": "string",
-                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                        },
-                        "name": {
-                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/name-and-value"
-                            },
-                            "x-key": "value-name"
-                        },
                         "connection-end-point": {
                             "type": "array",
                             "items": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/definitions/connection-end-point"
-                                    },
-                                    {
-                                        "properties": {
-                                            "connection-end-point_uuid": {
-                                                "type": "string",
-                                                "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-                                            },
-                                            "name": {
-                                                "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/name-and-value"
-                                                },
-                                                "x-key": "value-name"
-                                            },
-                                            "otsi-adapter": {
-                                                "$ref": "#/definitions/otsi-a-client-adaptation-pac"
-                                            },
-                                            "otsi-termination": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/otsi-termination-pac"
-                                                }
-                                            },
-                                            "otsi-ctp": {
-                                                "$ref": "#/definitions/otsi-g-ctp-pac"
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "x-key": "uuid"
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
                         },
-                        "otsi-pool": {
-                            "$ref": "#/definitions/otsi-a-pool-pac"
+                        "lower-connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
+                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
+                            }
+                        },
+                        "supported-link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
+                            }
+                        },
+                        "container-node": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                        },
+                        "route": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/route"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "switch-control": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch-control"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connection-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/operational-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
+                    "properties": {
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        },
+                        "client-node-edge-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                            }
+                        },
+                        "server-node-edge-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                        },
+                        "peer-connection-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                        },
+                        "associated-route": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                            }
+                        },
+                        "connection-port-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "connection-port-role": {
+                            "type": "string",
+                            "enum": [
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        }
+                    }
+                }
+            ],
+            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
+        },
+        "connectivity-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/route-compute-policy"
+                },
+                {
+                    "properties": {
+                        "service-type": {
+                            "type": "string",
+                            "enum": [
+                                "POINT_TO_POINT_CONNECTIVITY",
+                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
+                                "MULTIPOINT_CONNECTIVITY",
+                                "ROOTED_MULTIPOINT_CONNECTIVITY"
+                            ]
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "is-exclusive": {
+                            "type": "boolean",
+                            "description": "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)"
+                        },
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "schedule": {
+                            "$ref": "#/definitions/time-range"
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name"
+                        },
+                        "coroute-inclusion": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                        },
+                        "diversity-exclusion": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                            }
                         }
                     }
                 }
             ]
         },
+        "connectivity-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "$ref": "#/definitions/connectivity-constraint"
+                },
+                {
+                    "$ref": "#/definitions/topology-constraint"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
+                    "properties": {
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
+                            }
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ]
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
+        },
+        "connectivity-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "layer-protocol-name": {
+                            "type": "string",
+                            "enum": [
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
+                            ]
+                        },
+                        "capacity": {
+                            "$ref": "#/definitions/capacity-pac"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": [
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
+                            ],
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        },
+                        "protection-role": {
+                            "type": "string",
+                            "enum": [
+                                "WORK",
+                                "PROTECT",
+                                "PROTECTED",
+                                "NA",
+                                "WORK_RESTORE",
+                                "PROTECT_RESTORE"
+                            ],
+                            "description": "To specify the protection role of this Port when create or update ConnectivityService."
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "route": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
+        },
+        "connectivity-context": {
+            "properties": {
+                "connectivity-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connectivity-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "connection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "switch": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "selected-connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
+                            }
+                        },
+                        "selected-route": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                            }
+                        },
+                        "selection-control": {
+                            "type": "string",
+                            "enum": [
+                                "LOCK_OUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED"
+                            ],
+                            "description": "Degree of administrative control applied to the switch selection."
+                        },
+                        "selection-reason": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKOUT",
+                                "NORMAL",
+                                "MANUAL",
+                                "FORCED",
+                                "WAIT_TO_REVERT",
+                                "SIGNAL_DEGRADE",
+                                "SIGNAL_FAIL"
+                            ],
+                            "description": "The reason for the current switch selection."
+                        },
+                        "switch-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
+                        }
+                    }
+                }
+            ],
+            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
+        },
+        "switch-control": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "$ref": "#/definitions/resilience-constraint"
+                },
+                {
+                    "properties": {
+                        "sub-switch-control": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
+                            }
+                        },
+                        "switch": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/switch"
+                            },
+                            "x-key": "local-id"
+                        }
+                    }
+                }
+            ],
+            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
+        },
+        "resilience-constraint": {
+            "description": "A list of control parameters to apply to a switch.",
+            "properties": {
+                "resilience-type": {
+                    "$ref": "#/definitions/resilience-type"
+                },
+                "restoration-coordinate-type": {
+                    "type": "string",
+                    "enum": [
+                        "NO_COORDINATE",
+                        "HOLD_OFF_TIME",
+                        "WAIT_FOR_NOTIFICATION"
+                    ],
+                    "description": " The coordination mechanism between multi-layers."
+                },
+                "restore-priority": {
+                    "type": "string"
+                },
+                "reversion-mode": {
+                    "type": "string",
+                    "enum": [
+                        "REVERTIVE",
+                        "NON-REVERTIVE"
+                    ],
+                    "description": "Indcates whether the protection scheme is revertive or non-revertive."
+                },
+                "wait-to-revert-time": {
+                    "type": "string",
+                    "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
+                },
+                "hold-off-time": {
+                    "type": "string",
+                    "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
+                },
+                "is-lock-out": {
+                    "type": "boolean",
+                    "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
+                },
+                "is-frozen": {
+                    "type": "boolean",
+                    "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
+                },
+                "is-coordinated-switching-both-ends": {
+                    "type": "boolean",
+                    "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
+                },
+                "max-switch-times": {
+                    "type": "string",
+                    "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
+                },
+                "layer-protocol": {
+                    "type": "string",
+                    "enum": [
+                        "OTSiA",
+                        "OTU",
+                        "ODU",
+                        "ETH",
+                        "ETY"
+                    ],
+                    "description": "Indicate which layer this resilience parameters package configured for."
+                }
+            }
+        },
+        "topology-constraint": {
+            "properties": {
+                "include-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "avoid-topology": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                    }
+                },
+                "include-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "exclude-path": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                    }
+                },
+                "include-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list "
+                    }
+                },
+                "exclude-link": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                    }
+                },
+                "include-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
+                        "description": "This is a loose constraint - that is it is unordered and could be a partial list"
+                    }
+                },
+                "exclude-node": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                    }
+                },
+                "preferred-transport-layer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "OTSiA",
+                            "OTU",
+                            "ODU",
+                            "ETH",
+                            "ETY"
+                        ],
+                        "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
+                    }
+                }
+            }
+        },
+        "cep-list": {
+            "properties": {
+                "connection-end-point": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/connection-end-point"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "route-compute-policy": {
+            "properties": {
+                "route-objective-function": {
+                    "type": "string",
+                    "enum": [
+                        "MIN_WORK_ROUTE_HOP",
+                        "MIN_WORK_ROUTE_COST",
+                        "MIN_WORK_ROUTE_LATENCY",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
+                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
+                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
+                    ]
+                },
+                "diversity-policy": {
+                    "type": "string",
+                    "enum": [
+                        "SRLG",
+                        "SRNG",
+                        "SNG",
+                        "NODE",
+                        "LINK"
+                    ]
+                }
+            }
+        },
         "link": {
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
                 },
                 {
                     "properties": {
@@ -2013,30 +2034,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -2074,6 +2071,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -2099,21 +2111,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -2190,6 +2187,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -2215,12 +2218,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -2367,6 +2364,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -2381,18 +2390,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -2402,6 +2399,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -2432,18 +2441,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -2582,6 +2579,481 @@
                 }
             }
         },
+        "path": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "properties": {
+                        "link": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
+                            }
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        }
+                    }
+                }
+            ],
+            "description": "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes"
+        },
+        "path-service-end-point": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
+                        },
+                        "direction": {
+                            "type": "string",
+                            "description": "The orientation of defined flow at the EndPoint."
+                        },
+                        "service-layer": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
+        },
+        "path-computation-service": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/service-spec"
+                },
+                {
+                    "properties": {
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
+                            }
+                        },
+                        "end-point": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-service-end-point"
+                            },
+                            "x-key": "local-id"
+                        },
+                        "routing-constraint": {
+                            "$ref": "#/definitions/routing-constraint"
+                        },
+                        "objective-function": {
+                            "$ref": "#/definitions/path-objective-function"
+                        },
+                        "optimization-constraint": {
+                            "$ref": "#/definitions/path-optimization-constraint"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-objective-function": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "bandwidth-optimization": {
+                            "type": "string"
+                        },
+                        "concurrent-paths": {
+                            "type": "string"
+                        },
+                        "cost-optimization": {
+                            "type": "string"
+                        },
+                        "link-utilization": {
+                            "type": "string"
+                        },
+                        "resource-sharing": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "path-optimization-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "traffic-interruption": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "routing-constraint": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/local-class"
+                },
+                {
+                    "properties": {
+                        "requested-capacity": {
+                            "$ref": "#/definitions/capacity"
+                        },
+                        "service-level": {
+                            "type": "string",
+                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
+                        },
+                        "path-layer": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cost-characteristic": {
+                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cost-characteristic"
+                            },
+                            "x-key": "cost-name"
+                        },
+                        "latency-characteristic": {
+                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/latency-characteristic"
+                            },
+                            "x-key": "traffic-property-name"
+                        },
+                        "include-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        },
+                        "avoid-topology": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "path-computation-context": {
+            "properties": {
+                "path-comp-service": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path-computation-service"
+                    },
+                    "x-key": "uuid"
+                },
+                "path": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/path"
+                    },
+                    "x-key": "uuid"
+                }
+            }
+        },
+        "context_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/context"
+                },
+                {
+                    "properties": {
+                        "uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "nw-topology-service": {
+                            "$ref": "#/definitions/network-topology-service"
+                        },
+                        "topology": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/topology"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path-comp-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path-computation-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "path": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/path"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connectivity-service": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connectivity-service"
+                            },
+                            "x-key": "uuid"
+                        },
+                        "connection": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/connection"
+                            },
+                            "x-key": "uuid"
+                        }
+                    }
+                }
+            ]
+        },
+        "get-service-interface-point-detailsRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                }
+            }
+        },
+        "get-service-interface-point-detailsRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "$ref": "#/definitions/service-interface-point"
+                }
+            }
+        },
+        "get-service-interface-point-listRPC_output_schema": {
+            "properties": {
+                "sip": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service-interface-point"
+                    }
+                }
+            }
+        },
+        "update-service-interface-pointRPC_input_schema": {
+            "properties": {
+                "sip-id-or-name": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "owned-node-edge-point_schema": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/node-edge-point"
+                },
+                {
+                    "properties": {
+                        "owned-node-edge-point_uuid": {
+                            "type": "string",
+                            "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                        },
+                        "name": {
+                            "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name-and-value"
+                            },
+                            "x-key": "value-name"
+                        },
+                        "administrative-state": {
+                            "type": "string",
+                            "enum": [
+                                "LOCKED",
+                                "UNLOCKED"
+                            ]
+                        },
+                        "operational-state": {
+                            "type": "string",
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
+                        },
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
+                        },
+                        "termination-direction": {
+                            "type": "string",
+                            "enum": [
+                                "BIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
+                                "UNDEFINED_OR_UNKNOWN"
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                        },
+                        "termination-state": {
+                            "type": "string",
+                            "enum": [
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
+                        },
+                        "connection-end-point": {
+                            "type": "array",
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/connection-end-point"
+                                    },
+                                    {
+                                        "properties": {
+                                            "connection-end-point_uuid": {
+                                                "type": "string",
+                                                "description": "UUID: An identifier that is universally unique within an identifier space, where the identifier space is itself globally unique, and immutable. An UUID carries no semantics with respect to the purpose or state of the entity.\nUUID here uses string representation as defined in RFC 4122.  The canonical representation uses lowercase characters.\nPattern: [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12} \nExample of a UUID in string representation: f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+                                            },
+                                            "name": {
+                                                "description": "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/name-and-value"
+                                                },
+                                                "x-key": "value-name"
+                                            },
+                                            "operational-state": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "DISABLED",
+                                                    "ENABLED"
+                                                ]
+                                            },
+                                            "lifecycle-state": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "PLANNED",
+                                                    "POTENTIAL",
+                                                    "INSTALLED",
+                                                    "PENDING_REMOVAL"
+                                                ]
+                                            },
+                                            "termination-direction": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "BIDIRECTIONAL",
+                                                    "SINK",
+                                                    "SOURCE",
+                                                    "UNDEFINED_OR_UNKNOWN"
+                                                ],
+                                                "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
+                                            },
+                                            "termination-state": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "LP_CAN_NEVER_TERMINATE",
+                                                    "LT_NOT_TERMINATED",
+                                                    "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                                    "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                                    "TERMINATED_BIDIRECTIONAL",
+                                                    "LT_PERMENANTLY_TERMINATED",
+                                                    "TERMINATION_STATE_UNKNOWN"
+                                                ],
+                                                "description": "Indicates whether the layer is terminated and if so how."
+                                            },
+                                            "selected-nominal-central-frequency": {
+                                                "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                                                }
+                                            },
+                                            "supportable-lower-nominal-central-frequency": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                                                }
+                                            },
+                                            "supportable-upper-nominal-central-frequency": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                                                }
+                                            },
+                                            "selected-application-identifier": {
+                                                "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/application-identifier"
+                                                }
+                                            },
+                                            "supportable-application-identifier": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/application-identifier"
+                                                }
+                                            },
+                                            "selected-frequency-slot": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/frequency-slot"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "x-key": "uuid"
+                        },
+                        "available-frequency-slot": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/frequency-slot"
+                            }
+                        },
+                        "occupied-frequency-slot": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/frequency-slot"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "connection-end-point_schema": {
             "allOf": [
                 {
@@ -2601,677 +3073,86 @@
                             },
                             "x-key": "value-name"
                         },
-                        "otsi-adapter": {
-                            "$ref": "#/definitions/otsi-a-client-adaptation-pac"
-                        },
-                        "otsi-termination": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/otsi-termination-pac"
-                            }
-                        },
-                        "otsi-ctp": {
-                            "$ref": "#/definitions/otsi-g-ctp-pac"
-                        }
-                    }
-                }
-            ]
-        },
-        "connection": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "lower-connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid",
-                                "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
-                            }
-                        },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
+                        "operational-state": {
                             "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
+                            "enum": [
+                                "DISABLED",
+                                "ENABLED"
+                            ]
                         },
-                        "route": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/route"
-                            },
-                            "x-key": "local-id"
+                        "lifecycle-state": {
+                            "type": "string",
+                            "enum": [
+                                "PLANNED",
+                                "POTENTIAL",
+                                "INSTALLED",
+                                "PENDING_REMOVAL"
+                            ]
                         },
-                        "switch-control": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch-control"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "direction": {
+                        "termination-direction": {
                             "type": "string",
                             "enum": [
                                 "BIDIRECTIONAL",
-                                "UNIDIRECTIONAL",
+                                "SINK",
+                                "SOURCE",
                                 "UNDEFINED_OR_UNKNOWN"
-                            ]
+                            ],
+                            "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                         },
-                        "layer-protocol-name": {
+                        "termination-state": {
                             "type": "string",
                             "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connection-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/resource-spec"
-                },
-                {
-                    "properties": {
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
+                                "LP_CAN_NEVER_TERMINATE",
+                                "LT_NOT_TERMINATED",
+                                "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                                "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                                "TERMINATED_BIDIRECTIONAL",
+                                "LT_PERMENANTLY_TERMINATED",
+                                "TERMINATION_STATE_UNKNOWN"
+                            ],
+                            "description": "Indicates whether the layer is terminated and if so how."
                         },
-                        "client-node-edge-point": {
+                        "selected-nominal-central-frequency": {
+                            "description": "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.\nThis attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.\n",
                             "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
+                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "supportable-lower-nominal-central-frequency": {
                             "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
                             }
                         },
-                        "state": {
-                            "$ref": "#/definitions/operational-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
-                        },
-                        "connection-port-direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "connection-port-role": {
-                            "type": "string",
-                            "enum": [
-                                "SYMMETRIC",
-                                "ROOT",
-                                "LEAF",
-                                "TRUNK",
-                                "UNKNOWN"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        }
-                    }
-                }
-            ],
-            "description": "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. \nThe structure of LTP supports all transport protocols including circuit and packet forms."
-        },
-        "connectivity-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-type": {
-                            "type": "string",
-                            "enum": [
-                                "POINT_TO_POINT_CONNECTIVITY",
-                                "POINT_TO_MULTIPOINT_CONNECTIVITY",
-                                "MULTIPOINT_CONNECTIVITY",
-                                "ROOTED_MULTIPOINT_CONNECTIVITY"
-                            ]
-                        },
-                        "service-level": {
-                            "type": "string",
-                            "description": "An abstract value the meaning of which is mutually agreed \u2013 typically represents metrics such as - Class of service, priority, resiliency, availability"
-                        },
-                        "is-exclusive": {
-                            "type": "boolean",
-                            "description": "To distinguish if the resources are exclusive to the service  - for example between EPL(isExclusive=true) and EVPL (isExclusive=false), or between EPLAN (isExclusive=true) and EVPLAN (isExclusive=false)"
-                        },
-                        "requested-capacity": {
-                            "$ref": "#/definitions/capacity"
-                        },
-                        "schedule": {
-                            "$ref": "#/definitions/time-range"
-                        },
-                        "cost-characteristic": {
-                            "description": "The list of costs where each cost relates to some aspect of the TopologicalEntity.",
+                        "supportable-upper-nominal-central-frequency": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/cost-characteristic"
-                            },
-                            "x-key": "cost-name"
+                                "$ref": "#/definitions/nominal-central-frequency-or-wavelength"
+                            }
                         },
-                        "latency-characteristic": {
-                            "description": "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.",
+                        "selected-application-identifier": {
+                            "description": "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.",
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/latency-characteristic"
-                            },
-                            "x-key": "traffic-property-name"
+                                "$ref": "#/definitions/application-identifier"
+                            }
                         },
-                        "route-compute-policy": {
-                            "$ref": "#/definitions/route-compute-policy"
-                        },
-                        "coroute-inclusion": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
-                        },
-                        "diversity-exclusion": {
+                        "supportable-application-identifier": {
                             "type": "array",
                             "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid"
+                                "$ref": "#/definitions/application-identifier"
+                            }
+                        },
+                        "selected-frequency-slot": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/frequency-slot"
                             }
                         }
                     }
                 }
             ]
-        },
-        "connectivity-service": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/service-spec"
-                },
-                {
-                    "properties": {
-                        "end-point": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/connectivity-service-end-point"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "connection": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:uuid"
-                            }
-                        },
-                        "conn-constraint": {
-                            "$ref": "#/definitions/connectivity-constraint"
-                        },
-                        "topo-constraint": {
-                            "$ref": "#/definitions/topology-constraint"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "UNIDIRECTIONAL",
-                                "UNDEFINED_OR_UNKNOWN"
-                            ]
-                        },
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        },
-                        "resilience-constraint": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resilience-constraint"
-                            },
-                            "x-key": "local-id"
-                        }
-                    }
-                }
-            ],
-            "description": "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.\nAt the lowest level of recursion, a FC represents a cross-connection within an NE."
-        },
-        "connectivity-service-end-point": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "layer-protocol-name": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ]
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "The orientation of defined flow at the EndPoint."
-                        },
-                        "role": {
-                            "type": "string",
-                            "enum": [
-                                "SYMMETRIC",
-                                "ROOT",
-                                "LEAF",
-                                "TRUNK",
-                                "UNKNOWN"
-                            ],
-                            "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
-                        },
-                        "protection-role": {
-                            "type": "string",
-                            "enum": [
-                                "WORK",
-                                "PROTECT",
-                                "PROTECTED",
-                                "NA",
-                                "WORK_RESTORE",
-                                "PROTECT_RESTORE"
-                            ],
-                            "description": "To specify the protection role of this Port when create or update ConnectivityService."
-                        }
-                    }
-                }
-            ],
-            "description": "The association of the FC to LTPs is made via EndPoints.\nThe EndPoint (EP) object class models the access to the FC function. \nThe traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  \nIn cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. \nIt can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.\nThe EP replaces the Protection Unit of a traditional protection model. \nThe ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component"
-        },
-        "route": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        }
-                    }
-                }
-            ],
-            "description": "The FC Route (FcRoute) object class models the individual routes of an FC. \nThe route of an FC object is represented by a list of FCs at a lower level. \nNote that depending on the service supported by an FC, an the FC can have multiple routes."
-        },
-        "connectivity-context": {
-            "properties": {
-                "connectivity-service": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connectivity-service"
-                    },
-                    "x-key": "uuid"
-                },
-                "connection": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connection"
-                    },
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "switch": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "selected-connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
-                        "selected-route": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
-                            }
-                        },
-                        "selection-control": {
-                            "type": "string",
-                            "enum": [
-                                "LOCK_OUT",
-                                "NORMAL",
-                                "MANUAL",
-                                "FORCED"
-                            ],
-                            "description": "Degree of administrative control applied to the switch selection."
-                        },
-                        "selection-reason": {
-                            "type": "string",
-                            "enum": [
-                                "LOCKOUT",
-                                "NORMAL",
-                                "MANUAL",
-                                "FORCED",
-                                "WAIT_TO_REVERT",
-                                "SIGNAL_DEGRADE",
-                                "SIGNAL_FAIL"
-                            ],
-                            "description": "The reason for the current switch selection."
-                        },
-                        "switch-direction": {
-                            "type": "string",
-                            "enum": [
-                                "BIDIRECTIONAL",
-                                "INPUT",
-                                "OUTPUT",
-                                "UNIDENTIFIED_OR_UNKNOWN"
-                            ],
-                            "description": "Indicates whether the switch selects from ingress to the FC or to egress of the FC, or both."
-                        }
-                    }
-                }
-            ],
-            "description": "The class models the switched forwarding of traffic (traffic flow) between FcPorts (ConnectionEndPoints) and is present where there is protection functionality in the FC (Connection). \nIf an FC exposes protection (having two or more FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects to represent the alternative flow choices visible at the edge of the FC.\nThe FC switch represents and defines a protection switch structure encapsulated in the FC. \nEssentially performs one of the functions of the Protection Group in a traditional model. It associates to 2 or more FcPorts each playing the role of a Protection Unit. \nOne or more protection, i.e. standby/backup, FcPorts provide protection for one or more working (i.e. regular/main/preferred) FcPorts where either protection or working can feed one or more protected FcPort.\nThe switch may be used in revertive or non-revertive (symmetric) mode. When in revertive mode it may define a waitToRestore time.\nIt may be used in one of several modes including source switch, destination switched, source and destination switched etc (covering cases such as 1+1 and 1:1).\nIt may be locked out (prevented from switching), force switched or manual switched.\nIt will indicate switch state and change of state.\nThe switch can be switched away from all sources such that it becomes open and hence two coordinated switches can both feed the same LTP so long as at least one of the two is switched away from all sources (is 'open').\nThe ability for a Switch to be 'high impedance' allows bidirectional ForwardingConstructs to be overlaid on the same bidirectional LTP where the appropriate control is enabled to prevent signal conflict.\nThis ability allows multiple alternate routes to be present that otherwise would be in conflict."
-        },
-        "switch-control": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "sub-switch-control": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:switch-control/tapi-connectivity:local-id"
-                            }
-                        },
-                        "switch": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/switch"
-                            },
-                            "x-key": "local-id"
-                        },
-                        "control-parameters": {
-                            "$ref": "#/definitions/resilience-constraint"
-                        }
-                    }
-                }
-            ],
-            "description": "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme."
-        },
-        "resilience-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "resilience-type": {
-                            "$ref": "#/definitions/resilience-type"
-                        },
-                        "restoration-coordinate-type": {
-                            "type": "string",
-                            "enum": [
-                                "NO_COORDINATE",
-                                "HOLD_OFF_TIME",
-                                "WAIT_FOR_NOTIFICATION"
-                            ],
-                            "description": " The coordination mechanism between multi-layers."
-                        },
-                        "restore-priority": {
-                            "type": "string"
-                        },
-                        "reversion-mode": {
-                            "type": "string",
-                            "enum": [
-                                "REVERTIVE",
-                                "NON-REVERTIVE"
-                            ],
-                            "description": "Indcates whether the protection scheme is revertive or non-revertive."
-                        },
-                        "wait-to-revert-time": {
-                            "type": "string",
-                            "description": "If the protection system is revertive, this attribute specifies the time, in minutes, to wait after a fault clears on a higher priority (preferred) resource before reverting to the preferred resource."
-                        },
-                        "hold-off-time": {
-                            "type": "string",
-                            "description": "This attribute indicates the time, in milliseconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm."
-                        },
-                        "is-lock-out": {
-                            "type": "boolean",
-                            "description": "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.\nThis overrides all other protection control states including forced.\nIf the item is locked out then it cannot be used under any circumstances.\nNote: Only relevant when part of a protection scheme."
-                        },
-                        "is-frozen": {
-                            "type": "boolean",
-                            "description": "Temporarily prevents any switch action to be taken and, as such, freezes the current state. \nUntil the freeze is cleared, additional near-end external commands are rejected and fault condition changes and received APS messages are ignored.\nAll administrative controls of any aspect of protection are rejected."
-                        },
-                        "is-coordinated-switching-both-ends": {
-                            "type": "boolean",
-                            "description": "Is operating such that switching at both ends of each flow acorss the FC is coordinated at both ingress and egress ends."
-                        },
-                        "max-switch-times": {
-                            "type": "string",
-                            "description": "Used to limit the maximum swtich times. When work fault disappears , and traffic return to the original work path, switch counter reset."
-                        },
-                        "layer-protocol": {
-                            "type": "string",
-                            "enum": [
-                                "OTSiA",
-                                "OTU",
-                                "ODU",
-                                "ETH",
-                                "ETY"
-                            ],
-                            "description": "Indicate which layer this resilience parameters package configured for."
-                        }
-                    }
-                }
-            ],
-            "description": "A list of control parameters to apply to a switch."
-        },
-        "topology-constraint": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/local-class"
-                },
-                {
-                    "properties": {
-                        "include-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "avoid-topology": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                            }
-                        },
-                        "include-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "exclude-path": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-path-computation:path/tapi-path-computation:uuid"
-                            }
-                        },
-                        "include-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list "
-                            }
-                        },
-                        "exclude-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid"
-                            }
-                        },
-                        "include-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid",
-                                "description": "This is a loose constraint - that is it is unordered and could be a partial list"
-                            }
-                        },
-                        "exclude-node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
-                        "preferred-transport-layer": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "OTSiA",
-                                    "OTU",
-                                    "ODU",
-                                    "ETH",
-                                    "ETY"
-                                ],
-                                "description": "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        "cep-list": {
-            "properties": {
-                "connection-end-point": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/connection-end-point"
-                    },
-                    "x-key": "uuid"
-                }
-            }
-        },
-        "route-compute-policy": {
-            "properties": {
-                "route-objective-function": {
-                    "type": "string",
-                    "enum": [
-                        "MIN_WORK_ROUTE_HOP",
-                        "MIN_WORK_ROUTE_COST",
-                        "MIN_WORK_ROUTE_LATENCY",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST",
-                        "MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY",
-                        "LOAD_BALANCE_MAX_UNUSED_CAPACITY"
-                    ]
-                },
-                "diversity-policy": {
-                    "type": "string",
-                    "enum": [
-                        "SRLG",
-                        "SRNG",
-                        "SNG",
-                        "NODE",
-                        "LINK"
-                    ]
-                }
-            }
         },
         "get-connection-detailsRPC_input_schema": {
             "properties": {

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -10827,32 +10827,32 @@
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -10904,51 +10904,51 @@
                         "bandwidth-optimization": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         },
                         "concurrent-paths": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         },
                         "cost-optimization": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         },
                         "link-utilization": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         },
                         "resource-sharing": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         }
                     }
@@ -10965,11 +10965,11 @@
                         "traffic-interruption": {
                             "type": "string",
                             "enum": [
-                                "minimize",
-                                "maximize",
-                                "allow",
-                                "disallow",
-                                "dont-care"
+                                "MINIMIZE",
+                                "MAXIMIZE",
+                                "ALLOW",
+                                "DISALLOW",
+                                "DONT_CARE"
                             ]
                         }
                     }
@@ -10995,11 +10995,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
@@ -11105,11 +11105,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
@@ -11177,11 +11177,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -11216,11 +11216,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -11251,11 +11251,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -11282,21 +11282,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -11617,24 +11617,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11662,10 +11662,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11692,17 +11692,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11744,11 +11744,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -11783,23 +11783,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -11835,10 +11835,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -11870,9 +11870,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -10846,7 +10846,14 @@
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -10986,7 +10993,14 @@
                         "path-layer": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "cost-characteristic": {
@@ -11089,7 +11103,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -11154,7 +11175,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -11186,7 +11214,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -11214,7 +11249,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -11701,6 +11743,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1688,100 +1418,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2567,1339 +2203,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -4019,58 +2322,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4096,6 +2352,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4114,11 +2377,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4144,6 +2407,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4162,11 +2432,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4192,6 +2462,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4209,11 +2486,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4241,6 +2518,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4256,11 +2540,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4288,6 +2572,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4303,11 +2594,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4335,6 +2626,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4350,11 +2648,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4380,6 +2678,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4397,11 +2702,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4427,6 +2732,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4445,11 +2757,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4475,6 +2787,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4493,11 +2812,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4523,6 +2842,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4540,11 +2866,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4572,6 +2898,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4587,11 +2920,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4619,6 +2952,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4634,11 +2974,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4666,6 +3006,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4681,11 +3028,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4711,6 +3058,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4728,58 +3082,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4805,6 +3112,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4815,7 +3129,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -4826,11 +3140,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -4856,6 +3170,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -4880,58 +3201,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4957,6 +3231,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4967,7 +3248,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -4978,11 +3259,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5008,6 +3289,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5032,58 +3320,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/": {
             "get": {
                 "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5109,6 +3350,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5119,7 +3367,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
                             },
                             "type": "array"
                         }
@@ -5130,11 +3378,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
                 "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5160,6 +3408,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5289,91 +3544,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5392,6 +3567,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5410,11 +3592,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5433,6 +3615,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5451,11 +3640,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5474,6 +3663,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5491,11 +3687,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5516,6 +3712,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5531,11 +3734,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5556,6 +3759,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5571,11 +3781,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5596,6 +3806,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5611,11 +3828,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5634,6 +3851,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5651,11 +3875,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5674,6 +3898,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5692,11 +3923,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5715,6 +3946,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5733,11 +3971,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5756,6 +3994,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5773,11 +4018,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5798,6 +4043,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5813,11 +4065,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5838,6 +4090,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5853,11 +4112,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5878,6 +4137,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5893,11 +4159,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5916,6 +4182,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5933,51 +4206,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5996,6 +4229,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6006,7 +4246,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -6017,11 +4257,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6040,6 +4280,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6064,91 +4311,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6167,6 +4334,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6177,7 +4351,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -6188,11 +4362,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6211,6 +4385,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6227,6 +4408,111 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
                         }
                     },
                     "400": {
@@ -6326,6 +4612,752 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/link/": {
             "get": {
                 "summary": "Retrieve link",
@@ -6395,1254 +5427,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_link_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
-            "get": {
-                "summary": "Retrieve validation",
-                "description": "Retrieve operation of resource: validation",
-                "operationId": "retrieve_context_topology_link_validation_validation",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism by ID",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "validation-mechanism",
-                        "description": "ID of validation-mechanism",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
-            "get": {
-                "summary": "Retrieve lp-transition",
-                "description": "Retrieve operation of resource: lp-transition",
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     },
                     "400": {
@@ -7774,6 +5558,934 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "validation-mechanism",
+                        "description": "ID of validation-mechanism",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
                         }
                     },
                     "400": {
@@ -11061,6 +9773,30 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
+                },
+                {
                     "properties": {
                         "node-edge-point": {
                             "type": "array",
@@ -11075,30 +9811,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -11131,6 +9843,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -11156,21 +9883,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -11247,6 +9959,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -11272,12 +9990,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -11424,6 +10136,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -11438,18 +10162,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -11459,6 +10171,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -11489,18 +10213,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -11738,6 +10450,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -11752,12 +10470,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1688,100 +1418,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2567,1339 +2203,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -4019,58 +2322,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4096,6 +2352,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4114,11 +2377,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4144,6 +2407,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4162,11 +2432,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4192,6 +2462,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4209,11 +2486,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4241,6 +2518,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4256,11 +2540,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4288,6 +2572,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4303,11 +2594,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4335,6 +2626,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4350,11 +2648,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4380,6 +2678,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4397,11 +2702,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4427,6 +2732,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4445,11 +2757,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4475,6 +2787,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4493,11 +2812,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4523,6 +2842,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4540,11 +2866,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4572,6 +2898,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4587,11 +2920,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4619,6 +2952,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4634,11 +2974,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4666,6 +3006,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4681,11 +3028,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4711,6 +3058,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4728,58 +3082,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4805,6 +3112,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4815,7 +3129,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -4826,11 +3140,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -4856,6 +3170,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -4880,58 +3201,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4957,6 +3231,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4967,7 +3248,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -4978,11 +3259,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5008,6 +3289,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5032,58 +3320,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/": {
             "get": {
                 "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5109,6 +3350,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5119,7 +3367,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
                             },
                             "type": "array"
                         }
@@ -5130,11 +3378,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
                 "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5160,6 +3408,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5289,91 +3544,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5392,6 +3567,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5410,11 +3592,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5433,6 +3615,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5451,11 +3640,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5474,6 +3663,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5491,11 +3687,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5516,6 +3712,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5531,11 +3734,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5556,6 +3759,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5571,11 +3781,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5596,6 +3806,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5611,11 +3828,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5634,6 +3851,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5651,11 +3875,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5674,6 +3898,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5692,11 +3923,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5715,6 +3946,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5733,11 +3971,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5756,6 +3994,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5773,11 +4018,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5798,6 +4043,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5813,11 +4065,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5838,6 +4090,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5853,11 +4112,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5878,6 +4137,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5893,11 +4159,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5916,6 +4182,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5933,51 +4206,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5996,6 +4229,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6006,7 +4246,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -6017,11 +4257,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6040,6 +4280,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6064,91 +4311,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6167,6 +4334,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6177,7 +4351,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -6188,11 +4362,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6211,6 +4385,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6227,6 +4408,111 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
                         }
                     },
                     "400": {
@@ -6326,6 +4612,752 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/link/": {
             "get": {
                 "summary": "Retrieve link",
@@ -6395,1254 +5427,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_link_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
-            "get": {
-                "summary": "Retrieve validation",
-                "description": "Retrieve operation of resource: validation",
-                "operationId": "retrieve_context_topology_link_validation_validation",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism by ID",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "validation-mechanism",
-                        "description": "ID of validation-mechanism",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
-            "get": {
-                "summary": "Retrieve lp-transition",
-                "description": "Retrieve operation of resource: lp-transition",
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     },
                     "400": {
@@ -7774,6 +5558,934 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "validation-mechanism",
+                        "description": "ID of validation-mechanism",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
                         }
                     },
                     "400": {
@@ -8031,6 +6743,30 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
+                },
+                {
                     "properties": {
                         "node-edge-point": {
                             "type": "array",
@@ -8045,30 +6781,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -8106,6 +6818,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -8131,21 +6858,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -8222,6 +6934,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -8247,12 +6965,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -8399,6 +7111,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -8413,18 +7137,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -8434,6 +7146,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -8464,18 +7188,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -8741,6 +7453,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -8755,12 +7473,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -8073,7 +8073,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -8143,7 +8150,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -8175,7 +8189,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -8203,7 +8224,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -8718,6 +8746,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -8075,20 +8075,20 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "unidirectional",
-                                "undefined-or-unknown"
+                                "BIDIRECTIONAL",
+                                "UNIDIRECTIONAL",
+                                "UNDEFINED_OR_UNKNOWN"
                             ],
                             "description": "The directionality of the Link. \nIs applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). \nIs not present in more complex cases."
                         },
@@ -8152,11 +8152,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -8191,11 +8191,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -8226,11 +8226,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -8257,21 +8257,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -8491,21 +8491,21 @@
                         "rule-type": {
                             "type": "string",
                             "enum": [
-                                "forwarding",
-                                "capacity",
-                                "cost",
-                                "timing",
-                                "risk",
-                                "grouping"
+                                "FORWARDING",
+                                "CAPACITY",
+                                "COST",
+                                "TIMING",
+                                "RISK",
+                                "GROUPING"
                             ]
                         },
                         "forwarding-rule": {
                             "type": "string",
                             "enum": [
-                                "may-forward-across-group",
-                                "must-forward-across-group",
-                                "cannot-forward-across-group",
-                                "no-statement-on-forwarding"
+                                "MAY_FORWARD_ACROSS_GROUP",
+                                "MUST_FORWARD_ACROSS_GROUP",
+                                "CANNOT_FORWARD_ACROSS_GROUP",
+                                "NO_STATEMENT_ON_FORWARDING"
                             ]
                         },
                         "override-priority": {
@@ -8595,21 +8595,21 @@
                 "restoration-policy": {
                     "type": "string",
                     "enum": [
-                        "per-domain-restoration",
-                        "end-to-end-restoration",
-                        "na"
+                        "PER_DOMAIN_RESTORATION",
+                        "END_TO_END_RESTORATION",
+                        "NA"
                     ]
                 },
                 "protection-type": {
                     "type": "string",
                     "enum": [
-                        "no-protecton",
-                        "one-plus-one-protection",
-                        "one-plus-one-protection-with-dynamic-restoration",
-                        "permanent-one-plus-one-protection",
-                        "one-for-one-protection",
-                        "dynamic-restoration",
-                        "pre-computed-restoration"
+                        "NO_PROTECTON",
+                        "ONE_PLUS_ONE_PROTECTION",
+                        "ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION",
+                        "PERMANENT_ONE_PLUS_ONE_PROTECTION",
+                        "ONE_FOR_ONE_PROTECTION",
+                        "DYNAMIC_RESTORATION",
+                        "PRE_COMPUTED_RESTORATION"
                     ]
                 }
             }
@@ -8620,24 +8620,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -8665,10 +8665,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -8695,17 +8695,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -8747,11 +8747,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -8786,23 +8786,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -8838,10 +8838,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -8873,9 +8873,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -11007,11 +11007,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
@@ -11071,11 +11071,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -11098,32 +11098,32 @@
                         "role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. "
                         },
                         "direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         }
                     }
@@ -11192,11 +11192,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         },
@@ -11264,11 +11264,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -11303,11 +11303,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ]
                             }
                         }
@@ -11338,11 +11338,11 @@
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
-                                "otsi-a",
-                                "otu",
-                                "odu",
-                                "eth",
-                                "ety"
+                                "OTSiA",
+                                "OTU",
+                                "ODU",
+                                "ETH",
+                                "ETY"
                             ]
                         },
                         "aggregated-node-edge-point": {
@@ -11369,21 +11369,21 @@
                         "link-port-direction": {
                             "type": "string",
                             "enum": [
-                                "bidirectional",
-                                "input",
-                                "output",
-                                "unidentified-or-unknown"
+                                "BIDIRECTIONAL",
+                                "INPUT",
+                                "OUTPUT",
+                                "UNIDENTIFIED_OR_UNKNOWN"
                             ],
                             "description": "The orientation of defined flow at the LinkEnd."
                         },
                         "link-port-role": {
                             "type": "string",
                             "enum": [
-                                "symmetric",
-                                "root",
-                                "leaf",
-                                "trunk",
-                                "unknown"
+                                "SYMMETRIC",
+                                "ROOT",
+                                "LEAF",
+                                "TRUNK",
+                                "UNKNOWN"
                             ],
                             "description": "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. "
                         }
@@ -11704,24 +11704,24 @@
                 "administrative-state": {
                     "type": "string",
                     "enum": [
-                        "locked",
-                        "unlocked"
+                        "LOCKED",
+                        "UNLOCKED"
                     ]
                 },
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11749,10 +11749,10 @@
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11779,17 +11779,17 @@
                 "operational-state": {
                     "type": "string",
                     "enum": [
-                        "disabled",
-                        "enabled"
+                        "DISABLED",
+                        "ENABLED"
                     ]
                 },
                 "lifecycle-state": {
                     "type": "string",
                     "enum": [
-                        "planned",
-                        "potential",
-                        "installed",
-                        "pending-removal"
+                        "PLANNED",
+                        "POTENTIAL",
+                        "INSTALLED",
+                        "PENDING_REMOVAL"
                     ]
                 }
             }
@@ -11831,11 +11831,11 @@
                             "items": {
                                 "type": "string",
                                 "enum": [
-                                    "otsi-a",
-                                    "otu",
-                                    "odu",
-                                    "eth",
-                                    "ety"
+                                    "OTSiA",
+                                    "OTU",
+                                    "ODU",
+                                    "ETH",
+                                    "ETY"
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
@@ -11870,23 +11870,23 @@
                 "termination-direction": {
                     "type": "string",
                     "enum": [
-                        "bidirectional",
-                        "sink",
-                        "source",
-                        "undefined-or-unknown"
+                        "BIDIRECTIONAL",
+                        "SINK",
+                        "SOURCE",
+                        "UNDEFINED_OR_UNKNOWN"
                     ],
                     "description": "The overall directionality of the LP. \n- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.\n- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows\n- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows"
                 },
                 "termination-state": {
                     "type": "string",
                     "enum": [
-                        "lp-can-never-terminate",
-                        "lt-not-terminated",
-                        "terminated-server-to-client-flow",
-                        "terminated-client-to-server-flow",
-                        "terminated-bidirectional",
-                        "lt-permenantly-terminated",
-                        "termination-state-unknown"
+                        "LP_CAN_NEVER_TERMINATE",
+                        "LT_NOT_TERMINATED",
+                        "TERMINATED_SERVER_TO_CLIENT_FLOW",
+                        "TERMINATED_CLIENT_TO_SERVER_FLOW",
+                        "TERMINATED_BIDIRECTIONAL",
+                        "LT_PERMENANTLY_TERMINATED",
+                        "TERMINATION_STATE_UNKNOWN"
                     ],
                     "description": "Indicates whether the layer is terminated and if so how."
                 }
@@ -11922,10 +11922,10 @@
                 "bw-profile-type": {
                     "type": "string",
                     "enum": [
-                        "mef-10.x",
-                        "rfc-2697",
-                        "rfc-2698",
-                        "rfc-4115"
+                        "MEF_10.x",
+                        "RFC_2697",
+                        "RFC_2698",
+                        "RFC_4115"
                     ]
                 },
                 "committed-information-rate": {
@@ -11957,9 +11957,9 @@
                 "unit": {
                     "type": "string",
                     "enum": [
-                        "gbps",
-                        "mbps",
-                        "kbps"
+                        "GBPS",
+                        "MBPS",
+                        "KBPS"
                     ]
                 }
             }

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -11005,7 +11005,14 @@
                         "service-layer": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "cost-characteristic": {
@@ -11062,7 +11069,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -11103,7 +11117,14 @@
                             "description": "The orientation of defined flow at the EndPoint."
                         },
                         "service-layer": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         }
                     }
                 }
@@ -11169,7 +11190,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         },
                         "direction": {
@@ -11234,7 +11262,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -11266,7 +11301,14 @@
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ]
                             }
                         }
                     }
@@ -11294,7 +11336,14 @@
                 {
                     "properties": {
                         "layer-protocol-name": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "otsi-a",
+                                "otu",
+                                "odu",
+                                "eth",
+                                "ety"
+                            ]
                         },
                         "aggregated-node-edge-point": {
                             "type": "array",
@@ -11781,6 +11830,13 @@
                             "type": "array",
                             "items": {
                                 "type": "string",
+                                "enum": [
+                                    "otsi-a",
+                                    "otu",
+                                    "odu",
+                                    "eth",
+                                    "ety"
+                                ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
                         },

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -279,742 +279,6 @@
                 }
             }
         },
-        "/config/context/service-interface-point/{uuid}/state/": {
-            "post": {
-                "summary": "Create state by ID",
-                "description": "Create operation of resource: state",
-                "operationId": "create_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_service-interface-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update state by ID",
-                "description": "Update operation of resource: state",
-                "operationId": "update_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "state",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "description": "statebody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete state by ID",
-                "description": "Delete operation of resource: state",
-                "operationId": "delete_context_service-interface-point_state_state_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/": {
-            "post": {
-                "summary": "Create capacity by ID",
-                "description": "Create operation of resource: capacity",
-                "operationId": "create_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "get": {
-                "summary": "Retrieve capacity",
-                "description": "Retrieve operation of resource: capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update capacity by ID",
-                "description": "Update operation of resource: capacity",
-                "operationId": "update_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "capacity",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "description": "capacitybody object",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Delete capacity by ID",
-                "description": "Delete operation of resource: capacity",
-                "operationId": "delete_context_service-interface-point_capacity_capacity_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/service-interface-point/{uuid}/capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_service-interface-point_capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/service-interface-point/{uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -1208,6 +472,472 @@
                 "responses": {
                     "200": {
                         "description": "Successful operation"
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/service-interface-point/{uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_service-interface-point_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
                     },
                     "400": {
                         "description": "Internal Error"
@@ -1688,100 +1418,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/node-edge-point"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/owned-node-edge-point/{owned-node-edge-point_uuid}/termination/": {
-            "get": {
-                "summary": "Retrieve termination",
-                "description": "Retrieve operation of resource: termination",
-                "operationId": "retrieve_context_topology_node_owned-node-edge-point_termination_termination",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "owned-node-edge-point_uuid",
-                        "description": "ID of owned-node-edge-point_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/termination-pac"
                         }
                     },
                     "400": {
@@ -2567,1339 +2203,6 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "inter-rule-group_uuid",
-                        "description": "ID of inter-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
         "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/name/": {
             "get": {
                 "summary": "Retrieve name",
@@ -4019,58 +2322,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4096,6 +2352,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4114,11 +2377,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4144,6 +2407,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4162,11 +2432,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4192,6 +2462,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4209,11 +2486,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4241,6 +2518,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4256,11 +2540,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4288,6 +2572,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4303,11 +2594,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4335,6 +2626,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4350,11 +2648,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4380,6 +2678,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4397,11 +2702,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -4427,6 +2732,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4445,11 +2757,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4475,6 +2787,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4493,11 +2812,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -4523,6 +2842,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4540,11 +2866,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4572,6 +2898,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4587,11 +2920,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4619,6 +2952,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4634,11 +2974,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -4666,6 +3006,13 @@
                         "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4681,11 +3028,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -4711,6 +3058,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4728,58 +3082,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4805,6 +3112,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4815,7 +3129,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -4826,11 +3140,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -4856,6 +3170,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -4880,58 +3201,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -4957,6 +3231,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -4967,7 +3248,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -4978,11 +3259,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5008,6 +3289,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5032,58 +3320,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node-rule-group_uuid",
-                        "description": "ID of node-rule-group_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/": {
             "get": {
                 "summary": "Retrieve risk-characteristic",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5109,6 +3350,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5119,7 +3367,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
                             },
                             "type": "array"
                         }
@@ -5130,11 +3378,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/inter-rule-group/{inter-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
             "get": {
                 "summary": "Retrieve risk-characteristic by ID",
                 "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_node_node-rule-group_risk-parameter_risk-characteristic_risk-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_inter-rule-group_risk-characteristic_risk-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -5160,6 +3408,13 @@
                         "in": "path",
                         "name": "node-rule-group_uuid",
                         "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "inter-rule-group_uuid",
+                        "description": "ID of inter-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -5289,91 +3544,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_node_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/": {
             "get": {
                 "summary": "Retrieve total-potential-capacity",
                 "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-potential-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5392,6 +3567,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5410,11 +3592,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5433,6 +3615,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5451,11 +3640,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5474,6 +3663,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5491,11 +3687,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5516,6 +3712,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5531,11 +3734,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5556,6 +3759,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5571,11 +3781,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5596,6 +3806,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5611,11 +3828,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5634,6 +3851,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5651,11 +3875,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/": {
             "get": {
                 "summary": "Retrieve available-capacity",
                 "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_available-capacity",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_available-capacity",
                 "produces": [
                     "application/json"
                 ],
@@ -5674,6 +3898,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5692,11 +3923,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/total-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/total-size/": {
             "get": {
                 "summary": "Retrieve total-size",
                 "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_total-size_total-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_total-size_total-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5715,6 +3946,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5733,11 +3971,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/": {
             "get": {
                 "summary": "Retrieve bandwidth-profile",
                 "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_bandwidth-profile",
                 "produces": [
                     "application/json"
                 ],
@@ -5756,6 +3994,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5773,11 +4018,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
             "get": {
                 "summary": "Retrieve committed-information-rate",
                 "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5798,6 +4043,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5813,11 +4065,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
             "get": {
                 "summary": "Retrieve committed-burst-size",
                 "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5838,6 +4090,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5853,11 +4112,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
             "get": {
                 "summary": "Retrieve peak-information-rate",
                 "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
                 "produces": [
                     "application/json"
                 ],
@@ -5878,6 +4137,13 @@
                         "description": "ID of node_uuid",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5893,11 +4159,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
             "get": {
                 "summary": "Retrieve peak-burst-size",
                 "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_node_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "operationId": "retrieve_context_topology_node_node-rule-group_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
                 "produces": [
                     "application/json"
                 ],
@@ -5916,6 +4182,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -5933,51 +4206,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_node_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/": {
             "get": {
                 "summary": "Retrieve cost-characteristic",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -5996,6 +4229,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6006,7 +4246,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/"
                             },
                             "type": "array"
                         }
@@ -6017,11 +4257,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/cost-characteristic/{cost-name}/": {
             "get": {
                 "summary": "Retrieve cost-characteristic by ID",
                 "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-cost_cost-characteristic_cost-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_cost-characteristic_cost-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6040,6 +4280,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6064,91 +4311,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_node_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_node_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "node_uuid",
-                        "description": "ID of node_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/": {
             "get": {
                 "summary": "Retrieve latency-characteristic",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic",
                 "produces": [
                     "application/json"
                 ],
@@ -6167,6 +4334,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     }
@@ -6177,7 +4351,7 @@
                         "schema": {
                             "items": {
                                 "type": "string",
-                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/"
                             },
                             "type": "array"
                         }
@@ -6188,11 +4362,11 @@
                 }
             }
         },
-        "/config/context/topology/{uuid}/node/{node_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/latency-characteristic/{traffic-property-name}/": {
             "get": {
                 "summary": "Retrieve latency-characteristic by ID",
                 "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_node_transfer-timing_latency-characteristic_latency-characteristic_by_id",
+                "operationId": "retrieve_context_topology_node_node-rule-group_latency-characteristic_latency-characteristic_by_id",
                 "produces": [
                     "application/json"
                 ],
@@ -6211,6 +4385,13 @@
                         "in": "path",
                         "name": "node_uuid",
                         "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
                         "required": true,
                         "type": "string"
                     },
@@ -6227,6 +4408,111 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/node-rule-group/{node-rule-group_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_node_node-rule-group_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node-rule-group_uuid",
+                        "description": "ID of node-rule-group_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
                         }
                     },
                     "400": {
@@ -6326,6 +4612,752 @@
                 }
             }
         },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_node_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_node_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_node_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/node/{node_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_node_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "node_uuid",
+                        "description": "ID of node_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
         "/config/context/topology/{uuid}/link/": {
             "get": {
                 "summary": "Retrieve link",
@@ -6395,1254 +5427,6 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/link"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/state/": {
-            "get": {
-                "summary": "Retrieve state",
-                "description": "Retrieve operation of resource: state",
-                "operationId": "retrieve_context_topology_link_state_state",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/": {
-            "get": {
-                "summary": "Retrieve transfer-capacity",
-                "description": "Retrieve operation of resource: transfer-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_transfer-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/": {
-            "get": {
-                "summary": "Retrieve total-potential-capacity",
-                "description": "Retrieve operation of resource: total-potential-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-potential-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/": {
-            "get": {
-                "summary": "Retrieve available-capacity",
-                "description": "Retrieve operation of resource: available-capacity",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_available-capacity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Capacity available to be assigned.",
-                            "$ref": "#/definitions/capacity"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/total-size/": {
-            "get": {
-                "summary": "Retrieve total-size",
-                "description": "Retrieve operation of resource: total-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_total-size_total-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/": {
-            "get": {
-                "summary": "Retrieve bandwidth-profile",
-                "description": "Retrieve operation of resource: bandwidth-profile",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_bandwidth-profile",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/bandwidth-profile"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-information-rate/": {
-            "get": {
-                "summary": "Retrieve committed-information-rate",
-                "description": "Retrieve operation of resource: committed-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/committed-burst-size/": {
-            "get": {
-                "summary": "Retrieve committed-burst-size",
-                "description": "Retrieve operation of resource: committed-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-information-rate/": {
-            "get": {
-                "summary": "Retrieve peak-information-rate",
-                "description": "Retrieve operation of resource: peak-information-rate",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-capacity/available-capacity/bandwidth-profile/peak-burst-size/": {
-            "get": {
-                "summary": "Retrieve peak-burst-size",
-                "description": "Retrieve operation of resource: peak-burst-size",
-                "operationId": "retrieve_context_topology_link_transfer-capacity_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/capacity-value"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/": {
-            "get": {
-                "summary": "Retrieve transfer-cost",
-                "description": "Retrieve operation of resource: transfer-cost",
-                "operationId": "retrieve_context_topology_link_transfer-cost_transfer-cost",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-cost/cost-characteristic/{cost-name}/": {
-            "get": {
-                "summary": "Retrieve cost-characteristic by ID",
-                "description": "Retrieve operation of resource: cost-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-cost_cost-characteristic_cost-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "cost-name",
-                        "description": "ID of cost-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/cost-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-integrity/": {
-            "get": {
-                "summary": "Retrieve transfer-integrity",
-                "description": "Retrieve operation of resource: transfer-integrity",
-                "operationId": "retrieve_context_topology_link_transfer-integrity_transfer-integrity",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/": {
-            "get": {
-                "summary": "Retrieve transfer-timing",
-                "description": "Retrieve operation of resource: transfer-timing",
-                "operationId": "retrieve_context_topology_link_transfer-timing_transfer-timing",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/transfer-timing/latency-characteristic/{traffic-property-name}/": {
-            "get": {
-                "summary": "Retrieve latency-characteristic by ID",
-                "description": "Retrieve operation of resource: latency-characteristic",
-                "operationId": "retrieve_context_topology_link_transfer-timing_latency-characteristic_latency-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "traffic-property-name",
-                        "description": "ID of traffic-property-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/latency-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/": {
-            "get": {
-                "summary": "Retrieve risk-parameter",
-                "description": "Retrieve operation of resource: risk-parameter",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-parameter",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/risk-parameter/risk-characteristic/{risk-characteristic-name}/": {
-            "get": {
-                "summary": "Retrieve risk-characteristic by ID",
-                "description": "Retrieve operation of resource: risk-characteristic",
-                "operationId": "retrieve_context_topology_link_risk-parameter_risk-characteristic_risk-characteristic_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "risk-characteristic-name",
-                        "description": "ID of risk-characteristic-name",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/risk-characteristic"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/": {
-            "get": {
-                "summary": "Retrieve validation",
-                "description": "Retrieve operation of resource: validation",
-                "operationId": "retrieve_context_topology_link_validation_validation",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-pac"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "items": {
-                                "type": "string",
-                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/validation/validation-mechanism/{validation-mechanism}/": {
-            "get": {
-                "summary": "Retrieve validation-mechanism by ID",
-                "description": "Retrieve operation of resource: validation-mechanism",
-                "operationId": "retrieve_context_topology_link_validation_validation-mechanism_validation-mechanism_by_id",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "validation-mechanism",
-                        "description": "ID of validation-mechanism",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/validation-mechanism"
-                        }
-                    },
-                    "400": {
-                        "description": "Internal Error"
-                    }
-                }
-            }
-        },
-        "/config/context/topology/{uuid}/link/{link_uuid}/lp-transition/": {
-            "get": {
-                "summary": "Retrieve lp-transition",
-                "description": "Retrieve operation of resource: lp-transition",
-                "operationId": "retrieve_context_topology_link_lp-transition_lp-transition",
-                "produces": [
-                    "application/json"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uuid",
-                        "description": "ID of uuid",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "path",
-                        "name": "link_uuid",
-                        "description": "ID of link_uuid",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "schema": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         }
                     },
                     "400": {
@@ -7774,6 +5558,934 @@
                         "description": "Successful operation",
                         "schema": {
                             "$ref": "#/definitions/name-and-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/": {
+            "get": {
+                "summary": "Retrieve total-potential-capacity",
+                "description": "Retrieve operation of resource: total-potential-capacity",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-potential-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/total-potential-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_total-potential-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/": {
+            "get": {
+                "summary": "Retrieve available-capacity",
+                "description": "Retrieve operation of resource: available-capacity",
+                "operationId": "retrieve_context_topology_link_available-capacity_available-capacity",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Capacity available to be assigned.",
+                            "$ref": "#/definitions/capacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/total-size/": {
+            "get": {
+                "summary": "Retrieve total-size",
+                "description": "Retrieve operation of resource: total-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_total-size_total-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "description": "Total capacity of the TopologicalEntity in MB/s. In case of bandwidthProfile, this is expected to same as the committedInformationRate.",
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/": {
+            "get": {
+                "summary": "Retrieve bandwidth-profile",
+                "description": "Retrieve operation of resource: bandwidth-profile",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_bandwidth-profile",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/bandwidth-profile"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-information-rate/": {
+            "get": {
+                "summary": "Retrieve committed-information-rate",
+                "description": "Retrieve operation of resource: committed-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-information-rate_committed-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/committed-burst-size/": {
+            "get": {
+                "summary": "Retrieve committed-burst-size",
+                "description": "Retrieve operation of resource: committed-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_committed-burst-size_committed-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-information-rate/": {
+            "get": {
+                "summary": "Retrieve peak-information-rate",
+                "description": "Retrieve operation of resource: peak-information-rate",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-information-rate_peak-information-rate",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/available-capacity/bandwidth-profile/peak-burst-size/": {
+            "get": {
+                "summary": "Retrieve peak-burst-size",
+                "description": "Retrieve operation of resource: peak-burst-size",
+                "operationId": "retrieve_context_topology_link_available-capacity_bandwidth-profile_peak-burst-size_peak-burst-size",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/capacity-value"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/cost-characteristic/{cost-name}/": {
+            "get": {
+                "summary": "Retrieve cost-characteristic by ID",
+                "description": "Retrieve operation of resource: cost-characteristic",
+                "operationId": "retrieve_context_topology_link_cost-characteristic_cost-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "cost-name",
+                        "description": "ID of cost-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/cost-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/latency-characteristic/{traffic-property-name}/": {
+            "get": {
+                "summary": "Retrieve latency-characteristic by ID",
+                "description": "Retrieve operation of resource: latency-characteristic",
+                "operationId": "retrieve_context_topology_link_latency-characteristic_latency-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "traffic-property-name",
+                        "description": "ID of traffic-property-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/latency-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/risk-characteristic/{risk-characteristic-name}/": {
+            "get": {
+                "summary": "Retrieve risk-characteristic by ID",
+                "description": "Retrieve operation of resource: risk-characteristic",
+                "operationId": "retrieve_context_topology_link_risk-characteristic_risk-characteristic_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "risk-characteristic-name",
+                        "description": "ID of risk-characteristic-name",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/risk-characteristic"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "items": {
+                                "type": "string",
+                                "x-path": "/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "400": {
+                        "description": "Internal Error"
+                    }
+                }
+            }
+        },
+        "/config/context/topology/{uuid}/link/{link_uuid}/validation-mechanism/{validation-mechanism}/": {
+            "get": {
+                "summary": "Retrieve validation-mechanism by ID",
+                "description": "Retrieve operation of resource: validation-mechanism",
+                "operationId": "retrieve_context_topology_link_validation-mechanism_validation-mechanism_by_id",
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "uuid",
+                        "description": "ID of uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "link_uuid",
+                        "description": "ID of link_uuid",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "validation-mechanism",
+                        "description": "ID of validation-mechanism",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/validation-mechanism"
                         }
                     },
                     "400": {
@@ -11148,6 +9860,30 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
+                    "$ref": "#/definitions/validation-pac"
+                },
+                {
+                    "$ref": "#/definitions/layer-protocol-transition-pac"
+                },
+                {
                     "properties": {
                         "node-edge-point": {
                             "type": "array",
@@ -11162,30 +9898,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
-                        },
-                        "validation": {
-                            "$ref": "#/definitions/validation-pac"
-                        },
-                        "lp-transition": {
-                            "$ref": "#/definitions/layer-protocol-transition-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -11218,6 +9930,21 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-integrity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
                     "properties": {
                         "owned-node-edge-point": {
                             "type": "array",
@@ -11243,21 +9970,6 @@
                         "encap-topology": {
                             "type": "string",
                             "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:uuid"
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-integrity": {
-                            "$ref": "#/definitions/transfer-integrity-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
                         },
                         "layer-protocol-name": {
                             "type": "array",
@@ -11334,6 +10046,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/termination-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "string",
@@ -11359,12 +10077,6 @@
                                 "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid",
                                 "description": "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "termination": {
-                            "$ref": "#/definitions/termination-pac"
                         },
                         "link-port-direction": {
                             "type": "string",
@@ -11511,6 +10223,18 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
+                },
+                {
                     "properties": {
                         "rule": {
                             "type": "array",
@@ -11525,18 +10249,6 @@
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:node-rule-group/tapi-topology:uuid"
                             }
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -11546,6 +10258,18 @@
             "allOf": [
                 {
                     "$ref": "#/definitions/resource-spec"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-cost-pac"
+                },
+                {
+                    "$ref": "#/definitions/transfer-timing-pac"
+                },
+                {
+                    "$ref": "#/definitions/risk-parameter-pac"
                 },
                 {
                     "properties": {
@@ -11576,18 +10300,6 @@
                                 "$ref": "#/definitions/inter-rule-group"
                             },
                             "x-key": "uuid"
-                        },
-                        "transfer-capacity": {
-                            "$ref": "#/definitions/capacity-pac"
-                        },
-                        "transfer-cost": {
-                            "$ref": "#/definitions/transfer-cost-pac"
-                        },
-                        "transfer-timing": {
-                            "$ref": "#/definitions/transfer-timing-pac"
-                        },
-                        "risk-parameter": {
-                            "$ref": "#/definitions/risk-parameter-pac"
                         }
                     }
                 }
@@ -11825,6 +10537,12 @@
                     "$ref": "#/definitions/resource-spec"
                 },
                 {
+                    "$ref": "#/definitions/admin-state-pac"
+                },
+                {
+                    "$ref": "#/definitions/capacity-pac"
+                },
+                {
                     "properties": {
                         "layer-protocol-name": {
                             "type": "array",
@@ -11839,12 +10557,6 @@
                                 ],
                                 "description": "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental"
                             }
-                        },
-                        "state": {
-                            "$ref": "#/definitions/admin-state-pac"
-                        },
-                        "capacity": {
-                            "$ref": "#/definitions/capacity-pac"
                         }
                     }
                 }

--- a/UML/TapiCommon.notation
+++ b/UML/TapiCommon.notation
@@ -1443,6 +1443,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3HDgsZgEeeAD9H5zOiMUQ" x="214" y="-116"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_XzLwQMucEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XzLwQcucEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XzLwQ8ucEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XzLwQsucEeeFHsPqdArtwA" x="214" y="-116"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iE1WsT3fEea-1_BGg-qcjQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iE1Wsj3fEea-1_BGg-qcjQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_iE1Wsz3fEea-1_BGg-qcjQ">
@@ -2090,6 +2098,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_y3HDhsZgEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3HDh8ZgEeeAD9H5zOiMUQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3HDiMZgEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_XzLwRMucEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_O3-EAMhqEeaVlemTikmRHw" target="_XzLwQMucEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XzLwRcucEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XzMXUMucEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiCommon.uml#_O3NPAMhqEeaVlemTikmRHw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XzLwRsucEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XzLwR8ucEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XzLwSMucEeeFHsPqdArtwA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_-RwAgE0WEeaqn4OIuRCwEg" type="PapyrusUMLClassDiagram" name="EndPointDetails" measurementUnit="Pixel">

--- a/UML/TapiCommon.uml
+++ b/UML/TapiCommon.uml
@@ -229,7 +229,7 @@ Mm	00..59			time zone difference in minutes.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_i92HIL6PEeWRz-VHgA3LJQ" name="LayerProtocolName">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_i92HIL6PEeWRz-VHgA3LJQ" name="LayerProtocolName" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_mjS1wWkaEeWZEqTYAF8eqA">
           <body>Provides a controlled list of layer protocol names and indicates the naming authority.&#xD;
 &#xD;

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -113,14 +113,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wt-RckXOEeaB8vMnkFQLXQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsSYhGEeeOl5P_FBJSmA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeCTUIhGEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeCTUYhGEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeCTUohGEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeCTU4hGEeeOl5P_FBJSmA"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G928TBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G928jBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_0G928zBFEeam35bpdXJzEw"/>
@@ -314,14 +306,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HtYjDBFEeam35bpdXJzEw" x="222" y="15"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_0HtYqDBFEeam35bpdXJzEw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_0HtYqTBFEeam35bpdXJzEw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0HtYqzBFEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HtYqjBFEeam35bpdXJzEw" x="222" y="15"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HtY5DBFEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0HtY5TBFEeam35bpdXJzEw" showTitle="true"/>
@@ -873,14 +857,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_SWwL11EeWdore3Cxez9g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_au6foU5rEeeicu4cm-7qRg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au7GsE5rEeeicu4cm-7qRg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au7GsU5rEeeicu4cm-7qRg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_au7Gsk5rEeeicu4cm-7qRg" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au7Gs05rEeeicu4cm-7qRg"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_BDPgJv4xEea_VPdGG2-szQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_BDPgJ_4xEea_VPdGG2-szQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_BDPgKP4xEea_VPdGG2-szQ"/>
@@ -908,14 +884,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BDVm3f4xEea_VPdGG2-szQ" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_T0LaI_4yEea_VPdGG2-szQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_T0LaJP4yEea_VPdGG2-szQ" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0LaJv4yEea_VPdGG2-szQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T0LaJf4yEea_VPdGG2-szQ" x="396" y="-69"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__Y_BEIfVEeeirpBaj87qAw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="__Y_BEofVEeeirpBaj87qAw" type="5029"/>
@@ -967,14 +935,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_rgC9MIfUEeeirpBaj87qAw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdpr8YfWEeeirpBaj87qAw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdpr8ofWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdpr84fWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdpr9IfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdpr9YfWEeeirpBaj87qAw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__Y_oI4fVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__Y_oJIfVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="__Y_oJYfVEeeirpBaj87qAw"/>
@@ -1002,14 +962,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZO4sofVEeeirpBaj87qAw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_XS-VAIfWEeeirpBaj87qAw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_XS-VAYfWEeeirpBaj87qAw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XS-VA4fWEeeirpBaj87qAw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XS-VAofWEeeirpBaj87qAw" x="422" y="-77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_n02ZoIfbEeeirpBaj87qAw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_n02ZoofbEeeirpBaj87qAw" type="5029"/>
@@ -1052,14 +1004,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1D1BYfbEeeirpBaj87qAw" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_CqaUk4fhEeet-8tHdGGp_w" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_CqaUlIfhEeet-8tHdGGp_w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cqa7oIfhEeet-8tHdGGp_w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CqaUlYfhEeet-8tHdGGp_w" x="-70" y="-130"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SCXpgIhDEeeOl5P_FBJSmA" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_SCY3oIhDEeeOl5P_FBJSmA" type="5029"/>
@@ -1131,6 +1075,38 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4rXvkohDEeeOl5P_FBJSmA" x="915" y="-396"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_1Y6a0M4UEeehIvzuBRCtZQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_1Y6a0c4UEeehIvzuBRCtZQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Y6a084UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1Y6a0s4UEeehIvzuBRCtZQ" x="422" y="-77"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_4a16w84UEeehIvzuBRCtZQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_4a16xM4UEeehIvzuBRCtZQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4a16xs4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4a16xc4UEeehIvzuBRCtZQ" x="408" y="-395"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_516xo84UEeehIvzuBRCtZQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_516xpM4UEeehIvzuBRCtZQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_516xps4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_516xpc4UEeehIvzuBRCtZQ" x="422" y="-77"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_7Mj0c84UEeehIvzuBRCtZQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_7Mj0dM4UEeehIvzuBRCtZQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Mj0ds4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7Mj0dc4UEeehIvzuBRCtZQ" x="422" y="-77"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_vmgeMTBFEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_vmgeMjBFEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_vmgeMzBFEeam35bpdXJzEw">
@@ -1192,7 +1168,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0G90UzBFEeam35bpdXJzEw" type="4001" source="_0G9yhzBFEeam35bpdXJzEw" target="_0G91jDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0G90VDBFEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_0G90VTBFEeam35bpdXJzEw" x="-10" y="5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_0G90VTBFEeam35bpdXJzEw" x="-2" y="6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_0G90VjBFEeam35bpdXJzEw" type="6002">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-gFXcDI7EeamvfKYyWmELQ" source="PapyrusCSSForceValue">
@@ -1215,8 +1191,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_0G90YDBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0G90ZzBFEeam35bpdXJzEw" points="[0, 0, 189, -15]$[-189, 15, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aDBFEeam35bpdXJzEw" id="(0.5145985401459854,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aTBFEeam35bpdXJzEw" id="(0.5115511551155115,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aDBFEeam35bpdXJzEw" id="(0.513986013986014,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0G90aTBFEeam35bpdXJzEw" id="(0.5313531353135313,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0HHlHDBFEeam35bpdXJzEw" type="4001" source="_0HHioDBFEeam35bpdXJzEw" target="_0G9yhzBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHlHTBFEeam35bpdXJzEw" type="6001">
@@ -1239,19 +1215,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_0HHlKTBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlLTBFEeam35bpdXJzEw" points="[0, 0, 287, 65]$[-287, 0, 0, 65]$[-287, -65, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlLTBFEeam35bpdXJzEw" points="[0, 0, 278, 65]$[-278, 0, 0, 65]$[-278, -65, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLjBFEeam35bpdXJzEw" id="(0.0,0.3548387096774194)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLzBFEeam35bpdXJzEw" id="(0.7664233576642335,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0HtYrDBFEeam35bpdXJzEw" type="StereotypeCommentLink" source="_0G90UzBFEeam35bpdXJzEw" target="_0HtYqDBFEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_0HtYrTBFEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0HtYsTBFEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HtYrjBFEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HtYrzBFEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HtYsDBFEeam35bpdXJzEw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0KiqFDBFEeam35bpdXJzEw" type="StereotypeCommentLink" source="_0HHlHDBFEeam35bpdXJzEw" target="_0KiqEDBFEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_0KiqFTBFEeam35bpdXJzEw"/>
@@ -1355,8 +1321,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_wwARwUXOEeaB8vMnkFQLXQ"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_wt9DUEXOEeaB8vMnkFQLXQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wwARwkXOEeaB8vMnkFQLXQ" points="[13, -1, -131, 1]$[141, -3, -3, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzV5oEXOEeaB8vMnkFQLXQ" id="(0.900990099009901,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzV5oUXOEeaB8vMnkFQLXQ" id="(0.9452554744525548,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzV5oEXOEeaB8vMnkFQLXQ" id="(0.9372937293729373,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wzV5oUXOEeaB8vMnkFQLXQ" id="(0.9440559440559441,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_wxpQh0XOEeaB8vMnkFQLXQ" type="StereotypeCommentLink" source="_wwARwEXOEeaB8vMnkFQLXQ" target="_wxpQg0XOEeaB8vMnkFQLXQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_wxpQiEXOEeaB8vMnkFQLXQ"/>
@@ -1466,16 +1432,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2z3YP4yEea_VPdGG2-szQ" id="(0.0,0.8812785388127854)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T2z3Yf4yEea_VPdGG2-szQ" id="(1.0,0.06306306306306306)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_T0LaJ_4yEea_VPdGG2-szQ" type="StereotypeCommentLink" source="_TzUegP4yEea_VPdGG2-szQ" target="_T0LaI_4yEea_VPdGG2-szQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_T0LaKP4yEea_VPdGG2-szQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_T0LaLP4yEea_VPdGG2-szQ" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T0LaKf4yEea_VPdGG2-szQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0LaKv4yEea_VPdGG2-szQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T0LaK_4yEea_VPdGG2-szQ"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="__ZPfwIfVEeeirpBaj87qAw" type="StereotypeCommentLink" source="__Y_BEIfVEeeirpBaj87qAw" target="__ZO4sIfVEeeirpBaj87qAw">
       <styles xmi:type="notation:FontStyle" xmi:id="__ZPfwYfVEeeirpBaj87qAw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="__ZQG0YfVEeeirpBaj87qAw" name="BASE_ELEMENT">
@@ -1511,16 +1467,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPk5AIfWEeeirpBaj87qAw" id="(0.0,0.2009132420091324)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MPlgEIfWEeeirpBaj87qAw" id="(1.0,0.6431372549019608)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_XS-VBIfWEeeirpBaj87qAw" type="StereotypeCommentLink" source="_MMgW4IfWEeeirpBaj87qAw" target="_XS-VAIfWEeeirpBaj87qAw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_XS-VBYfWEeeirpBaj87qAw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XS-VCYfWEeeirpBaj87qAw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XS-VBofWEeeirpBaj87qAw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XS-VB4fWEeeirpBaj87qAw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XS-VCIfWEeeirpBaj87qAw"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_n1D1B4fbEeeirpBaj87qAw" type="StereotypeCommentLink" source="_n02ZoIfbEeeirpBaj87qAw" target="_n1D1A4fbEeeirpBaj87qAw">
       <styles xmi:type="notation:FontStyle" xmi:id="_n1D1CIfbEeeirpBaj87qAw"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1EcEofbEeeirpBaj87qAw" name="BASE_ELEMENT">
@@ -1555,16 +1501,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7a9EQofgEeet-8tHdGGp_w" points="[0, 0, -258, 51]$[258, -51, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7ezpgIfgEeet-8tHdGGp_w" id="(0.0,0.5021097046413502)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7ezpgYfgEeet-8tHdGGp_w" id="(1.0,0.5975609756097561)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Cqa7oYfhEeet-8tHdGGp_w" type="StereotypeCommentLink" source="_7a9EQIfgEeet-8tHdGGp_w" target="_CqaUk4fhEeet-8tHdGGp_w">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Cqa7oofhEeet-8tHdGGp_w"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cqa7pofhEeet-8tHdGGp_w" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Cqa7o4fhEeet-8tHdGGp_w" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cqa7pIfhEeet-8tHdGGp_w"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cqa7pYfhEeet-8tHdGGp_w"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_SCrykIhDEeeOl5P_FBJSmA" type="StereotypeCommentLink" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_SCrLgIhDEeeOl5P_FBJSmA">
       <styles xmi:type="notation:FontStyle" xmi:id="_SCrykYhDEeeOl5P_FBJSmA"/>
@@ -1660,6 +1596,46 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lo-pEohEEeeOl5P_FBJSmA" points="[0, 0, -88, -45]$[-76, 0, -164, -45]$[-76, 82, -164, 37]$[88, 82, 0, 37]$[88, 45, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LpAeQIhEEeeOl5P_FBJSmA" id="(0.0,0.7926267281105991)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LpAeQYhEEeeOl5P_FBJSmA" id="(0.3013698630136986,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1Y6a1M4UEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_0G90UzBFEeam35bpdXJzEw" target="_1Y6a0M4UEeehIvzuBRCtZQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1Y6a1c4UEeehIvzuBRCtZQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1Y6a2c4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1Y6a1s4UEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Y6a184UEeehIvzuBRCtZQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1Y6a2M4UEeehIvzuBRCtZQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_4a16x84UEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_7a9EQIfgEeet-8tHdGGp_w" target="_4a16w84UEeehIvzuBRCtZQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_4a16yM4UEeehIvzuBRCtZQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_4a2h0M4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_7ZpcsIfgEeet-8tHdGGp_w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4a16yc4UEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4a16ys4UEeehIvzuBRCtZQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4a16y84UEeehIvzuBRCtZQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_516xp84UEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_MMgW4IfWEeeirpBaj87qAw" target="_516xo84UEeehIvzuBRCtZQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_516xqM4UEeehIvzuBRCtZQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_516xrM4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_MKHxQIfWEeeirpBaj87qAw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_516xqc4UEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_516xqs4UEeehIvzuBRCtZQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_516xq84UEeehIvzuBRCtZQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_7Mj0d84UEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_TzUegP4yEea_VPdGG2-szQ" target="_7Mj0c84UEeehIvzuBRCtZQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_7Mj0eM4UEeehIvzuBRCtZQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7Mkbgs4UEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_Tx9zoP4yEea_VPdGG2-szQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7Mj0ec4UEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7MkbgM4UEeehIvzuBRCtZQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Mkbgc4UEeehIvzuBRCtZQ"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_9y8uwDBFEeam35bpdXJzEw" type="PapyrusUMLClassDiagram" name="ConnectivityServiceSkeleton" measurementUnit="Pixel">
@@ -4250,14 +4226,6 @@
         <children xmi:type="notation:Shape" xmi:id="_p3I7tIhCEeeOl5P_FBJSmA" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_p3I7tYhCEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_p3I7tohCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_p3I7t4hCEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_p3JiwIhCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_p3JiwYhCEeeOl5P_FBJSmA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_rSCMFOr0EeaeHOJw3lCT8A"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_rSCMFer0EeaeHOJw3lCT8A"/>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -487,9 +487,6 @@ The structure of LTP supports all transport protocols including circuit and pack
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
-        <generalization xmi:type="uml:Generalization" xmi:id="_r33L0D4zEea-1_BGg-qcjQ">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw" isReadOnly="true"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g">
@@ -578,7 +575,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MKK0kIfWEeeirpBaj87qAw" name="_resilienceConstraint" type="_MBqV4OrzEeaeHOJw3lCT8A" aggregation="composite" association="_MKHxQIfWEeeirpBaj87qAw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bTT98IfWEeeirpBaj87qAw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bTXoUIfWEeeirpBaj87qAw" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bTXoUIfWEeeirpBaj87qAw" value="1"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_MIWTIGh5EeWZEqTYAF8eqA" name="ConnectivityServiceEndPoint" isLeaf="true">
@@ -726,9 +723,6 @@ This ability allows multiple alternate routes to be present that otherwise would
         <ownedComment xmi:type="uml:Comment" xmi:id="_MBqV4erzEeaeHOJw3lCT8A" annotatedElement="_MBqV4OrzEeaeHOJw3lCT8A">
           <body>A list of control parameters to apply to a switch.</body>
         </ownedComment>
-        <generalization xmi:type="uml:Generalization" xmi:id="_xDapsIfVEeeirpBaj87qAw">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_0gCMcIfTEeeirpBaj87qAw" name="resilienceType">
           <type xmi:type="uml:DataType" href="TapiTopology.uml#_IQQS0IfNEeeirpBaj87qAw"/>
         </ownedAttribute>
@@ -808,9 +802,6 @@ All administrative controls of any aspect of protection are rejected.</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_-fei4P4wEea_VPdGG2-szQ" name="TopologyConstraint">
-        <generalization xmi:type="uml:Generalization" xmi:id="_ziATQP4xEea_VPdGG2-szQ">
-          <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-        </generalization>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true" association="_nxS_ADLCEeaULOmJRJKM0Q">
           <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
@@ -1049,7 +1040,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TPT-Bu_tEeWLlrwIF3w0vA" base_StructuralFeature="_TPT-Be_tEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_5oSYICM_EeaA8dOpokrEww" base_Association="_TPT-AO_tEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:StrictComposite xmi:id="_IDwVUBYdEeaOevPmmmHXcA" base_Association="_4Es8MGkIEeWZEqTYAF8eqA"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_b1QngO_qEeWLlrwIF3w0vA" base_Association="_WFlH4O_qEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_IZ4WgEHbEeWqPKyD1j6LMg" base_Class="_IZ3vcEHbEeWqPKyD1j6LMg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_MIWTL2h5EeWZEqTYAF8eqA" base_Class="_MIWTIGh5EeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_kuDzWEHaEeWqPKyD1j6LMg" base_Class="_kuDzQEHaEeWqPKyD1j6LMg"/>
@@ -1113,7 +1103,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelClass xmi:id="_-fei4f4wEea_VPdGG2-szQ" base_Class="_-fei4P4wEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TyD6RP4yEea_VPdGG2-szQ" base_StructuralFeature="_TyD6Qv4yEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_TyD6R_4yEea_VPdGG2-szQ" base_StructuralFeature="_TyD6Rf4yEea_VPdGG2-szQ"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_gqaFsP4yEea_VPdGG2-szQ" base_Association="_Tx9zoP4yEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Ca3vhv4zEea_VPdGG2-szQ" base_StructuralFeature="_Ca3vhP4zEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MjEHhv4zEea_VPdGG2-szQ" base_StructuralFeature="_MjEHhP4zEea_VPdGG2-szQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_DYrbkP4zEea_VPdGG2-szQ" base_StructuralFeature="_Ca3vh_4zEea_VPdGG2-szQ"/>
@@ -1284,7 +1273,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MKLboIfWEeeirpBaj87qAw" base_Property="_MKK0kIfWEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_MKLboofWEeeirpBaj87qAw" base_StructuralFeature="_MKLboYfWEeeirpBaj87qAw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_MKLbo4fWEeeirpBaj87qAw" base_Property="_MKLboYfWEeeirpBaj87qAw"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_XR2ToIfWEeeirpBaj87qAw" base_Association="_MKHxQIfWEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_1duKcIfYEeeirpBaj87qAw" base_StructuralFeature="_1dtjYIfYEeeirpBaj87qAw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1duKcYfYEeeirpBaj87qAw" base_Property="_1dtjYIfYEeeirpBaj87qAw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_k96BsYfbEeeirpBaj87qAw" base_Class="_k96BsIfbEeeirpBaj87qAw"/>
@@ -1297,7 +1285,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7ZsgAYfgEeet-8tHdGGp_w" base_Property="_7Zr48IfgEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_7ZtHEIfgEeet-8tHdGGp_w" base_StructuralFeature="_7ZsgAofgEeet-8tHdGGp_w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7ZtHEYfgEeet-8tHdGGp_w" base_Property="_7ZsgAofgEeet-8tHdGGp_w"/>
-  <OpenModel_Profile:StrictComposite xmi:id="_CpKXYIfhEeet-8tHdGGp_w" base_Association="_7ZpcsIfgEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_CHjpsYfiEeet-8tHdGGp_w" base_Parameter="_CHjpsIfiEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_KCNMEYfiEeet-8tHdGGp_w" base_Parameter="_KCNMEIfiEeet-8tHdGGp_w"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_207M8YfjEeet-8tHdGGp_w" base_StructuralFeature="_207M8IfjEeet-8tHdGGp_w"/>
@@ -1311,4 +1298,8 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_sGwYwcZaEeeAD9H5zOiMUQ" base_Property="_sGwYwMZaEeeAD9H5zOiMUQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_sGwYwsZaEeeAD9H5zOiMUQ" base_StructuralFeature="_sGwYwMZaEeeAD9H5zOiMUQ"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_zltdoMZaEeeAD9H5zOiMUQ" base_Association="_sGvKoMZaEeeAD9H5zOiMUQ"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_1Ys_cM4UEeehIvzuBRCtZQ" base_Association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_4ak1AM4UEeehIvzuBRCtZQ" base_Association="_7ZpcsIfgEeet-8tHdGGp_w"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_51xAoM4UEeehIvzuBRCtZQ" base_Association="_MKHxQIfWEeeirpBaj87qAw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_7MbRkM4UEeehIvzuBRCtZQ" base_Association="_Tx9zoP4yEea_VPdGG2-szQ"/>
 </xmi:XMI>

--- a/UML/TapiEth.notation
+++ b/UML/TapiEth.notation
@@ -322,7 +322,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-tUDO5Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_8QIrYK4wEeGjbtFXtCFKWg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-GMTO5Eea40e5DA9KE3w" x="289" y="444" height="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F9-GMTO5Eea40e5DA9KE3w" x="120" y="439" height="107"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_iCoq0DO5Eea40e5DA9KE3w" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_iCoq0jO5Eea40e5DA9KE3w" type="5029"/>
@@ -360,7 +360,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCpR7jO5Eea40e5DA9KE3w"/>
       </children>
       <element xmi:type="uml:Class" href="TapiEth.uml#_8QR1UK4wEeGjbtFXtCFKWg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCoq0TO5Eea40e5DA9KE3w" x="228" y="557" height="88"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iCoq0TO5Eea40e5DA9KE3w" x="117" y="558" height="88"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_F3cJsDlGEeaHY8ihI-WgZg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_F3cJsTlGEeaHY8ihI-WgZg" showTitle="true"/>
@@ -629,8 +629,11 @@
     </styles>
     <element xmi:type="uml:Package" href="TapiEth.uml#_MP5wgJKmEdybINoKQq_hfQ"/>
     <edges xmi:type="notation:Connector" xmi:id="__2PUwDN9Eea40e5DA9KE3w" type="4001" source="_T7eFADN7Eea40e5DA9KE3w" target="_M-W3ADN9Eea40e5DA9KE3w">
-      <children xmi:type="notation:DecorationNode" xmi:id="__2PUwzN9Eea40e5DA9KE3w" visible="false" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="__2PUxDN9Eea40e5DA9KE3w" y="-20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="__2PUwzN9Eea40e5DA9KE3w" type="6001">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_yTdQUM4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_yTdQUc4VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="__2PUxDN9Eea40e5DA9KE3w" x="13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="__2P70DN9Eea40e5DA9KE3w" type="6002">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SaYPkEWsEeaB8vMnkFQLXQ" source="PapyrusCSSForceValue">
@@ -663,14 +666,17 @@
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__3US0TN9Eea40e5DA9KE3w" id="(0.47619047619047616,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_IUR4EDN-Eea40e5DA9KE3w" type="4001" source="_T7eFADN7Eea40e5DA9KE3w" target="_pxNpQDN7Eea40e5DA9KE3w">
-      <children xmi:type="notation:DecorationNode" xmi:id="_IUSfIDN-Eea40e5DA9KE3w" visible="false" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUSfITN-Eea40e5DA9KE3w" y="-20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IUSfIDN-Eea40e5DA9KE3w" type="6001">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0Z9CwM4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0Z9p0M4VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUSfITN-Eea40e5DA9KE3w" x="-2" y="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_IUSfIjN-Eea40e5DA9KE3w" type="6002">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_VBVDskWsEeaB8vMnkFQLXQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_VBVDs0WsEeaB8vMnkFQLXQ" key="visible" value="true"/>
         </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUSfIzN-Eea40e5DA9KE3w" x="2" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IUSfIzN-Eea40e5DA9KE3w" x="-21" y="-5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_IUSfJDN-Eea40e5DA9KE3w" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_IUSfJTN-Eea40e5DA9KE3w" y="-20"/>
@@ -697,11 +703,17 @@
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IVTy0TN-Eea40e5DA9KE3w" id="(0.4900662251655629,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3FtcADO5Eea40e5DA9KE3w" type="4001" source="_pxNpQDN7Eea40e5DA9KE3w" target="_iCoq0DO5Eea40e5DA9KE3w">
-      <children xmi:type="notation:DecorationNode" xmi:id="_3FuDEDO5Eea40e5DA9KE3w" visible="false" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3FuDETO5Eea40e5DA9KE3w" y="-20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3FuDEDO5Eea40e5DA9KE3w" type="6001">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sYqF0s4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_sYqF084VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3FuDETO5Eea40e5DA9KE3w" x="3" y="-10"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_3FuDEjO5Eea40e5DA9KE3w" visible="false" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3FuDEzO5Eea40e5DA9KE3w" y="20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_3FuDEjO5Eea40e5DA9KE3w" type="6002">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sYqF0M4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_sYqF0c4VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3FuDEzO5Eea40e5DA9KE3w" x="1" y="10"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3FuDFDO5Eea40e5DA9KE3w" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3FuDFTO5Eea40e5DA9KE3w" y="-20"/>
@@ -725,11 +737,17 @@
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3IJsADO5Eea40e5DA9KE3w" id="(1.0,0.48863636363636365)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Adj8MDO6Eea40e5DA9KE3w" type="4001" source="_pxNpQDN7Eea40e5DA9KE3w" target="_F9-GMDO5Eea40e5DA9KE3w">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Adj8MzO6Eea40e5DA9KE3w" visible="false" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Adj8NDO6Eea40e5DA9KE3w" y="-20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Adj8MzO6Eea40e5DA9KE3w" type="6001">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oUZmMM4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oUaNQM4VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Adj8NDO6Eea40e5DA9KE3w" x="10" y="-11"/>
       </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_AdkjQDO6Eea40e5DA9KE3w" visible="false" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjQTO6Eea40e5DA9KE3w" y="20"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AdkjQDO6Eea40e5DA9KE3w" type="6002">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oUaNQc4VEeehIvzuBRCtZQ" source="PapyrusCSSForceValue">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oUaNQs4VEeehIvzuBRCtZQ" key="visible" value="true"/>
+        </eAnnotations>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjQTO6Eea40e5DA9KE3w" x="-6" y="13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_AdkjQjO6Eea40e5DA9KE3w" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjQzO6Eea40e5DA9KE3w" y="-20"/>
@@ -741,16 +759,16 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_qpbqAEWrEeaB8vMnkFQLXQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_qpbqAUWrEeaB8vMnkFQLXQ" key="visible" value="true"/>
         </eAnnotations>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjRzO6Eea40e5DA9KE3w" x="8" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjRzO6Eea40e5DA9KE3w" x="13" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_AdkjSDO6Eea40e5DA9KE3w" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjSTO6Eea40e5DA9KE3w" x="-17" y="17"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AdkjSTO6Eea40e5DA9KE3w" x="-24" y="-14"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Adj8MTO6Eea40e5DA9KE3w"/>
       <element xmi:type="uml:Association" href="TapiEth.uml#_AbxMcDO6Eea40e5DA9KE3w"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Adj8MjO6Eea40e5DA9KE3w" points="[25, 24, -253, -239]$[241, 263, -37, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AgNnkDO6Eea40e5DA9KE3w" id="(0.0,0.6190476190476191)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AgOOoDO6Eea40e5DA9KE3w" id="(1.0,0.5154639175257731)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AgOOoDO6Eea40e5DA9KE3w" id="(1.0,0.514018691588785)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_F3cJtDlGEeaHY8ihI-WgZg" type="StereotypeCommentLink" source="_T7eFADN7Eea40e5DA9KE3w" target="_F3cJsDlGEeaHY8ihI-WgZg">
       <styles xmi:type="notation:FontStyle" xmi:id="_F3cJtTlGEeaHY8ihI-WgZg"/>
@@ -894,7 +912,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Iy9pYEWsEeaB8vMnkFQLXQ" type="4001" source="_Co1CYEWsEeaB8vMnkFQLXQ" target="_3gR58DN-Eea40e5DA9KE3w">
       <children xmi:type="notation:DecorationNode" xmi:id="_Iy9pY0WsEeaB8vMnkFQLXQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iy9pZEWsEeaB8vMnkFQLXQ" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Iy9pZEWsEeaB8vMnkFQLXQ" x="6" y="-9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Iy9pZUWsEeaB8vMnkFQLXQ" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Iy9pZkWsEeaB8vMnkFQLXQ" x="-8" y="-16"/>

--- a/UML/TapiEth.uml
+++ b/UML/TapiEth.uml
@@ -248,7 +248,7 @@ Indicates the priority associated with the Partner’s System ID. If the aggrega
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__KuU8HnOEd2GobjTM4neEA" name="filterConfig" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__KuU8HnOEd2GobjTM4neEA" name="filterConfig1" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
           <ownedComment xmi:type="uml:Comment" xmi:id="_odulcCEkEd-ysdtezPKi3w" annotatedElement="__KuU8HnOEd2GobjTM4neEA">
             <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.&#xD;
 It indicates the configured filter action for each of the 33 group MAC addresses for control frames.&#xD;
@@ -332,7 +332,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
         <ownedComment xmi:type="uml:Comment" xmi:id="_I4OBgFBDEeWBGOds9dR2yw" annotatedElement="_8QR1UK4wEeGjbtFXtCFKWg">
           <body>Basic attributes: codirectional, condConfigList, prioConfigList</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList1" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_4ctfoOuSEeGZr5p9Vdkojw" annotatedElement="_Tg7zoOhhEeG35t-G7oiZlg">
             <body>This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
           </ownedComment>
@@ -359,7 +359,7 @@ If none of the above addresses match, the ETH_CI_D is passed.&#xD;
             <name xsi:nil="true"/>
           </defaultValue>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional" visibility="public" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional1" visibility="public" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_XllKMOuVEeGZr5p9Vdkojw" annotatedElement="_PHrv4LoIEeGh2ojTLz6Azw">
             <body>This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.</body>
           </ownedComment>
@@ -5022,4 +5022,9 @@ DEI = Drop Eligibility Indicator</body>
   <OpenModel_Profile_3:Specify xmi:id="_nAWJUMivEees0-2jg5eWTg" base_Abstraction="_earUAMivEees0-2jg5eWTg">
     <target>/TapiCommon:Context:_context/TapiTopology:TopologyContext:_topology/TapiTopology:Topology:_node/TapiTopology:Node:_ownedNodeEdgePoint</target>
   </OpenModel_Profile_3:Specify>
+  <OpenModel_Profile_3:ExtendedComposite xmi:id="_lHKOIM4VEeehIvzuBRCtZQ" base_Association="_AbxMcDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:ExtendedComposite xmi:id="_q68xsM4VEeehIvzuBRCtZQ" base_Association="_3Dz-kDO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:ExtendedComposite xmi:id="_vOuUAM4VEeehIvzuBRCtZQ" base_Association="__17LsDN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:ExtendedComposite xmi:id="_w4S54M4VEeehIvzuBRCtZQ" base_Association="_ITi4QDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_3:ExtendedComposite xmi:id="_1cNJ8M4VEeehIvzuBRCtZQ" base_Association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
 </xmi:XMI>

--- a/UML/TapiNotification.notation
+++ b/UML/TapiNotification.notation
@@ -74,10 +74,6 @@
         <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_whCiajBHEeam35bpdXJzEw"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_whCiazBHEeam35bpdXJzEw" type="3012">
-        <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_whCiijBHEeam35bpdXJzEw"/>
-      </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_whCiizBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_whCijDBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:FilteringStyle" xmi:id="_whCijTBHEeam35bpdXJzEw"/>
@@ -96,7 +92,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCimDBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Class" href="TapiCommon.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCixjBHEeam35bpdXJzEw" x="471" y="244" height="98"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whCixjBHEeam35bpdXJzEw" x="471" y="244" height="84"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whCixzBHEeam35bpdXJzEw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_whCiyDBHEeam35bpdXJzEw" type="5029"/>
@@ -190,10 +186,6 @@
         <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_gM0K89wpEeaaobmDldrjOQ"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_gM0K9NwpEeaaobmDldrjOQ" type="3012">
-        <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_gM0K9dwpEeaaobmDldrjOQ"/>
-      </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_whMTnDBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_whMTnTBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:FilteringStyle" xmi:id="_whMTnjBHEeam35bpdXJzEw"/>
@@ -212,7 +204,7 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMTqTBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Class" href="TapiNotification.uml#_oVDs4CzvEeaYO8M_h7XJ5A"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMT1zBHEeam35bpdXJzEw" x="61" y="210" height="196"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMT1zBHEeam35bpdXJzEw" x="61" y="232" height="174"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMT4jBHEeam35bpdXJzEw" type="2006">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMT4zBHEeam35bpdXJzEw" type="5023"/>
@@ -360,17 +352,13 @@
         <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_LzXX3SCAEeeWCKlkirNtnw"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_LzXX3iCAEeeWCKlkirNtnw" type="3005">
-        <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_LzXX3yCAEeeWCKlkirNtnw"/>
-      </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_whMVrTBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:SortingStyle" xmi:id="_whMVrjBHEeam35bpdXJzEw"/>
       <styles xmi:type="notation:FilteringStyle" xmi:id="_whMVrzBHEeam35bpdXJzEw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMVsDBHEeam35bpdXJzEw"/>
     </children>
     <element xmi:type="uml:Signal" href="TapiNotification.uml#_7CEIsC1qEeair-8ZDvf8jw"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMV2jBHEeam35bpdXJzEw" x="322" y="468" height="314"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_whMV2jBHEeam35bpdXJzEw" x="322" y="468" height="300"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_whMV2zBHEeam35bpdXJzEw" type="2004">
     <children xmi:type="notation:DecorationNode" xmi:id="_whMV3DBHEeam35bpdXJzEw" type="5011"/>
@@ -909,14 +897,6 @@
     <element xsi:nil="true"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uMoqlRM5Eee0L_IMWjydgQ" x="387" y="-25"/>
   </children>
-  <children xmi:type="notation:Shape" xmi:id="_t8qN0yB_EeeWCKlkirNtnw" type="StereotypeComment">
-    <styles xmi:type="notation:TitleStyle" xmi:id="_t8qN1CB_EeeWCKlkirNtnw" showTitle="true"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t8qN1iB_EeeWCKlkirNtnw" name="BASE_ELEMENT">
-      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Hh5YECB_EeeWCKlkirNtnw"/>
-    </styles>
-    <element xsi:nil="true"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t8qN1SB_EeeWCKlkirNtnw" x="522" y="388"/>
-  </children>
   <children xmi:type="notation:Shape" xmi:id="_K1csICCCEeeWCKlkirNtnw" type="2008">
     <children xmi:type="notation:DecorationNode" xmi:id="_K1csIiCCEeeWCKlkirNtnw" type="5029"/>
     <children xmi:type="notation:DecorationNode" xmi:id="_K1csIyCCEeeWCKlkirNtnw" type="8510">
@@ -1056,6 +1036,30 @@
     </styles>
     <element xsi:nil="true"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bx5HUlrnEeexvMtO2oNM9g" x="522" y="368"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_kq-EoMrkEeeFHsPqdArtwA" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_kq-EocrkEeeFHsPqdArtwA" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kq-Eo8rkEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kq-EosrkEeeFHsPqdArtwA" x="522" y="368"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_MKUj48rlEeeFHsPqdArtwA" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_MKUj5MrlEeeFHsPqdArtwA" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MKUj5srlEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MKUj5crlEeeFHsPqdArtwA" x="522" y="368"/>
+  </children>
+  <children xmi:type="notation:Shape" xmi:id="_NofLAMrlEeeFHsPqdArtwA" type="StereotypeComment">
+    <styles xmi:type="notation:TitleStyle" xmi:id="_NofLAcrlEeeFHsPqdArtwA" showTitle="true"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NofLA8rlEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Hh5YECB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NofLAsrlEeeFHsPqdArtwA" x="522" y="368"/>
   </children>
   <styles xmi:type="notation:StringValueStyle" xmi:id="_tIFpETBHEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
   <styles xmi:type="notation:DiagramStyle" xmi:id="_tIFpEjBHEeam35bpdXJzEw"/>
@@ -1246,7 +1250,7 @@
     <element xmi:type="uml:Association" href="TapiNotification.uml#_kFsxgE8SEea3rq3M7G3w3w"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kYjcEk8SEea3rq3M7G3w3w" points="[0, -20, -3, 193]$[14, -207, 11, 6]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEE8SEea3rq3M7G3w3w" id="(0.8458781362007168,0.0)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEU8SEea3rq3M7G3w3w" id="(0.5117647058823529,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kcrHEU8SEea3rq3M7G3w3w" id="(0.3522267206477733,1.0)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_kaZPIE8SEea3rq3M7G3w3w" type="StereotypeCommentLink" source="_kYjcEE8SEea3rq3M7G3w3w" target="_kaYoEE8SEea3rq3M7G3w3w">
     <styles xmi:type="notation:FontStyle" xmi:id="_kaZPIU8SEea3rq3M7G3w3w"/>
@@ -1315,10 +1319,10 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_wfDxkMh5EeaVlemTikmRHw" type="4001" source="_mX0b0Mh5EeaVlemTikmRHw" target="_whMS9zBHEeam35bpdXJzEw">
     <children xmi:type="notation:DecorationNode" xmi:id="_wfDxk8h5EeaVlemTikmRHw" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_wfDxlMh5EeaVlemTikmRHw" y="-20"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_wfDxlMh5EeaVlemTikmRHw" x="11" y="5"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_wfDxlch5EeaVlemTikmRHw" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_wfDxlsh5EeaVlemTikmRHw" x="-3" y="-4"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_wfDxlsh5EeaVlemTikmRHw" x="-9" y="-5"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_wfDxl8h5EeaVlemTikmRHw" type="6003">
       <layoutConstraint xmi:type="notation:Location" xmi:id="_wfDxmMh5EeaVlemTikmRHw" y="-20"/>
@@ -1350,7 +1354,7 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_AHgtIMh6EeaVlemTikmRHw" type="4001" source="_mX0b0Mh5EeaVlemTikmRHw" target="_whMUSDBHEeam35bpdXJzEw">
     <children xmi:type="notation:DecorationNode" xmi:id="_AHgtI8h6EeaVlemTikmRHw" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_AHgtJMh6EeaVlemTikmRHw" y="-20"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_AHgtJMh6EeaVlemTikmRHw" x="-100" y="-1"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_AHgtJch6EeaVlemTikmRHw" type="6002">
       <layoutConstraint xmi:type="notation:Location" xmi:id="_AHgtJsh6EeaVlemTikmRHw" x="-118" y="4"/>
@@ -1499,7 +1503,7 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_Hiw6wCB_EeeWCKlkirNtnw" type="4001" source="_whMUSDBHEeam35bpdXJzEw" target="_MQpe0SCCEeeWCKlkirNtnw">
     <children xmi:type="notation:DecorationNode" xmi:id="_Hiw6wyB_EeeWCKlkirNtnw" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_Hiw6xCB_EeeWCKlkirNtnw" x="-1" y="1"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Hiw6xCB_EeeWCKlkirNtnw" x="4" y="3"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_Hiw6xSB_EeeWCKlkirNtnw" type="6002">
       <layoutConstraint xmi:type="notation:Location" xmi:id="_Hiw6xiB_EeeWCKlkirNtnw" x="-11"/>
@@ -1521,16 +1525,6 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hiw6wiB_EeeWCKlkirNtnw" points="[18, 46, -26, -64]$[32, 91, -12, -19]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmDfUCB_EeeWCKlkirNtnw" id="(0.8494623655913979,1.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HmDfUSB_EeeWCKlkirNtnw" id="(0.2867383512544803,0.0)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_t8qN1yB_EeeWCKlkirNtnw" type="StereotypeCommentLink" source="_Hiw6wCB_EeeWCKlkirNtnw" target="_t8qN0yB_EeeWCKlkirNtnw">
-    <styles xmi:type="notation:FontStyle" xmi:id="_t8qN2CB_EeeWCKlkirNtnw"/>
-    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_t8qN3CB_EeeWCKlkirNtnw" name="BASE_ELEMENT">
-      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Hh5YECB_EeeWCKlkirNtnw"/>
-    </styles>
-    <element xsi:nil="true"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_t8qN2SB_EeeWCKlkirNtnw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t8qN2iB_EeeWCKlkirNtnw"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_t8qN2yB_EeeWCKlkirNtnw"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vrpfOCB_EeeWCKlkirNtnw" type="StereotypeCommentLink" source="_HBxtkCB_EeeWCKlkirNtnw">
     <styles xmi:type="notation:FontStyle" xmi:id="_vrpfOSB_EeeWCKlkirNtnw"/>
@@ -1624,5 +1618,35 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g4ChwlrnEeexvMtO2oNM9g" points="[0, 0, 85, 33]$[-85, 0, 0, 33]$[-85, -33, 0, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g7F1wFrnEeexvMtO2oNM9g" id="(0.0,0.24324324324324326)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g7F1wVrnEeexvMtO2oNM9g" id="(0.09098712446351931,1.0)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_kq-rsMrkEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_HBxtkCB_EeeWCKlkirNtnw" target="_kq-EoMrkEeeFHsPqdArtwA">
+    <styles xmi:type="notation:FontStyle" xmi:id="_kq-rscrkEeeFHsPqdArtwA"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_kq-rtcrkEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kq-rssrkEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kq-rs8rkEeeFHsPqdArtwA"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kq-rtMrkEeeFHsPqdArtwA"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_MKVK8MrlEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_HBxtkCB_EeeWCKlkirNtnw" target="_MKUj48rlEeeFHsPqdArtwA">
+    <styles xmi:type="notation:FontStyle" xmi:id="_MKVK8crlEeeFHsPqdArtwA"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MKVK9crlEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_HA6K4CB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MKVK8srlEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKVK88rlEeeFHsPqdArtwA"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MKVK9MrlEeeFHsPqdArtwA"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_NofLBMrlEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_Hiw6wCB_EeeWCKlkirNtnw" target="_NofLAMrlEeeFHsPqdArtwA">
+    <styles xmi:type="notation:FontStyle" xmi:id="_NofLBcrlEeeFHsPqdArtwA"/>
+    <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NohAMMrlEeeFHsPqdArtwA" name="BASE_ELEMENT">
+      <eObjectValue xmi:type="uml:Association" href="TapiNotification.uml#_Hh5YECB_EeeWCKlkirNtnw"/>
+    </styles>
+    <element xsi:nil="true"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NofLBsrlEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NofLB8rlEeeFHsPqdArtwA"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NofLCMrlEeeFHsPqdArtwA"/>
   </edges>
 </notation:Diagram>

--- a/UML/TapiNotification.uml
+++ b/UML/TapiNotification.uml
@@ -530,8 +530,6 @@ This specifics of this is typically dependent on the implementation protocol &am
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Hh5YFSB_EeeWCKlkirNtnw" base_StructuralFeature="_Hh5YEyB_EeeWCKlkirNtnw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Hh5YFyB_EeeWCKlkirNtnw" base_Property="_Hh5YFiB_EeeWCKlkirNtnw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Hh5YGCB_EeeWCKlkirNtnw" base_StructuralFeature="_Hh5YFiB_EeeWCKlkirNtnw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_t8gc0CB_EeeWCKlkirNtnw" base_Association="_Hh5YECB_EeeWCKlkirNtnw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_vrpfMCB_EeeWCKlkirNtnw" base_Association="_HA6K4CB_EeeWCKlkirNtnw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_K1S7ISCCEeeWCKlkirNtnw" base_Class="_K1S7ICCCEeeWCKlkirNtnw"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_MQpe0CCCEeeWCKlkirNtnw" base_Class="_MQft0CCCEeeWCKlkirNtnw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_wieSICCCEeeWCKlkirNtnw" base_Association="_Nsg9cE8cEea3rq3M7G3w3w"/>
@@ -541,4 +539,8 @@ This specifics of this is typically dependent on the implementation protocol &am
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_DOPJ8lqoEeexvMtO2oNM9g" base_Class="_mWGkkMh5EeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_DOPJ81qoEeexvMtO2oNM9g" base_Class="_K1S7ICCCEeeWCKlkirNtnw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_DOPJ9FqoEeexvMtO2oNM9g" base_Class="_MQft0CCCEeeWCKlkirNtnw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_maJjQMrkEeeFHsPqdArtwA" base_Association="_weSVgMh5EeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_sa_rYMrkEeeFHsPqdArtwA" base_Association="_AGv4IMh6EeaVlemTikmRHw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_MKMBAMrlEeeFHsPqdArtwA" base_Association="_HA6K4CB_EeeWCKlkirNtnw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_NoX2QMrlEeeFHsPqdArtwA" base_Association="_Hh5YECB_EeeWCKlkirNtnw"/>
 </xmi:XMI>

--- a/UML/TapiOdu.notation
+++ b/UML/TapiOdu.notation
@@ -3525,6 +3525,38 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YckZEpS1EeeTcuZP_vjYKw" x="-52" y="-429"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_d1POwMubEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d1POwcubEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d1POw8ubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d1POwsubEeeFHsPqdArtwA" x="208" y="-68"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d2fzAMubEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d2fzAcubEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d2gaEMubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d2fzAsubEeeFHsPqdArtwA" x="256" y="-434"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d3bAEMubEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d3bAEcubEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d3bAE8ubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d3bAEsubEeeFHsPqdArtwA" x="-42" y="-54"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_d4q9QMubEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_d4q9QcubEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d4q9Q8ubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d4q9QsubEeeFHsPqdArtwA" x="-52" y="-429"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_sZDP5B3BEea2UIYIpgn3Zw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_sZDP5R3BEea2UIYIpgn3Zw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_sZDP5h3BEea2UIYIpgn3Zw">
@@ -6870,6 +6902,46 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YckZFpS1EeeTcuZP_vjYKw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YckZF5S1EeeTcuZP_vjYKw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YckZGJS1EeeTcuZP_vjYKw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d1POxMubEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_sYz_AR3BEea2UIYIpgn3Zw" target="_d1POwMubEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d1POxcubEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d1P10MubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_sYxiwR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d1POxsubEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d1POx8ubEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d1POyMubEeeFHsPqdArtwA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d2gaEcubEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_sZDP5x3BEea2UIYIpgn3Zw" target="_d2fzAMubEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d2gaEsubEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d2gaFsubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d2gaE8ubEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d2gaFMubEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d2gaFcubEeeFHsPqdArtwA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d3bnIMubEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_C8QWsDIOEeaBg9FoTfINnA" target="_d3bAEMubEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d3bnIcubEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d3bnJcubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiOdu.uml#_CJrDMDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d3bnIsubEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d3bnI8ubEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d3bnJMubEeeFHsPqdArtwA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_d4q9RMubEeeFHsPqdArtwA" type="StereotypeCommentLink" source="_cO-YIDIOEeaBg9FoTfINnA" target="_d4q9QMubEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_d4q9RcubEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_d4rkUsubEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOdu.uml#_cOYiQDIOEeaBg9FoTfINnA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d4q9RsubEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d4rkUMubEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d4rkUcubEeeFHsPqdArtwA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_lW6NAJQPEeebLvYqX3NA2Q" type="PapyrusUMLClassDiagram" name="OduOamSpec" measurementUnit="Pixel">

--- a/UML/TapiOdu.uml
+++ b/UML/TapiOdu.uml
@@ -556,7 +556,7 @@ Standardized values are defined in Table 7-2/G.709.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Q1LjMGZNEeeGDK6oTuc93w" name="UNKNOWN"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_SCtGQGZNEeeGDK6oTuc93w" name="UNINTERPRETABLE"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_aUZgoJP1EeePQIrrJoWPZA" name="DegThr">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_aUZgoJP1EeePQIrrJoWPZA" name="DegThr" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_aUZgoZP1EeePQIrrJoWPZA" annotatedElement="_aUZgoJP1EeePQIrrJoWPZA">
           <body>Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. &#xD;
 &#xD;
@@ -584,7 +584,7 @@ Number of Errored Blocks is captured in an integer value.</body>
           <defaultValue xmi:type="uml:InstanceValue" xmi:id="_7eDssJRDEee0N_ppE1lIiw" type="_OTZ3gJRDEee0N_ppE1lIiw" instance="_RYxF8JRDEee0N_ppE1lIiw"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_aVzO0JP1EeePQIrrJoWPZA" name="DegThrType">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_aVzO0JP1EeePQIrrJoWPZA" name="DegThrType" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_aVzO0ZP1EeePQIrrJoWPZA" annotatedElement="_aVzO0JP1EeePQIrrJoWPZA">
           <body>The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.</body>
         </ownedComment>
@@ -599,7 +599,7 @@ Number of Errored Blocks is captured in an integer value.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_SL2PsJP2EeePQIrrJoWPZA" name="TcmStatus">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_SL2PsJP2EeePQIrrJoWPZA" name="TcmStatus" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_SL2PsZP2EeePQIrrJoWPZA" annotatedElement="_SL2PsJP2EeePQIrrJoWPZA">
           <body>See Table 15-5/G.709/Y.1331 </body>
         </ownedComment>
@@ -644,7 +644,7 @@ Number of Errored Blocks is captured in an integer value.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_XTiiQJP2EeePQIrrJoWPZA" name="TcmMode">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_XTiiQJP2EeePQIrrJoWPZA" name="TcmMode" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_XTiiQZP2EeePQIrrJoWPZA" annotatedElement="_XTiiQJP2EeePQIrrJoWPZA">
           <body>List of value modes for the sink side of the tandem connection monitoring function.</body>
         </ownedComment>
@@ -652,19 +652,19 @@ Number of Errored Blocks is captured in an integer value.</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XTiiQ5P2EeePQIrrJoWPZA" name="TRANSPARENT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XTiiRJP2EeePQIrrJoWPZA" name="MONITOR"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_XTjwYJP2EeePQIrrJoWPZA" name="TcmMonitoring">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_XTjwYJP2EeePQIrrJoWPZA" name="TcmMonitoring" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_XTjwYZP2EeePQIrrJoWPZA" annotatedElement="_XTjwYJP2EeePQIrrJoWPZA">
           <body>Monitoring types for the tandem connection monitoring function.</body>
         </ownedComment>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XTjwYpP2EeePQIrrJoWPZA" name="INTRUSIVE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XTjwY5P2EeePQIrrJoWPZA" name="NON-INTRUSIVE"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_r4SYsJP2EeePQIrrJoWPZA" name="TcmExtension">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_r4SYsJP2EeePQIrrJoWPZA" name="TcmExtension" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_r4SYsZP2EeePQIrrJoWPZA" name="NORMAL"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_r4SYspP2EeePQIrrJoWPZA" name="PASS-THROUGH"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_r4SYs5P2EeePQIrrJoWPZA" name="ERASE"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_OTZ3gJRDEee0N_ppE1lIiw" name="PercentageGranularity">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_OTZ3gJRDEee0N_ppE1lIiw" name="PercentageGranularity" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_RYxF8JRDEee0N_ppE1lIiw" name="ONES"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_goDTkJRDEee0N_ppE1lIiw" name="ONE_TENTHS">
           <ownedComment xmi:type="uml:Comment" xmi:id="_goDTkZRDEee0N_ppE1lIiw" annotatedElement="_goDTkJRDEee0N_ppE1lIiw">
@@ -682,7 +682,7 @@ Number of Errored Blocks is captured in an integer value.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_WKC-0JSfEeeTcuZP_vjYKw" name="UasChoice">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_WKC-0JSfEeeTcuZP_vjYKw" name="UasChoice" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_WKC-0ZSfEeeTcuZP_vjYKw" annotatedElement="_WKC-0JSfEeeTcuZP_vjYKw">
           <body>If bidirectional is TRUE then use the uas attribute, if bidirectional is FALSE use the nuas, and fuas attributes</body>
         </ownedComment>

--- a/UML/TapiOtsi.notation
+++ b/UML/TapiOtsi.notation
@@ -513,7 +513,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0s6w6I6dEeeyZasfnNSonw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiOtsi.uml#_KjQ3tBKOEeajhbtskMXJfw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0s6xHY6dEeeyZasfnNSonw" x="-47" y="-22" height="120"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0s6xHY6dEeeyZasfnNSonw" x="-47" y="-22" width="517" height="120"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0s7-QY6dEeeyZasfnNSonw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0s7-Qo6dEeeyZasfnNSonw" type="5029"/>
@@ -633,14 +633,6 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0vN2Mo6dEeeyZasfnNSonw" x="372" y="-387"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_0vQ5gI6dEeeyZasfnNSonw" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_0vQ5gY6dEeeyZasfnNSonw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vQ5g46dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0vQ5go6dEeeyZasfnNSonw" x="372" y="-387"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_0vTVwI6dEeeyZasfnNSonw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_0vTVwY6dEeeyZasfnNSonw" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vTVw46dEeeyZasfnNSonw" name="BASE_ELEMENT">
@@ -729,6 +721,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rPVwEo8ZEeedErNofqJXiw" x="13" y="-138"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_HMdrQ84xEeehIvzuBRCtZQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HMdrRM4xEeehIvzuBRCtZQ" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HMdrRs4xEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HMdrRc4xEeehIvzuBRCtZQ" x="372" y="-419"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6FlAY6dEeeyZasfnNSonw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6FlAo6dEeeyZasfnNSonw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_z6FlA46dEeeyZasfnNSonw">
@@ -812,7 +812,7 @@
       <element xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0s_Boo6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s_Bo46dEeeyZasfnNSonw" id="(0.038461538461538464,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s_BpI6dEeeyZasfnNSonw" id="(0.4635108481262327,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0s_BpI6dEeeyZasfnNSonw" id="(0.45366795366795365,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0s_BpY6dEeeyZasfnNSonw" type="4001" source="_0s7-QY6dEeeyZasfnNSonw" target="_0smAJ46dEeeyZasfnNSonw">
       <children xmi:type="notation:DecorationNode" xmi:id="_0s_Bpo6dEeeyZasfnNSonw" type="6001">
@@ -858,16 +858,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0vN2No6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vN2N46dEeeyZasfnNSonw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vN2OI6dEeeyZasfnNSonw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_0vQ5hI6dEeeyZasfnNSonw" type="StereotypeCommentLink" source="_0s_BkY6dEeeyZasfnNSonw" target="_0vQ5gI6dEeeyZasfnNSonw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_0vQ5hY6dEeeyZasfnNSonw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0vQ5iY6dEeeyZasfnNSonw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0vQ5ho6dEeeyZasfnNSonw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vQ5h46dEeeyZasfnNSonw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0vQ5iI6dEeeyZasfnNSonw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0vT80I6dEeeyZasfnNSonw" type="StereotypeCommentLink" source="_0s9MYo6dEeeyZasfnNSonw" target="_0vTVwI6dEeeyZasfnNSonw">
       <styles xmi:type="notation:FontStyle" xmi:id="_0vT80Y6dEeeyZasfnNSonw"/>
@@ -1003,6 +993,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rPVwFo8ZEeedErNofqJXiw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rPVwF48ZEeedErNofqJXiw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rPVwGI8ZEeedErNofqJXiw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HMeSUM4xEeehIvzuBRCtZQ" type="StereotypeCommentLink" source="_0s_BkY6dEeeyZasfnNSonw" target="_HMdrQ84xEeehIvzuBRCtZQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HMeSUc4xEeehIvzuBRCtZQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HMeSVc4xEeehIvzuBRCtZQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiOtsi.uml#_KjQ3phKOEeajhbtskMXJfw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HMeSUs4xEeehIvzuBRCtZQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HMeSU84xEeehIvzuBRCtZQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HMeSVM4xEeehIvzuBRCtZQ"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiOtsi.uml
+++ b/UML/TapiOtsi.uml
@@ -52,7 +52,7 @@
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3sRKOEeajhbtskMXJfw" name="_otsiTermination" type="_KjQ3tBKOEeajhbtskMXJfw" isReadOnly="true" aggregation="composite" association="_KjQ3phKOEeajhbtskMXJfw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3shKOEeajhbtskMXJfw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sxKOEeajhbtskMXJfw" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sxKOEeajhbtskMXJfw" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_2YQQkI6dEeeyZasfnNSonw" name="_otsiCtp" type="_nBhMkI6cEeeyZasfnNSonw" isReadOnly="true" aggregation="composite" association="_2YPCcI6dEeeyZasfnNSonw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KVifEJJnEee26o4qs2D5Ig"/>
@@ -60,21 +60,34 @@
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3tBKOEeajhbtskMXJfw" name="OtsiTerminationPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uxKOEeajhbtskMXJfw" name="selectedNominalCentralFrequency" visibility="public" type="_KjQ3xBKOEeajhbtskMXJfw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uxKOEeajhbtskMXJfw" name="selectedNominalCentralFrequency" visibility="public" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3vBKOEeajhbtskMXJfw" annotatedElement="_KjQ3uxKOEeajhbtskMXJfw">
             <body>This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.&#xD;
 This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.&#xD;
 </body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_J5NlYM4xEeehIvzuBRCtZQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_J5QosM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableLowerNominalCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_t2oxcI50EeeyZasfnNSonw" name="supportableUpperNominalCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uRKOEeajhbtskMXJfw" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9XaUJJmEee26o4qs2D5Ig" name="supportableLowerNominalCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KgckgM4xEeehIvzuBRCtZQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KgdyoM4xEeehIvzuBRCtZQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_t2oxcI50EeeyZasfnNSonw" name="supportableUpperNominalCentralFrequency" type="_KjQ3xBKOEeajhbtskMXJfw" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LI65wM4xEeehIvzuBRCtZQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LI8H4M4xEeehIvzuBRCtZQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uRKOEeajhbtskMXJfw" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3uhKOEeajhbtskMXJfw" annotatedElement="_KjQ3uRKOEeajhbtskMXJfw">
             <body>This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.</body>
           </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LuHRgM4xEeehIvzuBRCtZQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LuIfoM4xEeehIvzuBRCtZQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_7gkK0I50EeeyZasfnNSonw" name="supportableApplicationIdentifier" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7gkK0I50EeeyZasfnNSonw" name="supportableApplicationIdentifier" type="_KjQ3vRKOEeajhbtskMXJfw" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Mf6h4M4xEeehIvzuBRCtZQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mf8-IM4xEeehIvzuBRCtZQ" value="*"/>
+        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="OtsiAPoolPac">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_MpIOQI51EeeyZasfnNSonw" name="availableFrequencySlot" type="_ya6VcI6WEeeyZasfnNSonw" isReadOnly="true">
@@ -99,7 +112,7 @@ This attribute is required for the OCh Trial Termination Point Source at the tra
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_nBhMkI6cEeeyZasfnNSonw" name="OtsiGCtpPac">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jVAoEJROEee0N_ppE1lIiw" name="selectedFrequencySlot" type="_ya6VcI6WEeeyZasfnNSonw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jVAoEJROEee0N_ppE1lIiw" name="selectedFrequencySlot" type="_ya6VcI6WEeeyZasfnNSonw" isReadOnly="true">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ojmz4JROEee0N_ppE1lIiw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ojs6gJROEee0N_ppE1lIiw" value="*"/>
         </ownedAttribute>
@@ -284,7 +297,6 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenModel_Profile:Experimental xmi:id="_HKhtUBKmEeajhbtskMXJfw" base_Element="_KjQ3uxKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:Experimental xmi:id="_InurIBKmEeajhbtskMXJfw" base_Element="_KjQ3uRKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_ue4nIEUzEeaB8vMnkFQLXQ" base_Association="_KjQ3ohKOEeajhbtskMXJfw"/>
-  <OpenModel_Profile:ExtendedComposite xmi:id="_vn9IAEUzEeaB8vMnkFQLXQ" base_Association="_KjQ3phKOEeajhbtskMXJfw"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_st78AEU1EeaB8vMnkFQLXQ" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ouzcsdK-Eeau-fGWj88_Vg" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wucSQBM0Eee0L_IMWjydgQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
@@ -357,4 +369,5 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_x9YBYJJmEee26o4qs2D5Ig" base_Property="_x9XaUJJmEee26o4qs2D5Ig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_jXpsYJROEee0N_ppE1lIiw" base_Property="_jVAoEJROEee0N_ppE1lIiw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_jXrhkJROEee0N_ppE1lIiw" base_StructuralFeature="_jVAoEJROEee0N_ppE1lIiw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_HMXkoM4xEeehIvzuBRCtZQ" base_Association="_KjQ3phKOEeajhbtskMXJfw"/>
 </xmi:XMI>

--- a/UML/TapiOtsi.uml
+++ b/UML/TapiOtsi.uml
@@ -145,7 +145,7 @@ For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width i
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_JaphAC_3EeeAJ6VQzZ2ulw" name="PREFERRED_NO_CHANGE_WAVELENGTH_AS_RESTORE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KMjfEC_3EeeAJ6VQzZ2ulw" name="PREFERRED_NO_SKIPPING_WAVELENGTH"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_E7uYgI6HEeeyZasfnNSonw" name="ApplicationIdentifierType">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_E7uYgI6HEeeyZasfnNSonw" name="ApplicationIdentifierType" isLeaf="true">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_SDNzMI6HEeeyZasfnNSonw" name="PROPRIETARY"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_X6VXkI6HEeeyZasfnNSonw" name="ITUT_G959_1"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Pb4kkI6HEeeyZasfnNSonw" name="ITUT_G698_1"/>
@@ -153,7 +153,7 @@ For FLEX grid type, the adjusmentGranularity is 0.00625 THz and the slot width i
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eFl_8I6HEeeyZasfnNSonw" name="ITUT_G696_1"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_bmb14I6HEeeyZasfnNSonw" name="ITUT_G695"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_iHIbYI6KEeeyZasfnNSonw" name="GridType">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_iHIbYI6KEeeyZasfnNSonw" name="GridType" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_sHLtkI6WEeeyZasfnNSonw" annotatedElement="_iHIbYI6KEeeyZasfnNSonw">
           <body>The frequency grid standard that specify reference set of frequencies used to denote allowed nominal central frequencies that may be used for defining applications.</body>
         </ownedComment>
@@ -184,7 +184,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_htJmYI6QEeeyZasfnNSonw" name="AdjustmentGranularity">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_htJmYI6QEeeyZasfnNSonw" name="AdjustmentGranularity" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_p7t7kI6WEeeyZasfnNSonw" annotatedElement="_htJmYI6QEeeyZasfnNSonw">
           <body>Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)</body>
         </ownedComment>
@@ -214,7 +214,7 @@ Any combination of frequency slots is allowed as long as no two frequency slots 
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_ya6VcI6WEeeyZasfnNSonw" name="FrequencySlot">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_ya6VcI6WEeeyZasfnNSonw" name="FrequencySlot" isLeaf="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_5MmrsI6WEeeyZasfnNSonw" annotatedElement="_ya6VcI6WEeeyZasfnNSonw">
           <body>The frequency range allocated to a slot and unavailable to other slots within a flexible grid. A frequency slot is defined by its nominal central frequency. As per ITU-T G.694.1  the slot width is calculated as follows:&#xD;
 12.5 × &lt;slotWidthNumber> where slotWidthNumber is a positive integer and 12.5 is the slot width granularity in GHz</body>

--- a/UML/TapiPathComputation.notation
+++ b/UML/TapiPathComputation.notation
@@ -777,6 +777,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VPf75VroEeexvMtO2oNM9g" x="543" y="-170"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_mevKgM1kEeeFHsPqdArtwA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mevKgc1kEeeFHsPqdArtwA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mevKg81kEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mevKgs1kEeeFHsPqdArtwA" x="653" y="432"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_8OGbYTBGEeam35bpdXJzEw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_8OGbYjBGEeam35bpdXJzEw"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_8OGbYzBGEeam35bpdXJzEw">
@@ -1298,7 +1306,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JFjnMMhvEeaVlemTikmRHw" type="4001" source="_hxP6UMhuEeaVlemTikmRHw" target="__7kz7zBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_JFjnM8hvEeaVlemTikmRHw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_JFjnNMhvEeaVlemTikmRHw" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_JFjnNMhvEeaVlemTikmRHw" x="12" y="9"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_JFjnNchvEeaVlemTikmRHw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_JFjnNshvEeaVlemTikmRHw" x="10" y="-11"/>
@@ -1771,6 +1779,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VPf76VroEeexvMtO2oNM9g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VPf76lroEeexvMtO2oNM9g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VPf761roEeexvMtO2oNM9g"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mevKhM1kEeeFHsPqdArtwA" type="StereotypeCommentLink" source="__7bowDBGEeam35bpdXJzEw" target="_mevKgM1kEeeFHsPqdArtwA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mevKhc1kEeeFHsPqdArtwA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mevxk81kEeeFHsPqdArtwA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mevxkM1kEeeFHsPqdArtwA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mevxkc1kEeeFHsPqdArtwA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mevxks1kEeeFHsPqdArtwA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SwLpIEQ7EeaktYCiiVTurg" type="PapyrusUMLClassDiagram" name="PathConstraints" measurementUnit="Pixel">

--- a/UML/TapiPathComputation.uml
+++ b/UML/TapiPathComputation.uml
@@ -416,4 +416,5 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_1fJuVlqoEeexvMtO2oNM9g" base_Class="_hv0W8MhuEeaVlemTikmRHw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_LyAGsFroEeexvMtO2oNM9g" base_Association="_UdrWAMhvEeaVlemTikmRHw"/>
   <OpenModel_Profile:LifecycleAggregate xmi:id="_VPacUFroEeexvMtO2oNM9g" base_Association="_1EaBMC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_pDTZAM1kEeeFHsPqdArtwA" base_Association="_JEyyMMhvEeaVlemTikmRHw"/>
 </xmi:XMI>

--- a/YANG/tapi-common.tree
+++ b/YANG/tapi-common.tree
@@ -1,56 +1,54 @@
 module: tapi-common
     +--rw context!
        +--rw service-interface-point* [uuid]
-       |  +--ro layer-protocol-name*   layer-protocol-name
-       |  +--rw state
-       |  |  +--rw administrative-state?   administrative-state
-       |  |  +--ro operational-state?      operational-state
-       |  |  +--ro lifecycle-state?        lifecycle-state
-       |  +--rw capacity
-       |  |  +--ro total-potential-capacity
-       |  |  |  +--ro total-size
-       |  |  |  |  +--ro value?   uint64
-       |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  +--ro bandwidth-profile
-       |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |     +--ro committed-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro committed-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-information-rate
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro peak-burst-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro color-aware?                  boolean
-       |  |  |     +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |     +--ro total-size
+       |  +--ro layer-protocol-name*        layer-protocol-name
+       |  +--rw uuid                        uuid
+       |  +--rw name* [value-name]
+       |  |  +--rw value-name    string
+       |  |  +--rw value?        string
+       |  +--rw administrative-state?       administrative-state
+       |  +--ro operational-state?          operational-state
+       |  +--ro lifecycle-state?            lifecycle-state
+       |  +--ro total-potential-capacity
+       |  |  +--ro total-size
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    capacity-unit
+       |  |  +--ro bandwidth-profile
+       |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |     +--ro committed-information-rate
        |  |     |  +--ro value?   uint64
        |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro bandwidth-profile
-       |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |        +--ro committed-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro committed-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro color-aware?                  boolean
-       |  |        +--ro coupling-flag?                boolean
-       |  +--rw uuid                   uuid
-       |  +--rw name* [value-name]
-       |     +--rw value-name    string
-       |     +--rw value?        string
+       |  |     +--ro committed-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
+       |  +--ro available-capacity
+       |     +--ro total-size
+       |     |  +--ro value?   uint64
+       |     |  +--ro unit?    capacity-unit
+       |     +--ro bandwidth-profile
+       |        +--ro bw-profile-type?              bandwidth-profile-type
+       |        +--ro committed-information-rate
+       |        |  +--ro value?   uint64
+       |        |  +--ro unit?    capacity-unit
+       |        +--ro committed-burst-size
+       |        |  +--ro value?   uint64
+       |        |  +--ro unit?    capacity-unit
+       |        +--ro peak-information-rate
+       |        |  +--ro value?   uint64
+       |        |  +--ro unit?    capacity-unit
+       |        +--ro peak-burst-size
+       |        |  +--ro value?   uint64
+       |        |  +--ro unit?    capacity-unit
+       |        +--ro color-aware?                  boolean
+       |        +--ro coupling-flag?                boolean
        +--rw uuid?                      uuid
        +--rw name* [value-name]
           +--rw value-name    string
@@ -62,109 +60,105 @@ module: tapi-common
     |  |  +---w sip-id-or-name?   string
     |  +--ro output
     |     +--ro sip
-    |        +--ro layer-protocol-name*   layer-protocol-name
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro capacity
-    |        |  +--ro total-potential-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro available-capacity
-    |        |     +--ro total-size
+    |        +--ro layer-protocol-name*        layer-protocol-name
+    |        +--ro uuid?                       uuid
+    |        +--ro name* [value-name]
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro administrative-state?       administrative-state
+    |        +--ro operational-state?          operational-state
+    |        +--ro lifecycle-state?            lifecycle-state
+    |        +--ro total-potential-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
     |        |     |  +--ro value?   uint64
     |        |     |  +--ro unit?    capacity-unit
-    |        |     +--ro bandwidth-profile
-    |        |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |        +--ro committed-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro committed-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro color-aware?                  boolean
-    |        |        +--ro coupling-flag?                boolean
-    |        +--ro uuid?                  uuid
-    |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro available-capacity
+    |           +--ro total-size
+    |           |  +--ro value?   uint64
+    |           |  +--ro unit?    capacity-unit
+    |           +--ro bandwidth-profile
+    |              +--ro bw-profile-type?              bandwidth-profile-type
+    |              +--ro committed-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro committed-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro color-aware?                  boolean
+    |              +--ro coupling-flag?                boolean
     +---x get-service-interface-point-list
     |  +--ro output
     |     +--ro sip*
-    |        +--ro layer-protocol-name*   layer-protocol-name
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro capacity
-    |        |  +--ro total-potential-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro available-capacity
-    |        |     +--ro total-size
+    |        +--ro layer-protocol-name*        layer-protocol-name
+    |        +--ro uuid?                       uuid
+    |        +--ro name* [value-name]
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro administrative-state?       administrative-state
+    |        +--ro operational-state?          operational-state
+    |        +--ro lifecycle-state?            lifecycle-state
+    |        +--ro total-potential-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
     |        |     |  +--ro value?   uint64
     |        |     |  +--ro unit?    capacity-unit
-    |        |     +--ro bandwidth-profile
-    |        |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |        +--ro committed-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro committed-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro color-aware?                  boolean
-    |        |        +--ro coupling-flag?                boolean
-    |        +--ro uuid?                  uuid
-    |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro available-capacity
+    |           +--ro total-size
+    |           |  +--ro value?   uint64
+    |           |  +--ro unit?    capacity-unit
+    |           +--ro bandwidth-profile
+    |              +--ro bw-profile-type?              bandwidth-profile-type
+    |              +--ro committed-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro committed-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-information-rate
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro peak-burst-size
+    |              |  +--ro value?   uint64
+    |              |  +--ro unit?    capacity-unit
+    |              +--ro color-aware?                  boolean
+    |              +--ro coupling-flag?                boolean
     +---x update-service-interface-point
        +---w input
           +---w sip-id-or-name?   string

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -162,29 +162,6 @@ module tapi-common {
     /***********************
     * package type-definitions
     **********************/ 
-        identity layer-protocol-name {
-            description "none";
-        }
-        identity otsi-a {
-            base layer-protocol-name;
-            description "none";
-        }
-        identity otu {
-            base layer-protocol-name;
-            description "none";
-        }
-        identity odu {
-            base layer-protocol-name;
-            description "none";
-        }
-        identity eth {
-            base layer-protocol-name;
-            description "none";
-        }
-        identity ety {
-            base layer-protocol-name;
-            description "none";
-        }
         typedef administrative-state {
             type enumeration {
                 enum locked {
@@ -247,8 +224,22 @@ module tapi-common {
             description "The directionality of a Forwarding entity.";
         }
         typedef layer-protocol-name {
-            type identityref {
-                base layer-protocol-name;
+            type enumeration {
+                enum otsi-a {
+                    description "none";
+                }
+                enum otu {
+                    description "none";
+                }
+                enum odu {
+                    description "none";
+                }
+                enum eth {
+                    description "none";
+                }
+                enum ety {
+                    description "none";
+                }
             }
             description "Provides a controlled list of layer protocol names and indicates the naming authority.
                 Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -164,10 +164,10 @@ module tapi-common {
     **********************/ 
         typedef administrative-state {
             type enumeration {
-                enum locked {
+                enum LOCKED {
                     description "Users are administratively prohibited from making use of the resource.";
                 }
-                enum unlocked {
+                enum UNLOCKED {
                     description "Users are allowed to use the resource";
                 }
             }
@@ -191,19 +191,19 @@ module tapi-common {
         }
         typedef directive-value {
             type enumeration {
-                enum minimize {
+                enum MINIMIZE {
                     description "none";
                 }
-                enum maximize {
+                enum MAXIMIZE {
                     description "none";
                 }
-                enum allow {
+                enum ALLOW {
                     description "none";
                 }
-                enum disallow {
+                enum DISALLOW {
                     description "none";
                 }
-                enum dont-care {
+                enum DONT_CARE {
                     description "none";
                 }
             }
@@ -211,13 +211,13 @@ module tapi-common {
         }
         typedef forwarding-direction {
             type enumeration {
-                enum bidirectional {
+                enum BIDIRECTIONAL {
                     description "The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)";
                 }
-                enum unidirectional {
+                enum UNIDIRECTIONAL {
                     description "The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.";
                 }
-                enum undefined-or-unknown {
+                enum UNDEFINED_OR_UNKNOWN {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
@@ -225,19 +225,19 @@ module tapi-common {
         }
         typedef layer-protocol-name {
             type enumeration {
-                enum otsi-a {
+                enum OTSiA {
                     description "none";
                 }
-                enum otu {
+                enum OTU {
                     description "none";
                 }
-                enum odu {
+                enum ODU {
                     description "none";
                 }
-                enum eth {
+                enum ETH {
                     description "none";
                 }
-                enum ety {
+                enum ETY {
                     description "none";
                 }
             }
@@ -250,18 +250,18 @@ module tapi-common {
         }
         typedef lifecycle-state {
             type enumeration {
-                enum planned {
+                enum PLANNED {
                     description "The resource is planned but is not present in the network.";
                 }
-                enum potential {
+                enum POTENTIAL {
                     description "The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.
                         o    When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.
                         o    If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.";
                 }
-                enum installed {
+                enum INSTALLED {
                     description "The resource is present in the network and is capable of providing the service expected.";
                 }
-                enum pending-removal {
+                enum PENDING_REMOVAL {
                     description "The resource has been marked for removal";
                 }
             }
@@ -280,10 +280,10 @@ module tapi-common {
         }
         typedef operational-state {
             type enumeration {
-                enum disabled {
+                enum DISABLED {
                     description "The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.";
                 }
-                enum enabled {
+                enum ENABLED {
                     description "The resource is partially or fully operable and available for use";
                 }
             }
@@ -291,16 +291,16 @@ module tapi-common {
         }
         typedef port-direction {
             type enumeration {
-                enum bidirectional {
+                enum BIDIRECTIONAL {
                     description "The Port has both an INPUT flow and an OUTPUT flow defined.";
                 }
-                enum input {
+                enum INPUT {
                     description "The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).";
                 }
-                enum output {
+                enum OUTPUT {
                     description "The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).";
                 }
-                enum unidentified-or-unknown {
+                enum UNIDENTIFIED_OR_UNKNOWN {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
@@ -308,19 +308,19 @@ module tapi-common {
         }
         typedef port-role {
             type enumeration {
-                enum symmetric {
+                enum SYMMETRIC {
                     description "none";
                 }
-                enum root {
+                enum ROOT {
                     description "none";
                 }
-                enum leaf {
+                enum LEAF {
                     description "none";
                 }
-                enum trunk {
+                enum TRUNK {
                     description "none";
                 }
-                enum unknown {
+                enum UNKNOWN {
                     description "none";
                 }
             }
@@ -328,10 +328,10 @@ module tapi-common {
         }
         typedef termination-direction {
             type enumeration {
-                enum bidirectional {
+                enum BIDIRECTIONAL {
                     description "A Termination with both SINK and SOURCE flows.";
                 }
-                enum sink {
+                enum SINK {
                     description "The flow is up the layer stack from the server side to the client side. 
                         Considering an example of a Termination function within the termination entity, a SINK flow:
                         - will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component
@@ -340,7 +340,7 @@ module tapi-common {
                         A SINK termination is one that only supports a SINK flow.
                         A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity";
                 }
-                enum source {
+                enum SOURCE {
                     description "The flow is down the layer stack from the server side to the client side. 
                         Considering an example of a Termination function within the termination entity, a SOURCE flow:
                         - will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component
@@ -349,7 +349,7 @@ module tapi-common {
                         A SOURCE termination is one that only supports a SOURCE flow.
                         A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity";
                 }
-                enum undefined-or-unknown {
+                enum UNDEFINED_OR_UNKNOWN {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
             }
@@ -357,25 +357,25 @@ module tapi-common {
         }
         typedef termination-state {
             type enumeration {
-                enum lp-can-never-terminate {
+                enum LP_CAN_NEVER_TERMINATE {
                     description "A non-flexible case that can never be terminated.";
                 }
-                enum lt-not-terminated {
+                enum LT_NOT_TERMINATED {
                     description "A flexible termination that can terminate but is currently not terminated.";
                 }
-                enum terminated-server-to-client-flow {
+                enum TERMINATED_SERVER_TO_CLIENT_FLOW {
                     description "A flexible termination that is currently terminated for server to client flow only.";
                 }
-                enum terminated-client-to-server-flow {
+                enum TERMINATED_CLIENT_TO_SERVER_FLOW {
                     description "A flexible termination that is currently terminated for client to server flow only.";
                 }
-                enum terminated-bidirectional {
+                enum TERMINATED_BIDIRECTIONAL {
                     description "A flexible termination that is currently terminated in both directions of flow.";
                 }
-                enum lt-permenantly-terminated {
+                enum LT_PERMENANTLY_TERMINATED {
                     description "A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).";
                 }
-                enum termination-state-unknown {
+                enum TERMINATION_STATE_UNKNOWN {
                     description "There TerminationState cannot be determined.";
                 }
             }
@@ -444,13 +444,13 @@ module tapi-common {
         }
         typedef capacity-unit {
             type enumeration {
-                enum gbps {
+                enum GBPS {
                     description "Indicates that the integer CapacityValue is in Gigabit-per-second";
                 }
-                enum mbps {
+                enum MBPS {
                     description "Indicates that the integer CapacityValue is in Megabit-per-second";
                 }
-                enum kbps {
+                enum KBPS {
                     description "Indicates that the integer CapacityValue is in Kilobit-per-second";
                 }
             }
@@ -458,16 +458,16 @@ module tapi-common {
         }
         typedef bandwidth-profile-type {
             type enumeration {
-                enum mef-10.x {
+                enum MEF_10.x {
                     description "none";
                 }
-                enum rfc-2697 {
+                enum RFC_2697 {
                     description "none";
                 }
-                enum rfc-2698 {
+                enum RFC_2698 {
                     description "none";
                 }
-                enum rfc-4115 {
+                enum RFC_4115 {
                     description "none";
                 }
             }

--- a/YANG/tapi-common.yang
+++ b/YANG/tapi-common.yang
@@ -110,15 +110,9 @@ module tapi-common {
                 min-elements 1;
                 description "Usage of layerProtocolName [>1]  in the ServiceInterfacePoint should be considered experimental";
             }
-            container state {
-                uses admin-state-pac;
-                description "none";
-            }
-            container capacity {
-                uses capacity-pac;
-                description "none";
-            }
             uses resource-spec;
+            uses tapi-common:admin-state-pac;
+            uses tapi-common:capacity-pac;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -5,10 +5,6 @@ module: tapi-connectivity
     |  |  +--rw service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  +--rw layer-protocol-name?       tapi-common:layer-protocol-name
-    |  |  +--rw state
-    |  |  |  +--rw administrative-state?   administrative-state
-    |  |  |  +--ro operational-state?      operational-state
-    |  |  |  +--ro lifecycle-state?        lifecycle-state
     |  |  +--rw capacity
     |  |  |  +--ro total-potential-capacity
     |  |  |  |  +--ro total-size
@@ -55,97 +51,83 @@ module: tapi-connectivity
     |  |  +--rw protection-role?           protection-role
     |  |  +--rw local-id                   string
     |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |  +--rw conn-constraint
-    |  |  +--ro service-type?             service-type
-    |  |  +--ro service-level?            string
-    |  |  +--rw is-exclusive?             boolean
-    |  |  +--ro requested-capacity
-    |  |  |  +--ro total-size
-    |  |  |  |  +--ro value?   uint64
-    |  |  |  |  +--ro unit?    capacity-unit
-    |  |  |  +--ro bandwidth-profile
-    |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |  |  |     +--ro committed-information-rate
-    |  |  |     |  +--ro value?   uint64
-    |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |     +--ro committed-burst-size
-    |  |  |     |  +--ro value?   uint64
-    |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |     +--ro peak-information-rate
-    |  |  |     |  +--ro value?   uint64
-    |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |     +--ro peak-burst-size
-    |  |  |     |  +--ro value?   uint64
-    |  |  |     |  +--ro unit?    capacity-unit
-    |  |  |     +--ro color-aware?                  boolean
-    |  |  |     +--ro coupling-flag?                boolean
-    |  |  +--rw schedule
-    |  |  |  +--rw end-time?     date-and-time
-    |  |  |  +--rw start-time?   date-and-time
-    |  |  +--ro cost-characteristic* [cost-name]
-    |  |  |  +--ro cost-name         string
-    |  |  |  +--ro cost-value?       string
-    |  |  |  +--ro cost-algorithm?   string
-    |  |  +--ro latency-characteristic* [traffic-property-name]
-    |  |  |  +--ro traffic-property-name            string
-    |  |  |  +--ro fixed-latency-characteristic?    string
-    |  |  |  +--ro queing-latency-characteristic?   string
-    |  |  |  +--ro jitter-characteristic?           string
-    |  |  |  +--ro wander-characteristic?           string
-    |  |  +--rw route-compute-policy
-    |  |  |  +--rw route-objective-function?   route-objective-function
-    |  |  |  +--rw diversity-policy?           diversity-policy
-    |  |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  +--rw local-id?                 string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw topo-constraint
-    |  |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |  |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |  |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |  |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |  |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  +--rw local-id?                    string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw state
-    |  |  +--rw administrative-state?   administrative-state
-    |  |  +--ro operational-state?      operational-state
-    |  |  +--ro lifecycle-state?        lifecycle-state
-    |  +--rw direction?               tapi-common:forwarding-direction
-    |  +--rw layer-protocol-name?     tapi-common:layer-protocol-name
-    |  +--rw resilience-constraint* [local-id]
-    |  |  +--rw resilience-type
-    |  |  |  +--rw restoration-policy?   restoration-policy
-    |  |  |  +--rw protection-type?      protection-type
-    |  |  +--rw restoration-coordinate-type?          coordinate-type
-    |  |  +--rw restore-priority?                     uint64
-    |  |  +--rw reversion-mode?                       reversion-mode
-    |  |  +--rw wait-to-revert-time?                  uint64
-    |  |  +--rw hold-off-time?                        uint64
-    |  |  +--rw is-lock-out?                          boolean
-    |  |  +--rw is-frozen?                            boolean
-    |  |  +--rw is-coordinated-switching-both-ends?   boolean
-    |  |  +--rw max-switch-times?                     uint64
-    |  |  +--rw layer-protocol?                       tapi-common:layer-protocol-name
-    |  |  +--rw local-id                              string
-    |  |  +--rw name* [value-name]
-    |  |     +--rw value-name    string
-    |  |     +--rw value?        string
-    |  +--rw uuid                     uuid
+    |  |  |  +--rw value-name    string
+    |  |  |  +--rw value?        string
+    |  |  +--rw administrative-state?      administrative-state
+    |  |  +--ro operational-state?         operational-state
+    |  |  +--ro lifecycle-state?           lifecycle-state
+    |  +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |  +--rw direction?                            tapi-common:forwarding-direction
+    |  +--rw layer-protocol-name?                  tapi-common:layer-protocol-name
+    |  +--rw uuid                                  uuid
     |  +--rw name* [value-name]
-    |     +--rw value-name    string
-    |     +--rw value?        string
+    |  |  +--rw value-name    string
+    |  |  +--rw value?        string
+    |  +--ro service-type?                         service-type
+    |  +--ro service-level?                        string
+    |  +--rw is-exclusive?                         boolean
+    |  +--ro requested-capacity
+    |  |  +--ro total-size
+    |  |  |  +--ro value?   uint64
+    |  |  |  +--ro unit?    capacity-unit
+    |  |  +--ro bandwidth-profile
+    |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |  |     +--ro committed-information-rate
+    |  |     |  +--ro value?   uint64
+    |  |     |  +--ro unit?    capacity-unit
+    |  |     +--ro committed-burst-size
+    |  |     |  +--ro value?   uint64
+    |  |     |  +--ro unit?    capacity-unit
+    |  |     +--ro peak-information-rate
+    |  |     |  +--ro value?   uint64
+    |  |     |  +--ro unit?    capacity-unit
+    |  |     +--ro peak-burst-size
+    |  |     |  +--ro value?   uint64
+    |  |     |  +--ro unit?    capacity-unit
+    |  |     +--ro color-aware?                  boolean
+    |  |     +--ro coupling-flag?                boolean
+    |  +--rw schedule
+    |  |  +--rw end-time?     date-and-time
+    |  |  +--rw start-time?   date-and-time
+    |  +--ro cost-characteristic* [cost-name]
+    |  |  +--ro cost-name         string
+    |  |  +--ro cost-value?       string
+    |  |  +--ro cost-algorithm?   string
+    |  +--ro latency-characteristic* [traffic-property-name]
+    |  |  +--ro traffic-property-name            string
+    |  |  +--ro fixed-latency-characteristic?    string
+    |  |  +--ro queing-latency-characteristic?   string
+    |  |  +--ro jitter-characteristic?           string
+    |  |  +--ro wander-characteristic?           string
+    |  +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  +--rw route-objective-function?             route-objective-function
+    |  +--rw diversity-policy?                     diversity-policy
+    |  +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+    |  +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+    |  +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |  +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |  +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |  +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+    |  +--rw administrative-state?                 administrative-state
+    |  +--ro operational-state?                    operational-state
+    |  +--ro lifecycle-state?                      lifecycle-state
+    |  +--rw resilience-type
+    |  |  +--rw restoration-policy?   restoration-policy
+    |  |  +--rw protection-type?      protection-type
+    |  +--rw restoration-coordinate-type?          coordinate-type
+    |  +--rw restore-priority?                     uint64
+    |  +--rw reversion-mode?                       reversion-mode
+    |  +--rw wait-to-revert-time?                  uint64
+    |  +--rw hold-off-time?                        uint64
+    |  +--rw is-lock-out?                          boolean
+    |  +--rw is-frozen?                            boolean
+    |  +--rw is-coordinated-switching-both-ends?   boolean
+    |  +--rw max-switch-times?                     uint64
+    |  +--rw layer-protocol?                       tapi-common:layer-protocol-name
     +--ro connection* [uuid]
        +--ro connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        +--ro lower-connection*       -> /tapi-common:context/tapi-connectivity:connection/uuid
@@ -158,7 +140,7 @@ module: tapi-connectivity
        |     +--ro value-name    string
        |     +--ro value?        string
        +--ro switch-control* [local-id]
-       |  +--ro sub-switch-control*   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
+       |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
        |  +--ro switch* [local-id]
        |  |  +--ro selected-connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        |  |  +--ro selected-route*                  -> /tapi-common:context/tapi-connectivity:connection/route/local-id
@@ -169,37 +151,31 @@ module: tapi-connectivity
        |  |  +--ro name* [value-name]
        |  |     +--ro value-name    string
        |  |     +--ro value?        string
-       |  +--ro control-parameters
-       |  |  +--ro resilience-type
-       |  |  |  +--ro restoration-policy?   restoration-policy
-       |  |  |  +--ro protection-type?      protection-type
-       |  |  +--ro restoration-coordinate-type?          coordinate-type
-       |  |  +--ro restore-priority?                     uint64
-       |  |  +--ro reversion-mode?                       reversion-mode
-       |  |  +--ro wait-to-revert-time?                  uint64
-       |  |  +--ro hold-off-time?                        uint64
-       |  |  +--ro is-lock-out?                          boolean
-       |  |  +--ro is-frozen?                            boolean
-       |  |  +--ro is-coordinated-switching-both-ends?   boolean
-       |  |  +--ro max-switch-times?                     uint64
-       |  |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-       |  |  +--ro local-id?                             string
-       |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro local-id              string
+       |  +--ro local-id                              string
        |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro state
-       |  +--ro operational-state?   operational-state
-       |  +--ro lifecycle-state?     lifecycle-state
+       |  |  +--ro value-name    string
+       |  |  +--ro value?        string
+       |  +--ro resilience-type
+       |  |  +--ro restoration-policy?   restoration-policy
+       |  |  +--ro protection-type?      protection-type
+       |  +--ro restoration-coordinate-type?          coordinate-type
+       |  +--ro restore-priority?                     uint64
+       |  +--ro reversion-mode?                       reversion-mode
+       |  +--ro wait-to-revert-time?                  uint64
+       |  +--ro hold-off-time?                        uint64
+       |  +--ro is-lock-out?                          boolean
+       |  +--ro is-frozen?                            boolean
+       |  +--ro is-coordinated-switching-both-ends?   boolean
+       |  +--ro max-switch-times?                     uint64
+       |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
        +--ro direction?              tapi-common:forwarding-direction
        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
        +--ro uuid                    uuid
        +--ro name* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+       |  +--ro value-name    string
+       |  +--ro value?        string
+       +--ro operational-state?      operational-state
+       +--ro lifecycle-state?        lifecycle-state
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
     +--ro connection-end-point* [uuid]
        +--ro layer-protocol-name?         tapi-common:layer-protocol-name
@@ -207,18 +183,16 @@ module: tapi-connectivity
        +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        +--ro associated-route*            -> /tapi-common:context/tapi-connectivity:connection/route/local-id
-       +--ro state
-       |  +--ro operational-state?   operational-state
-       |  +--ro lifecycle-state?     lifecycle-state
-       +--ro termination
-       |  +--ro termination-direction?   termination-direction
-       |  +--ro termination-state?       termination-state
        +--ro connection-port-direction?   tapi-common:port-direction
        +--ro connection-port-role?        tapi-common:port-role
        +--ro uuid                         uuid
        +--ro name* [value-name]
-          +--ro value-name    string
-          +--ro value?        string
+       |  +--ro value-name    string
+       |  +--ro value?        string
+       +--ro operational-state?           operational-state
+       +--ro lifecycle-state?             lifecycle-state
+       +--ro termination-direction?       termination-direction
+       +--ro termination-state?           termination-state
 
   rpcs:
     +---x get-connection-details
@@ -238,7 +212,7 @@ module: tapi-connectivity
     |        |     +--ro value-name    string
     |        |     +--ro value?        string
     |        +--ro switch-control* [local-id]
-    |        |  +--ro sub-switch-control*   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
+    |        |  +--ro sub-switch-control*                   -> /tapi-common:context/tapi-connectivity:connection/switch-control/local-id
     |        |  +--ro switch* [local-id]
     |        |  |  +--ro selected-connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  |  +--ro selected-route*                  -> /tapi-common:context/tapi-connectivity:connection/route/local-id
@@ -249,37 +223,31 @@ module: tapi-connectivity
     |        |  |  +--ro name* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
-    |        |  +--ro control-parameters
-    |        |  |  +--ro resilience-type
-    |        |  |  |  +--ro restoration-policy?   restoration-policy
-    |        |  |  |  +--ro protection-type?      protection-type
-    |        |  |  +--ro restoration-coordinate-type?          coordinate-type
-    |        |  |  +--ro restore-priority?                     uint64
-    |        |  |  +--ro reversion-mode?                       reversion-mode
-    |        |  |  +--ro wait-to-revert-time?                  uint64
-    |        |  |  +--ro hold-off-time?                        uint64
-    |        |  |  +--ro is-lock-out?                          boolean
-    |        |  |  +--ro is-frozen?                            boolean
-    |        |  |  +--ro is-coordinated-switching-both-ends?   boolean
-    |        |  |  +--ro max-switch-times?                     uint64
-    |        |  |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-    |        |  |  +--ro local-id?                             string
-    |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro local-id              string
+    |        |  +--ro local-id                              string
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro operational-state?   operational-state
-    |        |  +--ro lifecycle-state?     lifecycle-state
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro resilience-type
+    |        |  |  +--ro restoration-policy?   restoration-policy
+    |        |  |  +--ro protection-type?      protection-type
+    |        |  +--ro restoration-coordinate-type?          coordinate-type
+    |        |  +--ro restore-priority?                     uint64
+    |        |  +--ro reversion-mode?                       reversion-mode
+    |        |  +--ro wait-to-revert-time?                  uint64
+    |        |  +--ro hold-off-time?                        uint64
+    |        |  +--ro is-lock-out?                          boolean
+    |        |  +--ro is-frozen?                            boolean
+    |        |  +--ro is-coordinated-switching-both-ends?   boolean
+    |        |  +--ro max-switch-times?                     uint64
+    |        |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
     |        +--ro direction?              tapi-common:forwarding-direction
     |        +--ro layer-protocol-name?    tapi-common:layer-protocol-name
     |        +--ro uuid?                   uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro operational-state?      operational-state
+    |        +--ro lifecycle-state?        lifecycle-state
     +---x get-connectivity-service-list
     |  +--ro output
     |     +--ro service*
@@ -287,10 +255,6 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -337,97 +301,83 @@ module: tapi-connectivity
     |        |  +--ro protection-role?           protection-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?             service-type
-    |        |  +--ro service-level?            string
-    |        |  +--ro is-exclusive?             boolean
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro schedule
-    |        |  |  +--ro end-time?     date-and-time
-    |        |  |  +--ro start-time?   date-and-time
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value?       string
-    |        |  |  +--ro cost-algorithm?   string
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  +--ro traffic-property-name            string
-    |        |  |  +--ro fixed-latency-characteristic?    string
-    |        |  |  +--ro queing-latency-characteristic?   string
-    |        |  |  +--ro jitter-characteristic?           string
-    |        |  |  +--ro wander-characteristic?           string
-    |        |  +--ro route-compute-policy
-    |        |  |  +--ro route-objective-function?   route-objective-function
-    |        |  |  +--ro diversity-policy?           diversity-policy
-    |        |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro topo-constraint
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?               tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        +--ro resilience-constraint* [local-id]
-    |        |  +--ro resilience-type
-    |        |  |  +--ro restoration-policy?   restoration-policy
-    |        |  |  +--ro protection-type?      protection-type
-    |        |  +--ro restoration-coordinate-type?          coordinate-type
-    |        |  +--ro restore-priority?                     uint64
-    |        |  +--ro reversion-mode?                       reversion-mode
-    |        |  +--ro wait-to-revert-time?                  uint64
-    |        |  +--ro hold-off-time?                        uint64
-    |        |  +--ro is-lock-out?                          boolean
-    |        |  +--ro is-frozen?                            boolean
-    |        |  +--ro is-coordinated-switching-both-ends?   boolean
-    |        |  +--ro max-switch-times?                     uint64
-    |        |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-    |        |  +--ro local-id                              string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                    uuid
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?      administrative-state
+    |        |  +--ro operational-state?         operational-state
+    |        |  +--ro lifecycle-state?           lifecycle-state
+    |        +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        +--ro direction?                            tapi-common:forwarding-direction
+    |        +--ro layer-protocol-name?                  tapi-common:layer-protocol-name
+    |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro service-type?                         service-type
+    |        +--ro service-level?                        string
+    |        +--ro is-exclusive?                         boolean
+    |        +--ro requested-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |        |  +--ro traffic-property-name            string
+    |        |  +--ro fixed-latency-characteristic?    string
+    |        |  +--ro queing-latency-characteristic?   string
+    |        |  +--ro jitter-characteristic?           string
+    |        |  +--ro wander-characteristic?           string
+    |        +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro route-objective-function?             route-objective-function
+    |        +--ro diversity-policy?                     diversity-policy
+    |        +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+    |        +--ro administrative-state?                 administrative-state
+    |        +--ro operational-state?                    operational-state
+    |        +--ro lifecycle-state?                      lifecycle-state
+    |        +--ro resilience-type
+    |        |  +--ro restoration-policy?   restoration-policy
+    |        |  +--ro protection-type?      protection-type
+    |        +--ro restoration-coordinate-type?          coordinate-type
+    |        +--ro restore-priority?                     uint64
+    |        +--ro reversion-mode?                       reversion-mode
+    |        +--ro wait-to-revert-time?                  uint64
+    |        +--ro hold-off-time?                        uint64
+    |        +--ro is-lock-out?                          boolean
+    |        +--ro is-frozen?                            boolean
+    |        +--ro is-coordinated-switching-both-ends?   boolean
+    |        +--ro max-switch-times?                     uint64
+    |        +--ro layer-protocol?                       tapi-common:layer-protocol-name
     +---x get-connectivity-service-details
     |  +---w input
     |  |  +---w service-id-or-name?   string
@@ -437,10 +387,6 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -487,107 +433,89 @@ module: tapi-connectivity
     |        |  +--ro protection-role?           protection-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?             service-type
-    |        |  +--ro service-level?            string
-    |        |  +--ro is-exclusive?             boolean
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro schedule
-    |        |  |  +--ro end-time?     date-and-time
-    |        |  |  +--ro start-time?   date-and-time
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value?       string
-    |        |  |  +--ro cost-algorithm?   string
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  +--ro traffic-property-name            string
-    |        |  |  +--ro fixed-latency-characteristic?    string
-    |        |  |  +--ro queing-latency-characteristic?   string
-    |        |  |  +--ro jitter-characteristic?           string
-    |        |  |  +--ro wander-characteristic?           string
-    |        |  +--ro route-compute-policy
-    |        |  |  +--ro route-objective-function?   route-objective-function
-    |        |  |  +--ro diversity-policy?           diversity-policy
-    |        |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro topo-constraint
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?               tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        +--ro resilience-constraint* [local-id]
-    |        |  +--ro resilience-type
-    |        |  |  +--ro restoration-policy?   restoration-policy
-    |        |  |  +--ro protection-type?      protection-type
-    |        |  +--ro restoration-coordinate-type?          coordinate-type
-    |        |  +--ro restore-priority?                     uint64
-    |        |  +--ro reversion-mode?                       reversion-mode
-    |        |  +--ro wait-to-revert-time?                  uint64
-    |        |  +--ro hold-off-time?                        uint64
-    |        |  +--ro is-lock-out?                          boolean
-    |        |  +--ro is-frozen?                            boolean
-    |        |  +--ro is-coordinated-switching-both-ends?   boolean
-    |        |  +--ro max-switch-times?                     uint64
-    |        |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-    |        |  +--ro local-id                              string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                    uuid
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?      administrative-state
+    |        |  +--ro operational-state?         operational-state
+    |        |  +--ro lifecycle-state?           lifecycle-state
+    |        +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        +--ro direction?                            tapi-common:forwarding-direction
+    |        +--ro layer-protocol-name?                  tapi-common:layer-protocol-name
+    |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro service-type?                         service-type
+    |        +--ro service-level?                        string
+    |        +--ro is-exclusive?                         boolean
+    |        +--ro requested-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |        |  +--ro traffic-property-name            string
+    |        |  +--ro fixed-latency-characteristic?    string
+    |        |  +--ro queing-latency-characteristic?   string
+    |        |  +--ro jitter-characteristic?           string
+    |        |  +--ro wander-characteristic?           string
+    |        +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro route-objective-function?             route-objective-function
+    |        +--ro diversity-policy?                     diversity-policy
+    |        +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+    |        +--ro administrative-state?                 administrative-state
+    |        +--ro operational-state?                    operational-state
+    |        +--ro lifecycle-state?                      lifecycle-state
+    |        +--ro resilience-type
+    |        |  +--ro restoration-policy?   restoration-policy
+    |        |  +--ro protection-type?      protection-type
+    |        +--ro restoration-coordinate-type?          coordinate-type
+    |        +--ro restore-priority?                     uint64
+    |        +--ro reversion-mode?                       reversion-mode
+    |        +--ro wait-to-revert-time?                  uint64
+    |        +--ro hold-off-time?                        uint64
+    |        +--ro is-lock-out?                          boolean
+    |        +--ro is-frozen?                            boolean
+    |        +--ro is-coordinated-switching-both-ends?   boolean
+    |        +--ro max-switch-times?                     uint64
+    |        +--ro layer-protocol?                       tapi-common:layer-protocol-name
     +---x create-connectivity-service
     |  +---w input
     |  |  +---w end-point*
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
-    |  |  |  +---w state
-    |  |  |  |  +---w administrative-state?   administrative-state
-    |  |  |  |  +---w operational-state?      operational-state
-    |  |  |  |  +---w lifecycle-state?        lifecycle-state
     |  |  |  +---w capacity
     |  |  |  |  +---w total-potential-capacity
     |  |  |  |  |  +---w total-size
@@ -634,12 +562,15 @@ module: tapi-connectivity
     |  |  |  +---w protection-role?           protection-role
     |  |  |  +---w local-id?                  string
     |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
+    |  |  |  |  +---w value-name    string
+    |  |  |  |  +---w value?        string
+    |  |  |  +---w administrative-state?      administrative-state
+    |  |  |  +---w operational-state?         operational-state
+    |  |  |  +---w lifecycle-state?           lifecycle-state
     |  |  +---w conn-constraint
-    |  |  |  +---w service-type?             service-type
-    |  |  |  +---w service-level?            string
-    |  |  |  +---w is-exclusive?             boolean
+    |  |  |  +---w service-type?               service-type
+    |  |  |  +---w service-level?              string
+    |  |  |  +---w is-exclusive?               boolean
     |  |  |  +---w requested-capacity
     |  |  |  |  +---w total-size
     |  |  |  |  |  +---w value?   uint64
@@ -673,15 +604,10 @@ module: tapi-connectivity
     |  |  |  |  +---w queing-latency-characteristic?   string
     |  |  |  |  +---w jitter-characteristic?           string
     |  |  |  |  +---w wander-characteristic?           string
-    |  |  |  +---w route-compute-policy
-    |  |  |  |  +---w route-objective-function?   route-objective-function
-    |  |  |  |  +---w diversity-policy?           diversity-policy
-    |  |  |  +---w coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w local-id?                 string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
+    |  |  |  +---w coroute-inclusion?          -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  +---w diversity-exclusion*        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  +---w route-objective-function?   route-objective-function
+    |  |  |  +---w diversity-policy?           diversity-policy
     |  |  +---w topo-constraint
     |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
     |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
@@ -692,10 +618,6 @@ module: tapi-connectivity
     |  |  |  +---w include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?                    string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
     |  |  +---w resilience-constraint*
     |  |  |  +---w resilience-type
     |  |  |  |  +---w restoration-policy?   restoration-policy
@@ -710,10 +632,6 @@ module: tapi-connectivity
     |  |  |  +---w is-coordinated-switching-both-ends?   boolean
     |  |  |  +---w max-switch-times?                     uint64
     |  |  |  +---w layer-protocol?                       tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?                             string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
     |  |  +---w state?                   string
     |  +--ro output
     |     +--ro service
@@ -721,10 +639,6 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -771,97 +685,83 @@ module: tapi-connectivity
     |        |  +--ro protection-role?           protection-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?             service-type
-    |        |  +--ro service-level?            string
-    |        |  +--ro is-exclusive?             boolean
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro schedule
-    |        |  |  +--ro end-time?     date-and-time
-    |        |  |  +--ro start-time?   date-and-time
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value?       string
-    |        |  |  +--ro cost-algorithm?   string
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  +--ro traffic-property-name            string
-    |        |  |  +--ro fixed-latency-characteristic?    string
-    |        |  |  +--ro queing-latency-characteristic?   string
-    |        |  |  +--ro jitter-characteristic?           string
-    |        |  |  +--ro wander-characteristic?           string
-    |        |  +--ro route-compute-policy
-    |        |  |  +--ro route-objective-function?   route-objective-function
-    |        |  |  +--ro diversity-policy?           diversity-policy
-    |        |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro topo-constraint
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?               tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        +--ro resilience-constraint* [local-id]
-    |        |  +--ro resilience-type
-    |        |  |  +--ro restoration-policy?   restoration-policy
-    |        |  |  +--ro protection-type?      protection-type
-    |        |  +--ro restoration-coordinate-type?          coordinate-type
-    |        |  +--ro restore-priority?                     uint64
-    |        |  +--ro reversion-mode?                       reversion-mode
-    |        |  +--ro wait-to-revert-time?                  uint64
-    |        |  +--ro hold-off-time?                        uint64
-    |        |  +--ro is-lock-out?                          boolean
-    |        |  +--ro is-frozen?                            boolean
-    |        |  +--ro is-coordinated-switching-both-ends?   boolean
-    |        |  +--ro max-switch-times?                     uint64
-    |        |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-    |        |  +--ro local-id                              string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                    uuid
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?      administrative-state
+    |        |  +--ro operational-state?         operational-state
+    |        |  +--ro lifecycle-state?           lifecycle-state
+    |        +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        +--ro direction?                            tapi-common:forwarding-direction
+    |        +--ro layer-protocol-name?                  tapi-common:layer-protocol-name
+    |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro service-type?                         service-type
+    |        +--ro service-level?                        string
+    |        +--ro is-exclusive?                         boolean
+    |        +--ro requested-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |        |  +--ro traffic-property-name            string
+    |        |  +--ro fixed-latency-characteristic?    string
+    |        |  +--ro queing-latency-characteristic?   string
+    |        |  +--ro jitter-characteristic?           string
+    |        |  +--ro wander-characteristic?           string
+    |        +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro route-objective-function?             route-objective-function
+    |        +--ro diversity-policy?                     diversity-policy
+    |        +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+    |        +--ro administrative-state?                 administrative-state
+    |        +--ro operational-state?                    operational-state
+    |        +--ro lifecycle-state?                      lifecycle-state
+    |        +--ro resilience-type
+    |        |  +--ro restoration-policy?   restoration-policy
+    |        |  +--ro protection-type?      protection-type
+    |        +--ro restoration-coordinate-type?          coordinate-type
+    |        +--ro restore-priority?                     uint64
+    |        +--ro reversion-mode?                       reversion-mode
+    |        +--ro wait-to-revert-time?                  uint64
+    |        +--ro hold-off-time?                        uint64
+    |        +--ro is-lock-out?                          boolean
+    |        +--ro is-frozen?                            boolean
+    |        +--ro is-coordinated-switching-both-ends?   boolean
+    |        +--ro max-switch-times?                     uint64
+    |        +--ro layer-protocol?                       tapi-common:layer-protocol-name
     +---x update-connectivity-service
     |  +---w input
     |  |  +---w service-id-or-name?      string
@@ -869,10 +769,6 @@ module: tapi-connectivity
     |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
-    |  |  |  +---w state
-    |  |  |  |  +---w administrative-state?   administrative-state
-    |  |  |  |  +---w operational-state?      operational-state
-    |  |  |  |  +---w lifecycle-state?        lifecycle-state
     |  |  |  +---w capacity
     |  |  |  |  +---w total-potential-capacity
     |  |  |  |  |  +---w total-size
@@ -919,12 +815,15 @@ module: tapi-connectivity
     |  |  |  +---w protection-role?           protection-role
     |  |  |  +---w local-id?                  string
     |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
+    |  |  |  |  +---w value-name    string
+    |  |  |  |  +---w value?        string
+    |  |  |  +---w administrative-state?      administrative-state
+    |  |  |  +---w operational-state?         operational-state
+    |  |  |  +---w lifecycle-state?           lifecycle-state
     |  |  +---w conn-constraint
-    |  |  |  +---w service-type?             service-type
-    |  |  |  +---w service-level?            string
-    |  |  |  +---w is-exclusive?             boolean
+    |  |  |  +---w service-type?               service-type
+    |  |  |  +---w service-level?              string
+    |  |  |  +---w is-exclusive?               boolean
     |  |  |  +---w requested-capacity
     |  |  |  |  +---w total-size
     |  |  |  |  |  +---w value?   uint64
@@ -958,15 +857,10 @@ module: tapi-connectivity
     |  |  |  |  +---w queing-latency-characteristic?   string
     |  |  |  |  +---w jitter-characteristic?           string
     |  |  |  |  +---w wander-characteristic?           string
-    |  |  |  +---w route-compute-policy
-    |  |  |  |  +---w route-objective-function?   route-objective-function
-    |  |  |  |  +---w diversity-policy?           diversity-policy
-    |  |  |  +---w coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |  |  |  +---w local-id?                 string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
+    |  |  |  +---w coroute-inclusion?          -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  +---w diversity-exclusion*        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |  |  |  +---w route-objective-function?   route-objective-function
+    |  |  |  +---w diversity-policy?           diversity-policy
     |  |  +---w topo-constraint
     |  |  |  +---w include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
     |  |  |  +---w avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
@@ -977,10 +871,6 @@ module: tapi-connectivity
     |  |  |  +---w include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
     |  |  |  +---w preferred-transport-layer*   tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?                    string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
     |  |  +---w resilience-constraint*
     |  |  |  +---w resilience-type
     |  |  |  |  +---w restoration-policy?   restoration-policy
@@ -995,10 +885,6 @@ module: tapi-connectivity
     |  |  |  +---w is-coordinated-switching-both-ends?   boolean
     |  |  |  +---w max-switch-times?                     uint64
     |  |  |  +---w layer-protocol?                       tapi-common:layer-protocol-name
-    |  |  |  +---w local-id?                             string
-    |  |  |  +---w name* [value-name]
-    |  |  |     +---w value-name    string
-    |  |  |     +---w value?        string
     |  |  +---w state?                   string
     |  +--ro output
     |     +--ro service
@@ -1006,10 +892,6 @@ module: tapi-connectivity
     |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -1056,97 +938,83 @@ module: tapi-connectivity
     |        |  +--ro protection-role?           protection-role
     |        |  +--ro local-id                   string
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro conn-constraint
-    |        |  +--ro service-type?             service-type
-    |        |  +--ro service-level?            string
-    |        |  +--ro is-exclusive?             boolean
-    |        |  +--ro requested-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro schedule
-    |        |  |  +--ro end-time?     date-and-time
-    |        |  |  +--ro start-time?   date-and-time
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |  |  +--ro cost-name         string
-    |        |  |  +--ro cost-value?       string
-    |        |  |  +--ro cost-algorithm?   string
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  +--ro traffic-property-name            string
-    |        |  |  +--ro fixed-latency-characteristic?    string
-    |        |  |  +--ro queing-latency-characteristic?   string
-    |        |  |  +--ro jitter-characteristic?           string
-    |        |  |  +--ro wander-characteristic?           string
-    |        |  +--ro route-compute-policy
-    |        |  |  +--ro route-objective-function?   route-objective-function
-    |        |  |  +--ro diversity-policy?           diversity-policy
-    |        |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-    |        |  +--ro local-id?                 string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro topo-constraint
-    |        |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-    |        |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-    |        |  +--ro local-id?                    string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro direction?               tapi-common:forwarding-direction
-    |        +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-    |        +--ro resilience-constraint* [local-id]
-    |        |  +--ro resilience-type
-    |        |  |  +--ro restoration-policy?   restoration-policy
-    |        |  |  +--ro protection-type?      protection-type
-    |        |  +--ro restoration-coordinate-type?          coordinate-type
-    |        |  +--ro restore-priority?                     uint64
-    |        |  +--ro reversion-mode?                       reversion-mode
-    |        |  +--ro wait-to-revert-time?                  uint64
-    |        |  +--ro hold-off-time?                        uint64
-    |        |  +--ro is-lock-out?                          boolean
-    |        |  +--ro is-frozen?                            boolean
-    |        |  +--ro is-coordinated-switching-both-ends?   boolean
-    |        |  +--ro max-switch-times?                     uint64
-    |        |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-    |        |  +--ro local-id                              string
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro uuid?                    uuid
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?      administrative-state
+    |        |  +--ro operational-state?         operational-state
+    |        |  +--ro lifecycle-state?           lifecycle-state
+    |        +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+    |        +--ro direction?                            tapi-common:forwarding-direction
+    |        +--ro layer-protocol-name?                  tapi-common:layer-protocol-name
+    |        +--ro uuid?                                 uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro service-type?                         service-type
+    |        +--ro service-level?                        string
+    |        +--ro is-exclusive?                         boolean
+    |        +--ro requested-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro schedule
+    |        |  +--ro end-time?     date-and-time
+    |        |  +--ro start-time?   date-and-time
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |        |  +--ro traffic-property-name            string
+    |        |  +--ro fixed-latency-characteristic?    string
+    |        |  +--ro queing-latency-characteristic?   string
+    |        |  +--ro jitter-characteristic?           string
+    |        |  +--ro wander-characteristic?           string
+    |        +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+    |        +--ro route-objective-function?             route-objective-function
+    |        +--ro diversity-policy?                     diversity-policy
+    |        +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+    |        +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+    |        +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+    |        +--ro administrative-state?                 administrative-state
+    |        +--ro operational-state?                    operational-state
+    |        +--ro lifecycle-state?                      lifecycle-state
+    |        +--ro resilience-type
+    |        |  +--ro restoration-policy?   restoration-policy
+    |        |  +--ro protection-type?      protection-type
+    |        +--ro restoration-coordinate-type?          coordinate-type
+    |        +--ro restore-priority?                     uint64
+    |        +--ro reversion-mode?                       reversion-mode
+    |        +--ro wait-to-revert-time?                  uint64
+    |        +--ro hold-off-time?                        uint64
+    |        +--ro is-lock-out?                          boolean
+    |        +--ro is-frozen?                            boolean
+    |        +--ro is-coordinated-switching-both-ends?   boolean
+    |        +--ro max-switch-times?                     uint64
+    |        +--ro layer-protocol?                       tapi-common:layer-protocol-name
     +---x delete-connectivity-service
        +---w input
        |  +---w service-id-or-name?   string
@@ -1156,10 +1024,6 @@ module: tapi-connectivity
              |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
              |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
              |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
-             |  +--ro state
-             |  |  +--ro administrative-state?   administrative-state
-             |  |  +--ro operational-state?      operational-state
-             |  |  +--ro lifecycle-state?        lifecycle-state
              |  +--ro capacity
              |  |  +--ro total-potential-capacity
              |  |  |  +--ro total-size
@@ -1206,94 +1070,80 @@ module: tapi-connectivity
              |  +--ro protection-role?           protection-role
              |  +--ro local-id                   string
              |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro connection*              -> /tapi-common:context/tapi-connectivity:connection/uuid
-             +--ro conn-constraint
-             |  +--ro service-type?             service-type
-             |  +--ro service-level?            string
-             |  +--ro is-exclusive?             boolean
-             |  +--ro requested-capacity
-             |  |  +--ro total-size
-             |  |  |  +--ro value?   uint64
-             |  |  |  +--ro unit?    capacity-unit
-             |  |  +--ro bandwidth-profile
-             |  |     +--ro bw-profile-type?              bandwidth-profile-type
-             |  |     +--ro committed-information-rate
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro committed-burst-size
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro peak-information-rate
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro peak-burst-size
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro color-aware?                  boolean
-             |  |     +--ro coupling-flag?                boolean
-             |  +--ro schedule
-             |  |  +--ro end-time?     date-and-time
-             |  |  +--ro start-time?   date-and-time
-             |  +--ro cost-characteristic* [cost-name]
-             |  |  +--ro cost-name         string
-             |  |  +--ro cost-value?       string
-             |  |  +--ro cost-algorithm?   string
-             |  +--ro latency-characteristic* [traffic-property-name]
-             |  |  +--ro traffic-property-name            string
-             |  |  +--ro fixed-latency-characteristic?    string
-             |  |  +--ro queing-latency-characteristic?   string
-             |  |  +--ro jitter-characteristic?           string
-             |  |  +--ro wander-characteristic?           string
-             |  +--ro route-compute-policy
-             |  |  +--ro route-objective-function?   route-objective-function
-             |  |  +--ro diversity-policy?           diversity-policy
-             |  +--ro coroute-inclusion?        -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-             |  +--ro diversity-exclusion*      -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
-             |  +--ro local-id?                 string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro topo-constraint
-             |  +--ro include-topology*            -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro avoid-topology*              -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro include-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-             |  +--ro exclude-path*                -> /tapi-common:context/tapi-path-computation:path/uuid
-             |  +--ro include-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-             |  +--ro exclude-link*                -> /tapi-common:context/tapi-topology:topology/link/uuid
-             |  +--ro include-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  +--ro exclude-node*                -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  +--ro preferred-transport-layer*   tapi-common:layer-protocol-name
-             |  +--ro local-id?                    string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro state
-             |  +--ro administrative-state?   administrative-state
-             |  +--ro operational-state?      operational-state
-             |  +--ro lifecycle-state?        lifecycle-state
-             +--ro direction?               tapi-common:forwarding-direction
-             +--ro layer-protocol-name?     tapi-common:layer-protocol-name
-             +--ro resilience-constraint* [local-id]
-             |  +--ro resilience-type
-             |  |  +--ro restoration-policy?   restoration-policy
-             |  |  +--ro protection-type?      protection-type
-             |  +--ro restoration-coordinate-type?          coordinate-type
-             |  +--ro restore-priority?                     uint64
-             |  +--ro reversion-mode?                       reversion-mode
-             |  +--ro wait-to-revert-time?                  uint64
-             |  +--ro hold-off-time?                        uint64
-             |  +--ro is-lock-out?                          boolean
-             |  +--ro is-frozen?                            boolean
-             |  +--ro is-coordinated-switching-both-ends?   boolean
-             |  +--ro max-switch-times?                     uint64
-             |  +--ro layer-protocol?                       tapi-common:layer-protocol-name
-             |  +--ro local-id                              string
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro uuid?                    uuid
+             |  |  +--ro value-name    string
+             |  |  +--ro value?        string
+             |  +--ro administrative-state?      administrative-state
+             |  +--ro operational-state?         operational-state
+             |  +--ro lifecycle-state?           lifecycle-state
+             +--ro connection*                           -> /tapi-common:context/tapi-connectivity:connection/uuid
+             +--ro direction?                            tapi-common:forwarding-direction
+             +--ro layer-protocol-name?                  tapi-common:layer-protocol-name
+             +--ro uuid?                                 uuid
              +--ro name* [value-name]
-                +--ro value-name    string
-                +--ro value?        string
+             |  +--ro value-name    string
+             |  +--ro value?        string
+             +--ro service-type?                         service-type
+             +--ro service-level?                        string
+             +--ro is-exclusive?                         boolean
+             +--ro requested-capacity
+             |  +--ro total-size
+             |  |  +--ro value?   uint64
+             |  |  +--ro unit?    capacity-unit
+             |  +--ro bandwidth-profile
+             |     +--ro bw-profile-type?              bandwidth-profile-type
+             |     +--ro committed-information-rate
+             |     |  +--ro value?   uint64
+             |     |  +--ro unit?    capacity-unit
+             |     +--ro committed-burst-size
+             |     |  +--ro value?   uint64
+             |     |  +--ro unit?    capacity-unit
+             |     +--ro peak-information-rate
+             |     |  +--ro value?   uint64
+             |     |  +--ro unit?    capacity-unit
+             |     +--ro peak-burst-size
+             |     |  +--ro value?   uint64
+             |     |  +--ro unit?    capacity-unit
+             |     +--ro color-aware?                  boolean
+             |     +--ro coupling-flag?                boolean
+             +--ro schedule
+             |  +--ro end-time?     date-and-time
+             |  +--ro start-time?   date-and-time
+             +--ro cost-characteristic* [cost-name]
+             |  +--ro cost-name         string
+             |  +--ro cost-value?       string
+             |  +--ro cost-algorithm?   string
+             +--ro latency-characteristic* [traffic-property-name]
+             |  +--ro traffic-property-name            string
+             |  +--ro fixed-latency-characteristic?    string
+             |  +--ro queing-latency-characteristic?   string
+             |  +--ro jitter-characteristic?           string
+             |  +--ro wander-characteristic?           string
+             +--ro coroute-inclusion?                    -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+             +--ro diversity-exclusion*                  -> /tapi-common:context/tapi-connectivity:connectivity-service/uuid
+             +--ro route-objective-function?             route-objective-function
+             +--ro diversity-policy?                     diversity-policy
+             +--ro include-topology*                     -> /tapi-common:context/tapi-topology:topology/uuid
+             +--ro avoid-topology*                       -> /tapi-common:context/tapi-topology:topology/uuid
+             +--ro include-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+             +--ro exclude-path*                         -> /tapi-common:context/tapi-path-computation:path/uuid
+             +--ro include-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+             +--ro exclude-link*                         -> /tapi-common:context/tapi-topology:topology/link/uuid
+             +--ro include-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+             +--ro exclude-node*                         -> /tapi-common:context/tapi-topology:topology/node/uuid
+             +--ro preferred-transport-layer*            tapi-common:layer-protocol-name
+             +--ro administrative-state?                 administrative-state
+             +--ro operational-state?                    operational-state
+             +--ro lifecycle-state?                      lifecycle-state
+             +--ro resilience-type
+             |  +--ro restoration-policy?   restoration-policy
+             |  +--ro protection-type?      protection-type
+             +--ro restoration-coordinate-type?          coordinate-type
+             +--ro restore-priority?                     uint64
+             +--ro reversion-mode?                       reversion-mode
+             +--ro wait-to-revert-time?                  uint64
+             +--ro hold-off-time?                        uint64
+             +--ro is-lock-out?                          boolean
+             +--ro is-frozen?                            boolean
+             +--ro is-coordinated-switching-both-ends?   boolean
+             +--ro max-switch-times?                     uint64
+             +--ro layer-protocol?                       tapi-common:layer-protocol-name

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -531,16 +531,16 @@ module tapi-connectivity {
     **********************/ 
         typedef service-type {
             type enumeration {
-                enum point-to-point-connectivity {
+                enum POINT_TO_POINT_CONNECTIVITY {
                     description "none";
                 }
-                enum point-to-multipoint-connectivity {
+                enum POINT_TO_MULTIPOINT_CONNECTIVITY {
                     description "none";
                 }
-                enum multipoint-connectivity {
+                enum MULTIPOINT_CONNECTIVITY {
                     description "none";
                 }
-                enum rooted-multipoint-connectivity {
+                enum ROOTED_MULTIPOINT_CONNECTIVITY {
                     description "none";
                 }
             }
@@ -548,10 +548,10 @@ module tapi-connectivity {
         }
         typedef reversion-mode {
             type enumeration {
-                enum revertive {
+                enum REVERTIVE {
                     description "An FC switched to a lower priority (non-preferred) resource will revert to a higher priority (preferred) resource when that recovers (potentially after some hold-off time).";
                 }
-                enum non-revertive {
+                enum NON-REVERTIVE {
                     description "An FC switched to a lower priority (non-preferred) resource will not revert to a higher priority (preferred) resource when that recovers.";
                 }
             }
@@ -559,19 +559,19 @@ module tapi-connectivity {
         }
         typedef selection-control {
             type enumeration {
-                enum lock-out {
+                enum LOCK_OUT {
                     description "The resource is configured to temporarily not be available for use in the protection scheme(s) it is part of.
                         This overrides all other protection control states including forced.
                         If the item is locked out then it cannot be used under any circumstances.
                         Note: Only relevant when part of a protection scheme.";
                 }
-                enum normal {
+                enum NORMAL {
                     description "none";
                 }
-                enum manual {
+                enum MANUAL {
                     description "none";
                 }
-                enum forced {
+                enum FORCED {
                     description "none";
                 }
             }
@@ -579,25 +579,25 @@ module tapi-connectivity {
         }
         typedef selection-reason {
             type enumeration {
-                enum lockout {
+                enum LOCKOUT {
                     description "none";
                 }
-                enum normal {
+                enum NORMAL {
                     description "none";
                 }
-                enum manual {
+                enum MANUAL {
                     description "none";
                 }
-                enum forced {
+                enum FORCED {
                     description "none";
                 }
-                enum wait-to-revert {
+                enum WAIT_TO_REVERT {
                     description "none";
                 }
-                enum signal-degrade {
+                enum SIGNAL_DEGRADE {
                     description "none";
                 }
-                enum signal-fail {
+                enum SIGNAL_FAIL {
                     description "none";
                 }
             }
@@ -605,13 +605,13 @@ module tapi-connectivity {
         }
         typedef coordinate-type {
             type enumeration {
-                enum no-coordinate {
+                enum NO_COORDINATE {
                     description "none";
                 }
-                enum hold-off-time {
+                enum HOLD_OFF_TIME {
                     description "none";
                 }
-                enum wait-for-notification {
+                enum WAIT_FOR_NOTIFICATION {
                     description "none";
                 }
             }
@@ -619,25 +619,25 @@ module tapi-connectivity {
         }
         typedef route-objective-function {
             type enumeration {
-                enum min-work-route-hop {
+                enum MIN_WORK_ROUTE_HOP {
                     description "none";
                 }
-                enum min-work-route-cost {
+                enum MIN_WORK_ROUTE_COST {
                     description "none";
                 }
-                enum min-work-route-latency {
+                enum MIN_WORK_ROUTE_LATENCY {
                     description "none";
                 }
-                enum min-sum-of-work-and-protection-route-hop {
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_HOP {
                     description "none";
                 }
-                enum min-sum-of-work-and-protection-route-cost {
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_COST {
                     description "none";
                 }
-                enum min-sum-of-work-and-protection-route-latency {
+                enum MIN_SUM_OF_WORK_AND_PROTECTION_ROUTE_LATENCY {
                     description "none";
                 }
-                enum load-balance-max-unused-capacity {
+                enum LOAD_BALANCE_MAX_UNUSED_CAPACITY {
                     description "none";
                 }
             }
@@ -645,19 +645,19 @@ module tapi-connectivity {
         }
         typedef diversity-policy {
             type enumeration {
-                enum srlg {
+                enum SRLG {
                     description "none";
                 }
-                enum srng {
+                enum SRNG {
                     description "none";
                 }
-                enum sng {
+                enum SNG {
                     description "none";
                 }
-                enum node {
+                enum NODE {
                     description "none";
                 }
-                enum link {
+                enum LINK {
                     description "none";
                 }
             }
@@ -665,22 +665,22 @@ module tapi-connectivity {
         }
         typedef protection-role {
             type enumeration {
-                enum work {
+                enum WORK {
                     description "none";
                 }
-                enum protect {
+                enum PROTECT {
                     description "none";
                 }
-                enum protected {
+                enum PROTECTED {
                     description "none";
                 }
-                enum na {
+                enum NA {
                     description "none";
                 }
-                enum work-restore {
+                enum WORK_RESTORE {
                     description "none";
                 }
-                enum protect-restore {
+                enum PROTECT_RESTORE {
                     description "none";
                 }
             }

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -75,11 +75,6 @@ module tapi-connectivity {
                 uses switch-control;
                 description "none";
             }
-            container state {
-                config false;
-                uses tapi-common:operational-state-pac;
-                description "none";
-            }
             leaf direction {
                 type tapi-common:forwarding-direction;
                 config false;
@@ -91,6 +86,7 @@ module tapi-connectivity {
                 description "none";
             }
             uses tapi-common:resource-spec;
+            uses tapi-common:operational-state-pac;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
@@ -127,15 +123,6 @@ module tapi-connectivity {
                 }
                 description "none";
             }
-            container state {
-                config false;
-                uses tapi-common:operational-state-pac;
-                description "none";
-            }
-            container termination {
-                uses tapi-common:termination-pac;
-                description "none";
-            }
             leaf connection-port-direction {
                 type tapi-common:port-direction;
                 config false;
@@ -147,6 +134,8 @@ module tapi-connectivity {
                 description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
             }
             uses tapi-common:resource-spec;
+            uses tapi-common:operational-state-pac;
+            uses tapi-common:termination-pac;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
@@ -187,10 +176,6 @@ module tapi-connectivity {
                 uses tapi-topology:latency-characteristic;
                 description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
             }
-            container route-compute-policy {
-                uses route-compute-policy;
-                description "none";
-            }
             leaf coroute-inclusion {
                 type leafref {
                     path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:uuid';
@@ -205,7 +190,7 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
-            uses tapi-common:local-class;
+            uses tapi-connectivity:route-compute-policy;
             description "none";
         }
         grouping connectivity-service {
@@ -222,18 +207,6 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
-            container conn-constraint {
-                uses connectivity-constraint;
-                description "none";
-            }
-            container topo-constraint {
-                uses topology-constraint;
-                description "none";
-            }
-            container state {
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
             leaf direction {
                 type tapi-common:forwarding-direction;
                 description "none";
@@ -242,12 +215,11 @@ module tapi-connectivity {
                 type tapi-common:layer-protocol-name;
                 description "none";
             }
-            list resilience-constraint {
-                key 'local-id';
-                uses resilience-constraint;
-                description "none";
-            }
             uses tapi-common:service-spec;
+            uses tapi-connectivity:connectivity-constraint;
+            uses tapi-connectivity:topology-constraint;
+            uses tapi-common:admin-state-pac;
+            uses tapi-connectivity:resilience-constraint;
             description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
@@ -269,10 +241,6 @@ module tapi-connectivity {
                 type tapi-common:layer-protocol-name;
                 description "none";
             }
-            container state {
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
             container capacity {
                 uses tapi-common:capacity-pac;
                 description "none";
@@ -290,6 +258,7 @@ module tapi-connectivity {
                 description "To specify the protection role of this Port when create or update ConnectivityService.";
             }
             uses tapi-common:local-class;
+            uses tapi-common:admin-state-pac;
             description "The association of the FC to LTPs is made via EndPoints.
                 The EndPoint (EP) object class models the access to the FC function. 
                 The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
@@ -380,11 +349,8 @@ module tapi-connectivity {
                 uses switch;
                 description "none";
             }
-            container control-parameters {
-                uses resilience-constraint;
-                description "none";
-            }
             uses tapi-common:local-class;
+            uses tapi-connectivity:resilience-constraint;
             description "Represents the capability to control and coordinate switches, to add/delete/modify FCs and to add/delete/modify LTPs/LPs so as to realize a protection scheme.";
         }
         grouping resilience-constraint {
@@ -438,7 +404,6 @@ module tapi-connectivity {
                 type tapi-common:layer-protocol-name;
                 description "Indicate which layer this resilience parameters package configured for.";
             }
-            uses tapi-common:local-class;
             description "A list of control parameters to apply to a switch.";
         }
         grouping topology-constraint {
@@ -503,7 +468,6 @@ module tapi-connectivity {
                 config false;
                 description "soft constraint requested by client to indicate the layer(s) of transport connection that it prefers to carry the service. This could be same as the service layer or one of the supported server layers";
             }
-            uses tapi-common:local-class;
             description "none";
         }
         grouping cep-list {

--- a/YANG/tapi-eth.tree
+++ b/YANG/tapi-eth.tree
@@ -1,98 +1,93 @@
 module: tapi-eth
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro ety-term
-       +--ro is-fts-enabled?        boolean
-       +--ro is-tx-pause-enabled?   boolean
-       +--ro phy-type?              ety-phy-type
-       +--ro phy-type-list*         ety-phy-type
+    +--ro is-fts-enabled?        boolean
+    +--ro is-tx-pause-enabled?   boolean
+    +--ro phy-type?              ety-phy-type
+    +--ro phy-type-list*         ety-phy-type
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro eth-term
-    |  +--ro priority-regenerate
-    |  |  +--ro priority-0?   uint64
-    |  |  +--ro priority-1?   uint64
-    |  |  +--ro priority-2?   uint64
-    |  |  +--ro priority-3?   uint64
-    |  |  +--ro priority-4?   uint64
-    |  |  +--ro priority-5?   uint64
-    |  |  +--ro priority-6?   uint64
-    |  |  +--ro priority-7?   uint64
-    |  +--ro ether-type?                   vlan-type
-    |  +--ro filter-config*                mac-address
-    |  +--ro frametype-config?             frame-type
-    |  +--ro port-vid?                     vid
-    |  +--ro priority-code-point-config?   pcp-coding
-    +--ro eth-ctp
-       +--ro auxiliary-function-position-sequence*   uint64
-       +--ro vlan-config?                            uint64
-       +--ro csf-rdi-fdi-enable?                     boolean
-       +--ro csf-report?                             boolean
-       +--ro filter-config-snk*                      mac-address
-       +--ro mac-length?                             uint64
-       +--ro filter-config
-       |  +--ro c-2-00-00-10?    boolean
-       |  +--ro c-2-00-00-00?    boolean
-       |  +--ro c-2-00-00-01?    boolean
-       |  +--ro c-2-00-00-02?    boolean
-       |  +--ro c-2-00-00-03?    boolean
-       |  +--ro c-2-00-00-04?    boolean
-       |  +--ro c-2-00-00-05?    boolean
-       |  +--ro c-2-00-00-06?    boolean
-       |  +--ro c-2-00-00-07?    boolean
-       |  +--ro c-2-00-00-08?    boolean
-       |  +--ro c-2-00-00-09?    boolean
-       |  +--ro c-2-00-00-0-a?   boolean
-       |  +--ro c-2-00-00-0-b?   boolean
-       |  +--ro c-2-00-00-0-c?   boolean
-       |  +--ro c-2-00-00-0-d?   boolean
-       |  +--ro c-2-00-00-0-e?   boolean
-       |  +--ro c-2-00-00-0-f?   boolean
-       |  +--ro c-2-00-00-20?    boolean
-       |  +--ro c-2-00-00-21?    boolean
-       |  +--ro c-2-00-00-22?    boolean
-       |  +--ro c-2-00-00-23?    boolean
-       |  +--ro c-2-00-00-24?    boolean
-       |  +--ro c-2-00-00-25?    boolean
-       |  +--ro c-2-00-00-26?    boolean
-       |  +--ro c-2-00-00-27?    boolean
-       |  +--ro c-2-00-00-28?    boolean
-       |  +--ro c-2-00-00-29?    boolean
-       |  +--ro c-2-00-00-2-a?   boolean
-       |  +--ro c-2-00-00-2-b?   boolean
-       |  +--ro c-2-00-00-2-c?   boolean
-       |  +--ro c-2-00-00-2-d?   boolean
-       |  +--ro c-2-00-00-2-e?   boolean
-       |  +--ro c-2-00-00-2-f?   boolean
-       +--ro is-ssf-reported?                        boolean
-       +--ro pll-thr?                                uint64
-       +--ro actor-oper-key?                         uint64
-       +--ro actor-system-id?                        mac-address
-       +--ro actor-system-priority?                  uint64
-       +--ro collector-max-delay?                    uint64
-       +--ro data-rate?                              uint64
-       +--ro partner-oper-key?                       uint64
-       +--ro partner-system-id?                      mac-address
-       +--ro partner-system-priority?                uint64
-       +--ro csf-config?                             csf-config
-       +--ro traffic-shaping
-       |  +--ro prio-config-list*
-       |  |  +--ro priority?   uint64
-       |  |  +--ro queue-id?   uint64
-       |  +--ro queue-config-list*
-       |  |  +--ro queue-id?          uint64
-       |  |  +--ro queue-depth?       uint64
-       |  |  +--ro queue-threshold?   uint64
-       |  +--ro sched-config?        scheduling-configuration
-       |  +--ro codirectional?       boolean
-       +--ro traffic-conditioning
-          +--ro prio-config-list*
-          |  +--ro priority?   uint64
-          |  +--ro queue-id?   uint64
-          +--ro cond-config-list*
-          |  +--ro cir?             uint64
-          |  +--ro cbs?             uint64
-          |  +--ro eir?             uint64
-          |  +--ro ebs?             uint64
-          |  +--ro coupling-flag?   boolean
-          |  +--ro colour-mode?     colour-mode
-          |  +--ro queue-id?        uint64
-          +--ro codirectional?      boolean
+    +--ro priority-regenerate
+    |  +--ro priority-0?   uint64
+    |  +--ro priority-1?   uint64
+    |  +--ro priority-2?   uint64
+    |  +--ro priority-3?   uint64
+    |  +--ro priority-4?   uint64
+    |  +--ro priority-5?   uint64
+    |  +--ro priority-6?   uint64
+    |  +--ro priority-7?   uint64
+    +--ro ether-type?                             vlan-type
+    +--ro filter-config-1*                        mac-address
+    +--ro frametype-config?                       frame-type
+    +--ro port-vid?                               vid
+    +--ro priority-code-point-config?             pcp-coding
+    +--ro auxiliary-function-position-sequence*   uint64
+    +--ro vlan-config?                            uint64
+    +--ro csf-rdi-fdi-enable?                     boolean
+    +--ro csf-report?                             boolean
+    +--ro filter-config-snk*                      mac-address
+    +--ro mac-length?                             uint64
+    +--ro filter-config
+    |  +--ro c-2-00-00-10?    boolean
+    |  +--ro c-2-00-00-00?    boolean
+    |  +--ro c-2-00-00-01?    boolean
+    |  +--ro c-2-00-00-02?    boolean
+    |  +--ro c-2-00-00-03?    boolean
+    |  +--ro c-2-00-00-04?    boolean
+    |  +--ro c-2-00-00-05?    boolean
+    |  +--ro c-2-00-00-06?    boolean
+    |  +--ro c-2-00-00-07?    boolean
+    |  +--ro c-2-00-00-08?    boolean
+    |  +--ro c-2-00-00-09?    boolean
+    |  +--ro c-2-00-00-0-a?   boolean
+    |  +--ro c-2-00-00-0-b?   boolean
+    |  +--ro c-2-00-00-0-c?   boolean
+    |  +--ro c-2-00-00-0-d?   boolean
+    |  +--ro c-2-00-00-0-e?   boolean
+    |  +--ro c-2-00-00-0-f?   boolean
+    |  +--ro c-2-00-00-20?    boolean
+    |  +--ro c-2-00-00-21?    boolean
+    |  +--ro c-2-00-00-22?    boolean
+    |  +--ro c-2-00-00-23?    boolean
+    |  +--ro c-2-00-00-24?    boolean
+    |  +--ro c-2-00-00-25?    boolean
+    |  +--ro c-2-00-00-26?    boolean
+    |  +--ro c-2-00-00-27?    boolean
+    |  +--ro c-2-00-00-28?    boolean
+    |  +--ro c-2-00-00-29?    boolean
+    |  +--ro c-2-00-00-2-a?   boolean
+    |  +--ro c-2-00-00-2-b?   boolean
+    |  +--ro c-2-00-00-2-c?   boolean
+    |  +--ro c-2-00-00-2-d?   boolean
+    |  +--ro c-2-00-00-2-e?   boolean
+    |  +--ro c-2-00-00-2-f?   boolean
+    +--ro is-ssf-reported?                        boolean
+    +--ro pll-thr?                                uint64
+    +--ro actor-oper-key?                         uint64
+    +--ro actor-system-id?                        mac-address
+    +--ro actor-system-priority?                  uint64
+    +--ro collector-max-delay?                    uint64
+    +--ro data-rate?                              uint64
+    +--ro partner-oper-key?                       uint64
+    +--ro partner-system-id?                      mac-address
+    +--ro partner-system-priority?                uint64
+    +--ro csf-config?                             csf-config
+    +--ro prio-config-list*
+    |  +--ro priority?   uint64
+    |  +--ro queue-id?   uint64
+    +--ro queue-config-list*
+    |  +--ro queue-id?          uint64
+    |  +--ro queue-depth?       uint64
+    |  +--ro queue-threshold?   uint64
+    +--ro sched-config?                           scheduling-configuration
+    +--ro codirectional?                          boolean
+    +--ro prio-config-list-1*
+    |  +--ro priority?   uint64
+    |  +--ro queue-id?   uint64
+    +--ro cond-config-list*
+    |  +--ro cir?             uint64
+    |  +--ro cbs?             uint64
+    |  +--ro eir?             uint64
+    |  +--ro ebs?             uint64
+    |  +--ro coupling-flag?   boolean
+    |  +--ro colour-mode?     colour-mode
+    |  +--ro queue-id?        uint64
+    +--ro codirectional-1?                        boolean

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -143,25 +143,13 @@ module tapi-eth {
                 description "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.
                     range of type : true, false";
             }
-            container traffic-shaping {
-                uses traffic-shaping-pac;
-                description "none";
-            }
-            container traffic-conditioning {
-                uses traffic-conditioning-pac;
-                description "none";
-            }
+            uses tapi-eth:traffic-shaping-pac;
+            uses tapi-eth:traffic-conditioning-pac;
             description "none";
         }
         grouping eth-connection-end-point-spec {
-            container eth-term {
-                uses eth-termination-pac;
-                description "none";
-            }
-            container eth-ctp {
-                uses eth-ctp-pac;
-                description "none";
-            }
+            uses tapi-eth:eth-termination-pac;
+            uses tapi-eth:eth-ctp-pac;
             description "none";
         }
         grouping eth-termination-pac {
@@ -173,7 +161,7 @@ module tapi-eth {
                 type vlan-type;
                 description "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.";
             }
-            leaf-list filter-config {
+            leaf-list filter-config-1 {
                 type mac-address;
                 description "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.
                     It indicates the configured filter action for each of the 33 group MAC addresses for control frames.
@@ -232,7 +220,7 @@ module tapi-eth {
             description "none";
         }
         grouping traffic-conditioning-pac {
-            list prio-config-list {
+            list prio-config-list-1 {
                 config false;
                 uses priority-configuration;
                 description "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
@@ -249,7 +237,7 @@ module tapi-eth {
                     - Coupling flag (CF): 0 or 1
                     - Color mode (CM): color-blind and color-aware.";
             }
-            leaf codirectional {
+            leaf codirectional-1 {
                 type boolean;
                 config false;
                 description "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.";
@@ -284,10 +272,7 @@ module tapi-eth {
                 Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
         }
         grouping eth-node-edge-point-spec {
-            container ety-term {
-                uses ety-termination-pac;
-                description "none";
-            }
+            uses tapi-eth:ety-termination-pac;
             description "none";
         }
 

--- a/YANG/tapi-eth.yang
+++ b/YANG/tapi-eth.yang
@@ -600,10 +600,10 @@ module tapi-eth {
         }
         typedef admin-state {
             type enumeration {
-                enum lock {
+                enum LOCK {
                     description "none";
                 }
-                enum normal {
+                enum NORMAL {
                     description "none";
                 }
             }
@@ -611,10 +611,10 @@ module tapi-eth {
         }
         typedef colour-mode {
             type enumeration {
-                enum colour-blind {
+                enum COLOUR_BLIND {
                     description "none";
                 }
-                enum colour-aware {
+                enum COLOUR_AWARE {
                     description "none";
                 }
             }
@@ -622,31 +622,31 @@ module tapi-eth {
         }
         typedef csf-config {
             type enumeration {
-                enum disabled {
+                enum DISABLED {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is false
                         - MI_CSFrdifdi_Enable is false
                         - MI_CSFdci_Enable is false.";
                 }
-                enum enabled {
+                enum ENABLED {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is false
                         - MI_CSFdci_Enable is false.";
                 }
-                enum enabled-with-rdi-fdi {
+                enum ENABLED_WITH_RDI_FDI {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is true
                         - MI_CSFdci_Enable is false.";
                 }
-                enum enabled-with-rdi-fdi-dci {
+                enum ENABLED_WITH_RDI_FDI_DCI {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is true
                         - MI_CSFdci_Enable is true.";
                 }
-                enum enabled-with-dci {
+                enum ENABLED_WITH_DCI {
                     description "This literal covers the following states of the CSF related MI informations:
                         - MI_CSF_Enable is true
                         - MI_CSFrdifdi_Enable is false
@@ -657,46 +657,46 @@ module tapi-eth {
         }
         typedef ety-phy-type {
             type enumeration {
-                enum other {
+                enum OTHER {
                     description "none";
                 }
-                enum unknown {
+                enum UNKNOWN {
                     description "none";
                 }
-                enum none {
+                enum NONE {
                     description "none";
                 }
-                enum 2-base-tl {
+                enum 2BASE_TL {
                     description "none";
                 }
-                enum 10-mbit-s {
+                enum 10MBIT_S {
                     description "none";
                 }
-                enum 10-pass-ts {
+                enum 10PASS_TS {
                     description "none";
                 }
-                enum 100-base-t-4 {
+                enum 100BASE_T4 {
                     description "none";
                 }
-                enum 100-base-x {
+                enum 100BASE_X {
                     description "none";
                 }
-                enum 100-base-t-2 {
+                enum 100BASE_T2 {
                     description "none";
                 }
-                enum 1000-base-x {
+                enum 1000BASE_X {
                     description "none";
                 }
-                enum 1000-base-t {
+                enum 1000BASE_T {
                     description "none";
                 }
-                enum 10-gbase-x {
+                enum 10GBASE-X {
                     description "none";
                 }
-                enum 10-gbase-r {
+                enum 10GBASE_R {
                     description "none";
                 }
-                enum 10-gbase-w {
+                enum 10GBASE_W {
                     description "none";
                 }
             }
@@ -704,13 +704,13 @@ module tapi-eth {
         }
         typedef frame-type {
             type enumeration {
-                enum admit-only-vlan-tagged-frames {
+                enum ADMIT_ONLY_VLAN_TAGGED_FRAMES {
                     description "none";
                 }
-                enum admit-only-untagged-and-priority-tagged-frames {
+                enum ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES {
                     description "none";
                 }
-                enum admit-all-frames {
+                enum ADMIT_ALL_FRAMES {
                     description "none";
                 }
             }
@@ -718,25 +718,25 @@ module tapi-eth {
         }
         typedef oam-period {
             type enumeration {
-                enum 3-33-ms {
+                enum 3_33MS {
                     description "Default for protection.";
                 }
-                enum 10-ms {
+                enum 10MS {
                     description "none";
                 }
-                enum 100-ms {
+                enum 100MS {
                     description "none";
                 }
-                enum 1-s {
+                enum 1S {
                     description "none";
                 }
-                enum 10-s {
+                enum 10S {
                     description "none";
                 }
-                enum 1-min {
+                enum 1MIN {
                     description "none";
                 }
-                enum 10-min {
+                enum 10MIN {
                     description "none";
                 }
             }
@@ -744,19 +744,19 @@ module tapi-eth {
         }
         typedef pcp-coding {
             type enumeration {
-                enum 8-p-0-d {
+                enum 8P0D {
                     description "none";
                 }
-                enum 7-p-1-d {
+                enum 7P1D {
                     description "none";
                 }
-                enum 6-p-2-d {
+                enum 6P2D {
                     description "none";
                 }
-                enum 5-p-3-d {
+                enum 5P3D {
                     description "none";
                 }
-                enum dei {
+                enum DEI {
                     description "This enumeration value means that all priorities should be drop eligible.
                         DEI = Drop Eligibility Indicator";
                 }
@@ -765,13 +765,13 @@ module tapi-eth {
         }
         typedef vlan-type {
             type enumeration {
-                enum c-tag {
+                enum C_Tag {
                     description "0x8100";
                 }
-                enum s-tag {
+                enum S_Tag {
                     description "0x88a8";
                 }
-                enum i-tag {
+                enum I_Tag {
                     description "88-e7";
                 }
             }

--- a/YANG/tapi-notification.yang
+++ b/YANG/tapi-notification.yang
@@ -245,19 +245,19 @@ module tapi-notification {
         }
         typedef notification-type {
             type enumeration {
-                enum object-creation {
+                enum OBJECT_CREATION {
                     description "Not a normal state. The system is unable to determine the correct value.";
                 }
-                enum object-deletion {
+                enum OBJECT_DELETION {
                     description "none";
                 }
-                enum attribute-value-change {
+                enum ATTRIBUTE_VALUE_CHANGE {
                     description "none";
                 }
-                enum alarm-event {
+                enum ALARM_EVENT {
                     description "none";
                 }
-                enum threshold-crossing-alert {
+                enum THRESHOLD_CROSSING_ALERT {
                     description "none";
                 }
             }
@@ -265,37 +265,37 @@ module tapi-notification {
         }
         typedef object-type {
             type enumeration {
-                enum topology {
+                enum TOPOLOGY {
                     description "none";
                 }
-                enum node {
+                enum NODE {
                     description "none";
                 }
-                enum link {
+                enum LINK {
                     description "none";
                 }
-                enum connection {
+                enum CONNECTION {
                     description "none";
                 }
-                enum path {
+                enum PATH {
                     description "none";
                 }
-                enum connectivity-service {
+                enum CONNECTIVITY_SERVICE {
                     description "none";
                 }
-                enum virtual-network-service {
+                enum VIRTUAL_NETWORK_SERVICE {
                     description "none";
                 }
-                enum path-computation-service {
+                enum PATH_COMPUTATION_SERVICE {
                     description "none";
                 }
-                enum node-edge-point {
+                enum NODE_EDGE_POINT {
                     description "none";
                 }
-                enum service-interface-point {
+                enum SERVICE_INTERFACE_POINT {
                     description "none";
                 }
-                enum connection-end-point {
+                enum CONNECTION_END_POINT {
                     description "none";
                 }
             }
@@ -303,13 +303,13 @@ module tapi-notification {
         }
         typedef source-indicator {
             type enumeration {
-                enum resource-operation {
+                enum RESOURCE_OPERATION {
                     description "none";
                 }
-                enum management-operation {
+                enum MANAGEMENT_OPERATION {
                     description "none";
                 }
-                enum unknown {
+                enum UNKNOWN {
                     description "none";
                 }
             }
@@ -317,10 +317,10 @@ module tapi-notification {
         }
         typedef subscription-state {
             type enumeration {
-                enum suspended {
+                enum SUSPENDED {
                     description "none";
                 }
-                enum active {
+                enum ACTIVE {
                     description "none";
                 }
             }
@@ -328,19 +328,19 @@ module tapi-notification {
         }
         typedef perceived-serverity-type {
             type enumeration {
-                enum critical {
+                enum CRITICAL {
                     description "none";
                 }
-                enum major {
+                enum MAJOR {
                     description "none";
                 }
-                enum minor {
+                enum MINOR {
                     description "none";
                 }
-                enum warning {
+                enum WARNING {
                     description "none";
                 }
-                enum cleared {
+                enum CLEARED {
                     description "none";
                 }
             }
@@ -348,13 +348,13 @@ module tapi-notification {
         }
         typedef threshold-crossing-type {
             type enumeration {
-                enum threshold-above {
+                enum THRESHOLD_ABOVE {
                     description "none";
                 }
-                enum threshold-below {
+                enum THRESHOLD_BELOW {
                     description "none";
                 }
-                enum cleared {
+                enum CLEARED {
                     description "none";
                 }
             }
@@ -362,13 +362,13 @@ module tapi-notification {
         }
         typedef service-affecting {
             type enumeration {
-                enum service-affecting {
+                enum SERVICE_AFFECTING {
                     description "none";
                 }
-                enum not-service-affecting {
+                enum NOT_SERVICE_AFFECTING {
                     description "none";
                 }
-                enum unknown {
+                enum UNKNOWN {
                     description "none";
                 }
             }

--- a/YANG/tapi-oam.tree
+++ b/YANG/tapi-oam.tree
@@ -6,23 +6,21 @@ module: tapi-oam
     |  |  +--rw service-interface-point?          -> /tapi-common:context/service-interface-point/uuid
     |  |  +--rw connectivity-service-end-point?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
     |  |  +--rw pro-active-measurement-job* [local-id]
-    |  |  |  +--rw state
-    |  |  |  |  +--rw administrative-state?   administrative-state
-    |  |  |  |  +--ro operational-state?      operational-state
-    |  |  |  |  +--ro lifecycle-state?        lifecycle-state
-    |  |  |  +--rw local-id    string
+    |  |  |  +--rw local-id                string
     |  |  |  +--rw name* [value-name]
-    |  |  |     +--rw value-name    string
-    |  |  |     +--rw value?        string
+    |  |  |  |  +--rw value-name    string
+    |  |  |  |  +--rw value?        string
+    |  |  |  +--rw administrative-state?   administrative-state
+    |  |  |  +--ro operational-state?      operational-state
+    |  |  |  +--ro lifecycle-state?        lifecycle-state
     |  |  +--rw on-demand-measurement-job* [local-id]
-    |  |  |  +--rw state
-    |  |  |  |  +--rw administrative-state?   administrative-state
-    |  |  |  |  +--ro operational-state?      operational-state
-    |  |  |  |  +--ro lifecycle-state?        lifecycle-state
-    |  |  |  +--rw local-id    string
+    |  |  |  +--rw local-id                string
     |  |  |  +--rw name* [value-name]
-    |  |  |     +--rw value-name    string
-    |  |  |     +--rw value?        string
+    |  |  |  |  +--rw value-name    string
+    |  |  |  |  +--rw value?        string
+    |  |  |  +--rw administrative-state?   administrative-state
+    |  |  |  +--ro operational-state?      operational-state
+    |  |  |  +--ro lifecycle-state?        lifecycle-state
     |  |  +--ro associated-mep?                   -> /tapi-common:context/tapi-oam:meg/mep/local-id
     |  |  +--ro direction?                        tapi-common:port-direction
     |  |  +--rw local-id                          string

--- a/YANG/tapi-oam.yang
+++ b/YANG/tapi-oam.yang
@@ -80,19 +80,13 @@ module tapi-oam {
             description "none";
         }
         grouping on-demand-measurement-job {
-            container state {
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
             uses tapi-common:local-class;
+            uses tapi-common:admin-state-pac;
             description "none";
         }
         grouping pro-active-measurement-job {
-            container state {
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
             uses tapi-common:local-class;
+            uses tapi-common:admin-state-pac;
             description "none";
         }
         grouping meg {

--- a/YANG/tapi-odu.tree
+++ b/YANG/tapi-odu.tree
@@ -1,79 +1,65 @@
 module: tapi-odu
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro odu-pool
-       +--ro client-capacity?        uint64
-       +--ro max-client-instances?   uint64
-       +--ro max-client-size?        uint64
+    +--ro client-capacity?        uint64
+    +--ro max-client-instances?   uint64
+    +--ro max-client-size?        uint64
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro odu-common
-    |  +--ro odu-type?             odu-type
-    |  +--ro odu-rate?             uint64
-    |  +--ro odu-rate-tolerance?   uint64
-    +--ro odu-term-and-adapter
-    |  +--ro opu-tributary-slot-size?   odu-slot-size
-    |  +--ro auto-payload-type?         boolean
-    |  +--ro configured-client-type?    string
-    |  +--ro configured-mapping-type?   mapping-type
-    |  +--ro accepted-payload-type
-    |     +--ro named-payload-type?   odu-named-payload-type
-    |     +--ro hex-payload-type?     uint64
-    +--ro odu-ctp
-    |  +--ro tributary-slot-list*     uint64
-    |  +--ro tributary-port-number?   uint64
-    |  +--ro accepted-m-si?           string
-    +--ro odu-protection
-       +--ro aps-enable?   boolean
-       +--ro aps-level?    uint64
+    +--ro odu-type?                  odu-type
+    +--ro odu-rate?                  uint64
+    +--ro odu-rate-tolerance?        uint64
+    +--ro opu-tributary-slot-size?   odu-slot-size
+    +--ro auto-payload-type?         boolean
+    +--ro configured-client-type?    string
+    +--ro configured-mapping-type?   mapping-type
+    +--ro accepted-payload-type
+    |  +--ro named-payload-type?   odu-named-payload-type
+    |  +--ro hex-payload-type?     uint64
+    +--ro tributary-slot-list*       uint64
+    +--ro tributary-port-number?     uint64
+    +--ro accepted-m-si?             string
+    +--ro aps-enable?                boolean
+    +--ro aps-level?                 uint64
   augment /tapi-common:context/tapi-oam:meg/tapi-oam:mep:
-    +--ro odu-common
-    |  +--ro odu-type?             odu-type
-    |  +--ro odu-rate?             uint64
-    |  +--ro odu-rate-tolerance?   uint64
-    +--ro odu-term-and-adapter
-    |  +--ro opu-tributary-slot-size?   odu-slot-size
-    |  +--ro auto-payload-type?         boolean
-    |  +--ro configured-client-type?    string
-    |  +--ro configured-mapping-type?   mapping-type
-    |  +--ro accepted-payload-type
-    |     +--ro named-payload-type?   odu-named-payload-type
-    |     +--ro hex-payload-type?     uint64
-    +--ro odu-ctp
-    |  +--ro tributary-slot-list*     uint64
-    |  +--ro tributary-port-number?   uint64
-    |  +--ro accepted-m-si?           string
-    +--ro odu-protection
-       +--ro aps-enable?   boolean
-       +--ro aps-level?    uint64
+    +--ro odu-type?                  odu-type
+    +--ro odu-rate?                  uint64
+    +--ro odu-rate-tolerance?        uint64
+    +--ro opu-tributary-slot-size?   odu-slot-size
+    +--ro auto-payload-type?         boolean
+    +--ro configured-client-type?    string
+    +--ro configured-mapping-type?   mapping-type
+    +--ro accepted-payload-type
+    |  +--ro named-payload-type?   odu-named-payload-type
+    |  +--ro hex-payload-type?     uint64
+    +--ro tributary-slot-list*       uint64
+    +--ro tributary-port-number?     uint64
+    +--ro accepted-m-si?             string
+    +--ro aps-enable?                boolean
+    +--ro aps-level?                 uint64
   augment /tapi-common:context/tapi-oam:meg/tapi-oam:mip:
-    +--ro odu-mip
-    |  +--ro acti?               string
-    |  +--ro ex-dapi?            string
-    |  +--ro ex-sapi?            string
-    |  +--ro tim-act-disabled?   boolean
-    |  +--ro tim-det-mode?       tim-det-mo
-    |  +--ro deg-m?              uint64
-    |  +--ro deg-thr
-    |     +--ro deg-thr-value?            uint64
-    |     +--ro deg-thr-type?             deg-thr-type
-    |     +--ro percentage-granularity?   percentage-granularity
-    +--ro odu-ncm
-    |  +--ro tcm-fields-in-use*   uint64
-    +--ro odu-tcm
-    |  +--ro tcm-field?   uint64
-    +--ro odu-pm
-    |  +--ro n-bbe?   uint64
-    |  +--ro f-bbe?   uint64
-    |  +--ro n-ses?   uint64
-    |  +--ro f-ses?   uint64
-    |  +--ro uas
-    |     +--ro bidirectional?   boolean
-    |     +--ro uas?             uint64
-    |     +--ro nuas?            uint64
-    |     +--ro fuas?            uint64
-    +--ro odu-defect
-       +--ro bdi?   boolean
-       +--ro deg?   boolean
-       +--ro lck?   boolean
-       +--ro oci?   boolean
-       +--ro ssf?   boolean
-       +--ro tim?   boolean
+    +--ro acti?                string
+    +--ro ex-dapi?             string
+    +--ro ex-sapi?             string
+    +--ro tim-act-disabled?    boolean
+    +--ro tim-det-mode?        tim-det-mo
+    +--ro deg-m?               uint64
+    +--ro deg-thr
+    |  +--ro deg-thr-value?            uint64
+    |  +--ro deg-thr-type?             deg-thr-type
+    |  +--ro percentage-granularity?   percentage-granularity
+    +--ro tcm-fields-in-use*   uint64
+    +--ro tcm-field?           uint64
+    +--ro n-bbe?               uint64
+    +--ro f-bbe?               uint64
+    +--ro n-ses?               uint64
+    +--ro f-ses?               uint64
+    +--ro uas
+    |  +--ro bidirectional?   boolean
+    |  +--ro uas?             uint64
+    |  +--ro nuas?            uint64
+    |  +--ro fuas?            uint64
+    +--ro bdi?                 boolean
+    +--ro deg?                 boolean
+    +--ro lck?                 boolean
+    +--ro oci?                 boolean
+    +--ro ssf?                 boolean
+    +--ro tim?                 boolean

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -75,25 +75,10 @@ module tapi-odu {
                 It is present only if the CEP contains a TTP";
         }
         grouping odu-connection-end-point-spec {
-            container odu-common {
-                uses odu-common-pac;
-                description "none";
-            }
-            container odu-term-and-adapter {
-                config false;
-                uses odu-termination-and-client-adaptation-pac;
-                description "none";
-            }
-            container odu-ctp {
-                config false;
-                uses odu-ctp-pac;
-                description "none";
-            }
-            container odu-protection {
-                config false;
-                uses odu-protection-pac;
-                description "none";
-            }
+            uses tapi-odu:odu-common-pac;
+            uses tapi-odu:odu-termination-and-client-adaptation-pac;
+            uses tapi-odu:odu-ctp-pac;
+            uses tapi-odu:odu-protection-pac;
             description "none";
         }
         grouping odu-pool-pac {
@@ -114,11 +99,7 @@ module tapi-odu {
             description "none";
         }
         grouping odu-node-edge-point-spec {
-            container odu-pool {
-                config false;
-                uses odu-pool-pac;
-                description "none";
-            }
+            uses tapi-odu:odu-pool-pac;
             description "none";
         }
         grouping odu-ctp-pac {
@@ -151,28 +132,11 @@ module tapi-odu {
                 It is present only if the CEP contains a CTP";
         }
         grouping odu-mep-spec {
-            container odu-mep {
-                uses odu-mep-pac;
-                description "none";
-            }
-            container odu-ncm {
-                config false;
-                uses odu-ncm-pac;
-                description "none";
-            }
-            container odu-tcm {
-                config false;
-                uses odu-tcm-mep-pac;
-                description "none";
-            }
-            container odu-defect {
-                uses odu-defect-pac;
-                description "none";
-            }
-            container odu-pm {
-                uses odu-pm-pac;
-                description "none";
-            }
+            uses tapi-odu:odu-mep-pac;
+            uses tapi-odu:odu-ncm-pac;
+            uses tapi-odu:odu-tcm-mep-pac;
+            uses tapi-odu:odu-defect-pac;
+            uses tapi-odu:odu-pm-pac;
             description "none";
         }
         grouping odu-protection-pac {
@@ -231,29 +195,11 @@ module tapi-odu {
             description "none";
         }
         grouping odu-mip-spec {
-            container odu-mip {
-                config false;
-                uses odu-mip-pac;
-                description "none";
-            }
-            container odu-ncm {
-                config false;
-                uses odu-ncm-pac;
-                description "none";
-            }
-            container odu-tcm {
-                config false;
-                uses odu-tcm-mip-pac;
-                description "none";
-            }
-            container odu-pm {
-                uses odu-pm-pac;
-                description "none";
-            }
-            container odu-defect {
-                uses odu-defect-pac;
-                description "none";
-            }
+            uses tapi-odu:odu-mip-pac;
+            uses tapi-odu:odu-ncm-pac;
+            uses tapi-odu:odu-tcm-mip-pac;
+            uses tapi-odu:odu-pm-pac;
+            uses tapi-odu:odu-defect-pac;
             description "none";
         }
         grouping odu-mip-pac {

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -403,112 +403,6 @@ module tapi-odu {
     /***********************
     * package type-definitions
     **********************/ 
-        identity deg-thr-type {
-            description "none";
-        }
-        identity percentage {
-            base deg-thr-type;
-            description "Choice of % or Number of errored blocks";
-        }
-        identity number-errored-blocks {
-            base deg-thr-type;
-            description "Number of % or blocks";
-        }
-        identity tcm-status {
-            description "none";
-        }
-        identity no-source-tc {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
-        }
-        identity in-use-without-iae {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
-        }
-        identity in-use-with-iae {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
-        }
-        identity reserved-1 {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
-        }
-        identity reserved-2 {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
-        }
-        identity lck {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODU-LCK";
-        }
-        identity oci {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODU-OCI";
-        }
-        identity ais {
-            base tcm-status;
-            description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODU-AIS";
-        }
-        identity tcm-mode {
-            description "none";
-        }
-        identity operational {
-            base tcm-mode;
-            description "none";
-        }
-        identity transparent {
-            base tcm-mode;
-            description "none";
-        }
-        identity monitor {
-            base tcm-mode;
-            description "none";
-        }
-        identity tcm-monitoring {
-            description "none";
-        }
-        identity intrusive {
-            base tcm-monitoring;
-            description "none";
-        }
-        identity non-intrusive {
-            base tcm-monitoring;
-            description "none";
-        }
-        identity tcm-extension {
-            description "none";
-        }
-        identity normal {
-            base tcm-extension;
-            description "none";
-        }
-        identity pass-through {
-            base tcm-extension;
-            description "none";
-        }
-        identity erase {
-            base tcm-extension;
-            description "none";
-        }
-        identity percentage-granularity {
-            description "none";
-        }
-        identity ones {
-            base percentage-granularity;
-            description "none";
-        }
-        identity one-tenths {
-            base percentage-granularity;
-            description "value * (1/10)";
-        }
-        identity one-hundredths {
-            base percentage-granularity;
-            description "value * (1/100)";
-        }
-        identity one-thousandths {
-            base percentage-granularity;
-            description "value * (1/1000)";
-        }
         typedef odu-type {
             type enumeration {
                 enum odu-0 {
@@ -633,38 +527,98 @@ module tapi-odu {
                 Number of Errored Blocks is captured in an integer value.";
         }
         typedef deg-thr-type {
-            type identityref {
-                base deg-thr-type;
+            type enumeration {
+                enum percentage {
+                    description "Choice of % or Number of errored blocks";
+                }
+                enum number-errored-blocks {
+                    description "Number of % or blocks";
+                }
             }
             description "The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.";
         }
         typedef tcm-status {
-            type identityref {
-                base tcm-status;
+            type enumeration {
+                enum no-source-tc {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
+                }
+                enum in-use-without-iae {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
+                }
+                enum in-use-with-iae {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
+                }
+                enum reserved-1 {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
+                }
+                enum reserved-2 {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
+                }
+                enum lck {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODU-LCK";
+                }
+                enum oci {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODU-OCI";
+                }
+                enum ais {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODU-AIS";
+                }
             }
             description "See Table 15-5/G.709/Y.1331 ";
         }
         typedef tcm-mode {
-            type identityref {
-                base tcm-mode;
+            type enumeration {
+                enum operational {
+                    description "none";
+                }
+                enum transparent {
+                    description "none";
+                }
+                enum monitor {
+                    description "none";
+                }
             }
             description "List of value modes for the sink side of the tandem connection monitoring function.";
         }
         typedef tcm-monitoring {
-            type identityref {
-                base tcm-monitoring;
+            type enumeration {
+                enum intrusive {
+                    description "none";
+                }
+                enum non-intrusive {
+                    description "none";
+                }
             }
             description "Monitoring types for the tandem connection monitoring function.";
         }
         typedef tcm-extension {
-            type identityref {
-                base tcm-extension;
+            type enumeration {
+                enum normal {
+                    description "none";
+                }
+                enum pass-through {
+                    description "none";
+                }
+                enum erase {
+                    description "none";
+                }
             }
             description "none";
         }
         typedef percentage-granularity {
-            type identityref {
-                base percentage-granularity;
+            type enumeration {
+                enum ones {
+                    description "none";
+                }
+                enum one-tenths {
+                    description "value * (1/10)";
+                }
+                enum one-hundredths {
+                    description "value * (1/100)";
+                }
+                enum one-thousandths {
+                    description "value * (1/1000)";
+                }
             }
             description "none";
         }

--- a/YANG/tapi-odu.yang
+++ b/YANG/tapi-odu.yang
@@ -405,28 +405,28 @@ module tapi-odu {
     **********************/ 
         typedef odu-type {
             type enumeration {
-                enum odu-0 {
+                enum ODU0 {
                     description "none";
                 }
-                enum odu-1 {
+                enum ODU1 {
                     description "none";
                 }
-                enum odu-2 {
+                enum ODU2 {
                     description "none";
                 }
-                enum odu-2-e {
+                enum ODU2E {
                     description "none";
                 }
-                enum odu-3 {
+                enum ODU3 {
                     description "none";
                 }
-                enum odu-4 {
+                enum ODU4 {
                     description "none";
                 }
-                enum odu-flex {
+                enum ODU_FLEX {
                     description "none";
                 }
-                enum odu-cn {
+                enum ODU_CN {
                     description "none";
                 }
             }
@@ -434,22 +434,22 @@ module tapi-odu {
         }
         typedef mapping-type {
             type enumeration {
-                enum amp {
+                enum AMP {
                     description "none";
                 }
-                enum bmp {
+                enum BMP {
                     description "none";
                 }
-                enum gfp-f {
+                enum GFP-F {
                     description "none";
                 }
-                enum gmp {
+                enum GMP {
                     description "none";
                 }
-                enum ttp-gfp-bmp {
+                enum TTP_GFP_BMP {
                     description "none";
                 }
-                enum null {
+                enum NULL {
                     description "none";
                 }
             }
@@ -457,16 +457,16 @@ module tapi-odu {
         }
         typedef tim-det-mo {
             type enumeration {
-                enum dapi {
+                enum DAPI {
                     description "none";
                 }
-                enum sapi {
+                enum SAPI {
                     description "none";
                 }
-                enum both {
+                enum BOTH {
                     description "none";
                 }
-                enum off {
+                enum OFF {
                     description "none";
                 }
             }
@@ -474,10 +474,10 @@ module tapi-odu {
         }
         typedef odu-slot-size {
             type enumeration {
-                enum 1-g-25 {
+                enum 1G25 {
                     description "none";
                 }
-                enum 2-g-5 {
+                enum 2G5 {
                     description "none";
                 }
             }
@@ -496,10 +496,10 @@ module tapi-odu {
         }
         typedef odu-named-payload-type {
             type enumeration {
-                enum unknown {
+                enum UNKNOWN {
                     description "none";
                 }
-                enum uninterpretable {
+                enum UNINTERPRETABLE {
                     description "none";
                 }
             }
@@ -528,10 +528,10 @@ module tapi-odu {
         }
         typedef deg-thr-type {
             type enumeration {
-                enum percentage {
+                enum PERCENTAGE {
                     description "Choice of % or Number of errored blocks";
                 }
-                enum number-errored-blocks {
+                enum NUMBER_ERRORED_BLOCKS {
                     description "Number of % or blocks";
                 }
             }
@@ -539,28 +539,28 @@ module tapi-odu {
         }
         typedef tcm-status {
             type enumeration {
-                enum no-source-tc {
+                enum NO_SOURCE_TC {
                     description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
                 }
-                enum in-use-without-iae {
+                enum IN_USE_WITHOUT_IAE {
                     description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
                 }
-                enum in-use-with-iae {
+                enum IN_USE_WITH_IAE {
                     description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
                 }
-                enum reserved-1 {
+                enum RESERVED_1 {
                     description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
                 }
-                enum reserved-2 {
+                enum RESERVED_2 {
                     description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
                 }
-                enum lck {
+                enum LCK {
                     description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODU-LCK";
                 }
-                enum oci {
+                enum OCI {
                     description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODU-OCI";
                 }
-                enum ais {
+                enum AIS {
                     description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODU-AIS";
                 }
             }
@@ -568,13 +568,13 @@ module tapi-odu {
         }
         typedef tcm-mode {
             type enumeration {
-                enum operational {
+                enum OPERATIONAL {
                     description "none";
                 }
-                enum transparent {
+                enum TRANSPARENT {
                     description "none";
                 }
-                enum monitor {
+                enum MONITOR {
                     description "none";
                 }
             }
@@ -582,10 +582,10 @@ module tapi-odu {
         }
         typedef tcm-monitoring {
             type enumeration {
-                enum intrusive {
+                enum INTRUSIVE {
                     description "none";
                 }
-                enum non-intrusive {
+                enum NON-INTRUSIVE {
                     description "none";
                 }
             }
@@ -593,13 +593,13 @@ module tapi-odu {
         }
         typedef tcm-extension {
             type enumeration {
-                enum normal {
+                enum NORMAL {
                     description "none";
                 }
-                enum pass-through {
+                enum PASS-THROUGH {
                     description "none";
                 }
-                enum erase {
+                enum ERASE {
                     description "none";
                 }
             }
@@ -607,16 +607,16 @@ module tapi-odu {
         }
         typedef percentage-granularity {
             type enumeration {
-                enum ones {
+                enum ONES {
                     description "none";
                 }
-                enum one-tenths {
+                enum ONE_TENTHS {
                     description "value * (1/10)";
                 }
-                enum one-hundredths {
+                enum ONE_HUNDREDTHS {
                     description "value * (1/100)";
                 }
-                enum one-thousandths {
+                enum ONE_THOUSANDTHS {
                     description "value * (1/1000)";
                 }
             }

--- a/YANG/tapi-otsi.tree
+++ b/YANG/tapi-otsi.tree
@@ -1,43 +1,39 @@
 module: tapi-otsi
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point:
-    +--ro otsi-adapter
-    +--ro otsi-termination*
-    |  +--ro selected-nominal-central-frequency
-    |  |  +--ro grid-type?                grid-type
-    |  |  +--ro adjustment-granularity?   adjustment-granularity
-    |  |  +--ro channel-number?           uint64
-    |  +--ro supportable-lower-nominal-central-frequency
-    |  |  +--ro grid-type?                grid-type
-    |  |  +--ro adjustment-granularity?   adjustment-granularity
-    |  |  +--ro channel-number?           uint64
-    |  +--ro supportable-upper-nominal-central-frequency
-    |  |  +--ro grid-type?                grid-type
-    |  |  +--ro adjustment-granularity?   adjustment-granularity
-    |  |  +--ro channel-number?           uint64
-    |  +--ro selected-application-identifier
-    |  |  +--ro application-identifier-type?    application-identifier-type
-    |  |  +--ro application-identifier-value?   string
-    |  +--ro supportable-application-identifier
-    |     +--ro application-identifier-type?    application-identifier-type
-    |     +--ro application-identifier-value?   string
-    +--ro otsi-ctp
-       +--ro selected-frequency-slot*
-          +--ro nominal-central-frequency
-          |  +--ro grid-type?                grid-type
-          |  +--ro adjustment-granularity?   adjustment-granularity
-          |  +--ro channel-number?           uint64
-          +--ro slot-width-number?           uint64
+    +--ro selected-nominal-central-frequency*
+    |  +--ro grid-type?                grid-type
+    |  +--ro adjustment-granularity?   adjustment-granularity
+    |  +--ro channel-number?           uint64
+    +--ro supportable-lower-nominal-central-frequency*
+    |  +--ro grid-type?                grid-type
+    |  +--ro adjustment-granularity?   adjustment-granularity
+    |  +--ro channel-number?           uint64
+    +--ro supportable-upper-nominal-central-frequency*
+    |  +--ro grid-type?                grid-type
+    |  +--ro adjustment-granularity?   adjustment-granularity
+    |  +--ro channel-number?           uint64
+    +--ro selected-application-identifier*
+    |  +--ro application-identifier-type?    application-identifier-type
+    |  +--ro application-identifier-value?   string
+    +--ro supportable-application-identifier*
+    |  +--ro application-identifier-type?    application-identifier-type
+    |  +--ro application-identifier-value?   string
+    +--ro selected-frequency-slot*
+       +--ro nominal-central-frequency
+       |  +--ro grid-type?                grid-type
+       |  +--ro adjustment-granularity?   adjustment-granularity
+       |  +--ro channel-number?           uint64
+       +--ro slot-width-number?           uint64
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
-    +--ro otsi-pool
-       +--ro available-frequency-slot*
-       |  +--ro nominal-central-frequency
-       |  |  +--ro grid-type?                grid-type
-       |  |  +--ro adjustment-granularity?   adjustment-granularity
-       |  |  +--ro channel-number?           uint64
-       |  +--ro slot-width-number?           uint64
-       +--ro occupied-frequency-slot*
-          +--ro nominal-central-frequency
-          |  +--ro grid-type?                grid-type
-          |  +--ro adjustment-granularity?   adjustment-granularity
-          |  +--ro channel-number?           uint64
-          +--ro slot-width-number?           uint64
+    +--ro available-frequency-slot*
+    |  +--ro nominal-central-frequency
+    |  |  +--ro grid-type?                grid-type
+    |  |  +--ro adjustment-granularity?   adjustment-granularity
+    |  |  +--ro channel-number?           uint64
+    |  +--ro slot-width-number?           uint64
+    +--ro occupied-frequency-slot*
+       +--ro nominal-central-frequency
+       |  +--ro grid-type?                grid-type
+       |  +--ro adjustment-granularity?   adjustment-granularity
+       |  +--ro channel-number?           uint64
+       +--ro slot-width-number?           uint64

--- a/YANG/tapi-otsi.yang
+++ b/YANG/tapi-otsi.yang
@@ -156,19 +156,19 @@ module tapi-otsi {
         }
         typedef optical-routing-strategy {
             type enumeration {
-                enum optimal-osnr {
+                enum OPTIMAL_OSNR {
                     description "none";
                 }
-                enum no-relay {
+                enum NO_RELAY {
                     description "none";
                 }
-                enum min-relay {
+                enum MIN_RELAY {
                     description "none";
                 }
-                enum preferred-no-change-wavelength-as-restore {
+                enum PREFERRED_NO_CHANGE_WAVELENGTH_AS_RESTORE {
                     description "none";
                 }
-                enum preferred-no-skipping-wavelength {
+                enum PREFERRED_NO_SKIPPING_WAVELENGTH {
                     description "none";
                 }
             }
@@ -176,22 +176,22 @@ module tapi-otsi {
         }
         typedef application-identifier-type {
             type enumeration {
-                enum proprietary {
+                enum PROPRIETARY {
                     description "none";
                 }
-                enum itut-g-959-1 {
+                enum ITUT_G959_1 {
                     description "none";
                 }
-                enum itut-g-698-1 {
+                enum ITUT_G698_1 {
                     description "none";
                 }
-                enum itut-g-698-2 {
+                enum ITUT_G698_2 {
                     description "none";
                 }
-                enum itut-g-696-1 {
+                enum ITUT_G696_1 {
                     description "none";
                 }
-                enum itut-g-695 {
+                enum ITUT_G695 {
                     description "none";
                 }
             }
@@ -199,14 +199,14 @@ module tapi-otsi {
         }
         typedef grid-type {
             type enumeration {
-                enum dwdm {
+                enum DWDM {
                     description "Fixed frequency grid in C & L bands as specified in ITU-T G.694.1
                         ";
                 }
-                enum cwdm {
+                enum CWDM {
                     description "Fixed frequency grid as specified in ITU-T G.694.2";
                 }
-                enum flex {
+                enum FLEX {
                     description "Flexible frequency grid as specified in ITU-T G.694.1. In this case,
                         - the allowed frequency slots have a nominal central frequency (in THz) defined by:
                         193.1 + n × 0.00625 where n is a positive or negative integer including 0 and 0.00625 is the nominal central frequency granularity in THz
@@ -214,7 +214,7 @@ module tapi-otsi {
                         12.5 × m where m is a positive integer and 12.5 is the slot width granularity in GHz.
                         Any combination of frequency slots is allowed as long as no two frequency slots overlap.";
                 }
-                enum unspecified {
+                enum UNSPECIFIED {
                     description "Unspecified/proprietary frequency grid";
                 }
             }
@@ -222,19 +222,19 @@ module tapi-otsi {
         }
         typedef adjustment-granularity {
             type enumeration {
-                enum g-100-ghz {
+                enum G_100GHZ {
                     description "0.1 THz";
                 }
-                enum g-50-ghz {
+                enum G_50GHZ {
                     description "0.05 THz";
                 }
-                enum g-25-ghz {
+                enum G_25GHZ {
                     description "0.025 THz";
                 }
-                enum g-12-5-ghz {
+                enum G_12_5GHZ {
                     description "0.0125 THz";
                 }
-                enum g-6-25-ghz {
+                enum G_6_25GHZ {
                     description "0.00625 THz";
                 }
             }

--- a/YANG/tapi-otsi.yang
+++ b/YANG/tapi-otsi.yang
@@ -36,45 +36,35 @@ module tapi-otsi {
             description "none";
         }
         grouping otsi-connection-end-point-spec {
-            container otsi-adapter {
-                config false;
-                uses otsi-a-client-adaptation-pac;
-                description "none";
-            }
-            list otsi-termination {
-                config false;
-                uses otsi-termination-pac;
-                description "none";
-            }
-            container otsi-ctp {
-                config false;
-                uses otsi-g-ctp-pac;
-                description "none";
-            }
+            uses tapi-otsi:otsi-a-client-adaptation-pac;
+            uses tapi-otsi:otsi-termination-pac;
+            uses tapi-otsi:otsi-g-ctp-pac;
             description "none";
         }
         grouping otsi-termination-pac {
-            container selected-nominal-central-frequency {
+            list selected-nominal-central-frequency {
+                config false;
                 uses nominal-central-frequency-or-wavelength;
                 description "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.
                     This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.
                     ";
             }
-            container supportable-lower-nominal-central-frequency {
+            list supportable-lower-nominal-central-frequency {
                 config false;
                 uses nominal-central-frequency-or-wavelength;
                 description "none";
             }
-            container supportable-upper-nominal-central-frequency {
+            list supportable-upper-nominal-central-frequency {
                 config false;
                 uses nominal-central-frequency-or-wavelength;
                 description "none";
             }
-            container selected-application-identifier {
+            list selected-application-identifier {
+                config false;
                 uses application-identifier;
                 description "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.";
             }
-            container supportable-application-identifier {
+            list supportable-application-identifier {
                 config false;
                 uses application-identifier;
                 description "none";
@@ -95,11 +85,7 @@ module tapi-otsi {
             description "none";
         }
         grouping otsi-node-edge-point-spec {
-            container otsi-pool {
-                config false;
-                uses otsi-a-pool-pac;
-                description "none";
-            }
+            uses tapi-otsi:otsi-a-pool-pac;
             description "none";
         }
         grouping otsi-routing-spec {
@@ -111,6 +97,7 @@ module tapi-otsi {
         }
         grouping otsi-g-ctp-pac {
             list selected-frequency-slot {
+                config false;
                 uses frequency-slot;
                 description "none";
             }

--- a/YANG/tapi-otsi.yang
+++ b/YANG/tapi-otsi.yang
@@ -123,81 +123,6 @@ module tapi-otsi {
     /***********************
     * package type-definitions
     **********************/ 
-        identity application-identifier-type {
-            description "none";
-        }
-        identity proprietary {
-            base application-identifier-type;
-            description "none";
-        }
-        identity itut-g-959-1 {
-            base application-identifier-type;
-            description "none";
-        }
-        identity itut-g-698-1 {
-            base application-identifier-type;
-            description "none";
-        }
-        identity itut-g-698-2 {
-            base application-identifier-type;
-            description "none";
-        }
-        identity itut-g-696-1 {
-            base application-identifier-type;
-            description "none";
-        }
-        identity itut-g-695 {
-            base application-identifier-type;
-            description "none";
-        }
-        identity grid-type {
-            description "none";
-        }
-        identity dwdm {
-            base grid-type;
-            description "Fixed frequency grid in C & L bands as specified in ITU-T G.694.1
-                ";
-        }
-        identity cwdm {
-            base grid-type;
-            description "Fixed frequency grid as specified in ITU-T G.694.2";
-        }
-        identity flex {
-            base grid-type;
-            description "Flexible frequency grid as specified in ITU-T G.694.1. In this case,
-                - the allowed frequency slots have a nominal central frequency (in THz) defined by:
-                193.1 + n × 0.00625 where n is a positive or negative integer including 0 and 0.00625 is the nominal central frequency granularity in THz
-                - and a slot width defined by:
-                12.5 × m where m is a positive integer and 12.5 is the slot width granularity in GHz.
-                Any combination of frequency slots is allowed as long as no two frequency slots overlap.";
-        }
-        identity unspecified {
-            base grid-type;
-            description "Unspecified/proprietary frequency grid";
-        }
-        identity adjustment-granularity {
-            description "none";
-        }
-        identity g-100-ghz {
-            base adjustment-granularity;
-            description "0.1 THz";
-        }
-        identity g-50-ghz {
-            base adjustment-granularity;
-            description "0.05 THz";
-        }
-        identity g-25-ghz {
-            base adjustment-granularity;
-            description "0.025 THz";
-        }
-        identity g-12-5-ghz {
-            base adjustment-granularity;
-            description "0.0125 THz";
-        }
-        identity g-6-25-ghz {
-            base adjustment-granularity;
-            description "0.00625 THz";
-        }
         grouping application-identifier {
             leaf application-identifier-type {
                 type application-identifier-type;
@@ -250,20 +175,68 @@ module tapi-otsi {
             description "none";
         }
         typedef application-identifier-type {
-            type identityref {
-                base application-identifier-type;
+            type enumeration {
+                enum proprietary {
+                    description "none";
+                }
+                enum itut-g-959-1 {
+                    description "none";
+                }
+                enum itut-g-698-1 {
+                    description "none";
+                }
+                enum itut-g-698-2 {
+                    description "none";
+                }
+                enum itut-g-696-1 {
+                    description "none";
+                }
+                enum itut-g-695 {
+                    description "none";
+                }
             }
             description "none";
         }
         typedef grid-type {
-            type identityref {
-                base grid-type;
+            type enumeration {
+                enum dwdm {
+                    description "Fixed frequency grid in C & L bands as specified in ITU-T G.694.1
+                        ";
+                }
+                enum cwdm {
+                    description "Fixed frequency grid as specified in ITU-T G.694.2";
+                }
+                enum flex {
+                    description "Flexible frequency grid as specified in ITU-T G.694.1. In this case,
+                        - the allowed frequency slots have a nominal central frequency (in THz) defined by:
+                        193.1 + n × 0.00625 where n is a positive or negative integer including 0 and 0.00625 is the nominal central frequency granularity in THz
+                        - and a slot width defined by:
+                        12.5 × m where m is a positive integer and 12.5 is the slot width granularity in GHz.
+                        Any combination of frequency slots is allowed as long as no two frequency slots overlap.";
+                }
+                enum unspecified {
+                    description "Unspecified/proprietary frequency grid";
+                }
             }
             description "The frequency grid standard that specify reference set of frequencies used to denote allowed nominal central frequencies that may be used for defining applications.";
         }
         typedef adjustment-granularity {
-            type identityref {
-                base adjustment-granularity;
+            type enumeration {
+                enum g-100-ghz {
+                    description "0.1 THz";
+                }
+                enum g-50-ghz {
+                    description "0.05 THz";
+                }
+                enum g-25-ghz {
+                    description "0.025 THz";
+                }
+                enum g-12-5-ghz {
+                    description "0.0125 THz";
+                }
+                enum g-6-25-ghz {
+                    description "0.00625 THz";
+                }
             }
             description "Adjustment granularity in Gigahertz. As per ITU-T G.694.1, it is used to calculate nominal central frequency (in THz)";
         }

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -12,20 +12,18 @@ module: tapi-topology
        |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
        |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
-       |  |  +--ro state
-       |  |  |  +--ro administrative-state?   administrative-state
-       |  |  |  +--ro operational-state?      operational-state
-       |  |  |  +--ro lifecycle-state?        lifecycle-state
-       |  |  +--ro termination
-       |  |  |  +--ro termination-direction?   termination-direction
-       |  |  |  +--ro termination-state?       termination-state
        |  |  +--ro link-port-direction?              tapi-common:port-direction
        |  |  +--ro link-port-role?                   tapi-common:port-role
        |  |  +--ro uuid                              uuid
        |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
+       |  |  +--ro administrative-state?             administrative-state
+       |  |  +--ro operational-state?                operational-state
+       |  |  +--ro lifecycle-state?                  lifecycle-state
+       |  |  +--ro termination-direction?            termination-direction
+       |  |  +--ro termination-state?                termination-state
+       |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
        |  +--ro node-rule-group* [uuid]
        |  |  +--ro rule* [local-id]
        |  |  |  +--ro rule-type?           rule-type
@@ -35,8 +33,8 @@ module: tapi-topology
        |  |  |  +--ro name* [value-name]
        |  |  |     +--ro value-name    string
        |  |  |     +--ro value?        string
-       |  |  +--ro node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  |  +--ro node-rule-group*     -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+       |  |  +--ro node-edge-point*            -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+       |  |  +--ro node-rule-group*            -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
        |  |  +--ro inter-rule-group* [uuid]
        |  |  |  +--ro rule* [local-id]
        |  |  |  |  +--ro rule-type?           rule-type
@@ -47,68 +45,10 @@ module: tapi-topology
        |  |  |  |     +--ro value-name    string
        |  |  |  |     +--ro value?        string
        |  |  |  +--ro associated-node-rule-group*   -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-       |  |  |  +--ro transfer-capacity
-       |  |  |  |  +--ro total-potential-capacity
-       |  |  |  |  |  +--ro total-size
-       |  |  |  |  |  |  +--ro value?   uint64
-       |  |  |  |  |  |  +--ro unit?    capacity-unit
-       |  |  |  |  |  +--ro bandwidth-profile
-       |  |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |  |  |     +--ro committed-information-rate
-       |  |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |  |     +--ro committed-burst-size
-       |  |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |  |     +--ro peak-information-rate
-       |  |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |  |     +--ro peak-burst-size
-       |  |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |  |     +--ro color-aware?                  boolean
-       |  |  |  |  |     +--ro coupling-flag?                boolean
-       |  |  |  |  +--ro available-capacity
-       |  |  |  |     +--ro total-size
-       |  |  |  |     |  +--ro value?   uint64
-       |  |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |  |     +--ro bandwidth-profile
-       |  |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |  |        +--ro committed-information-rate
-       |  |  |  |        |  +--ro value?   uint64
-       |  |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |  |        +--ro committed-burst-size
-       |  |  |  |        |  +--ro value?   uint64
-       |  |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |  |        +--ro peak-information-rate
-       |  |  |  |        |  +--ro value?   uint64
-       |  |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |  |        +--ro peak-burst-size
-       |  |  |  |        |  +--ro value?   uint64
-       |  |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |  |        +--ro color-aware?                  boolean
-       |  |  |  |        +--ro coupling-flag?                boolean
-       |  |  |  +--ro transfer-cost
-       |  |  |  |  +--ro cost-characteristic* [cost-name]
-       |  |  |  |     +--ro cost-name         string
-       |  |  |  |     +--ro cost-value?       string
-       |  |  |  |     +--ro cost-algorithm?   string
-       |  |  |  +--ro transfer-timing
-       |  |  |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  |  |     +--ro traffic-property-name            string
-       |  |  |  |     +--ro fixed-latency-characteristic?    string
-       |  |  |  |     +--ro queing-latency-characteristic?   string
-       |  |  |  |     +--ro jitter-characteristic?           string
-       |  |  |  |     +--ro wander-characteristic?           string
-       |  |  |  +--ro risk-parameter
-       |  |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
-       |  |  |  |     +--ro risk-characteristic-name    string
-       |  |  |  |     +--ro risk-identifier-list*       string
        |  |  |  +--ro uuid                          uuid
        |  |  |  +--ro name* [value-name]
-       |  |  |     +--ro value-name    string
-       |  |  |     +--ro value?        string
-       |  |  +--ro transfer-capacity
+       |  |  |  |  +--ro value-name    string
+       |  |  |  |  +--ro value?        string
        |  |  |  +--ro total-potential-capacity
        |  |  |  |  +--ro total-size
        |  |  |  |  |  +--ro value?   uint64
@@ -130,51 +70,42 @@ module: tapi-topology
        |  |  |  |     +--ro color-aware?                  boolean
        |  |  |  |     +--ro coupling-flag?                boolean
        |  |  |  +--ro available-capacity
-       |  |  |     +--ro total-size
-       |  |  |     |  +--ro value?   uint64
-       |  |  |     |  +--ro unit?    capacity-unit
-       |  |  |     +--ro bandwidth-profile
-       |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |  |        +--ro committed-information-rate
-       |  |  |        |  +--ro value?   uint64
-       |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |        +--ro committed-burst-size
-       |  |  |        |  +--ro value?   uint64
-       |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |        +--ro peak-information-rate
-       |  |  |        |  +--ro value?   uint64
-       |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |        +--ro peak-burst-size
-       |  |  |        |  +--ro value?   uint64
-       |  |  |        |  +--ro unit?    capacity-unit
-       |  |  |        +--ro color-aware?                  boolean
-       |  |  |        +--ro coupling-flag?                boolean
-       |  |  +--ro transfer-cost
+       |  |  |  |  +--ro total-size
+       |  |  |  |  |  +--ro value?   uint64
+       |  |  |  |  |  +--ro unit?    capacity-unit
+       |  |  |  |  +--ro bandwidth-profile
+       |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |  |  |     +--ro committed-information-rate
+       |  |  |  |     |  +--ro value?   uint64
+       |  |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |  |     +--ro committed-burst-size
+       |  |  |  |     |  +--ro value?   uint64
+       |  |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |  |     +--ro peak-information-rate
+       |  |  |  |     |  +--ro value?   uint64
+       |  |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |  |     +--ro peak-burst-size
+       |  |  |  |     |  +--ro value?   uint64
+       |  |  |  |     |  +--ro unit?    capacity-unit
+       |  |  |  |     +--ro color-aware?                  boolean
+       |  |  |  |     +--ro coupling-flag?                boolean
        |  |  |  +--ro cost-characteristic* [cost-name]
-       |  |  |     +--ro cost-name         string
-       |  |  |     +--ro cost-value?       string
-       |  |  |     +--ro cost-algorithm?   string
-       |  |  +--ro transfer-timing
+       |  |  |  |  +--ro cost-name         string
+       |  |  |  |  +--ro cost-value?       string
+       |  |  |  |  +--ro cost-algorithm?   string
        |  |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |  |     +--ro traffic-property-name            string
-       |  |  |     +--ro fixed-latency-characteristic?    string
-       |  |  |     +--ro queing-latency-characteristic?   string
-       |  |  |     +--ro jitter-characteristic?           string
-       |  |  |     +--ro wander-characteristic?           string
-       |  |  +--ro risk-parameter
+       |  |  |  |  +--ro traffic-property-name            string
+       |  |  |  |  +--ro fixed-latency-characteristic?    string
+       |  |  |  |  +--ro queing-latency-characteristic?   string
+       |  |  |  |  +--ro jitter-characteristic?           string
+       |  |  |  |  +--ro wander-characteristic?           string
        |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
        |  |  |     +--ro risk-characteristic-name    string
        |  |  |     +--ro risk-identifier-list*       string
-       |  |  +--ro uuid                 uuid
+       |  |  +--ro uuid                        uuid
        |  |  +--ro name* [value-name]
-       |  |     +--ro value-name    string
-       |  |     +--ro value?        string
-       |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-       |  +--ro state
-       |  |  +--ro administrative-state?   administrative-state
-       |  |  +--ro operational-state?      operational-state
-       |  |  +--ro lifecycle-state?        lifecycle-state
-       |  +--ro transfer-capacity
+       |  |  |  +--ro value-name    string
+       |  |  |  +--ro value?        string
        |  |  +--ro total-potential-capacity
        |  |  |  +--ro total-size
        |  |  |  |  +--ro value?   uint64
@@ -196,58 +127,6 @@ module: tapi-topology
        |  |  |     +--ro color-aware?                  boolean
        |  |  |     +--ro coupling-flag?                boolean
        |  |  +--ro available-capacity
-       |  |     +--ro total-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro bandwidth-profile
-       |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |        +--ro committed-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro committed-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro color-aware?                  boolean
-       |  |        +--ro coupling-flag?                boolean
-       |  +--ro transfer-cost
-       |  |  +--ro cost-characteristic* [cost-name]
-       |  |     +--ro cost-name         string
-       |  |     +--ro cost-value?       string
-       |  |     +--ro cost-algorithm?   string
-       |  +--ro transfer-integrity
-       |  |  +--ro error-characteristic?                      string
-       |  |  +--ro loss-characteristic?                       string
-       |  |  +--ro repeat-delivery-characteristic?            string
-       |  |  +--ro delivery-order-characteristic?             string
-       |  |  +--ro unavailable-time-characteristic?           string
-       |  |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro transfer-timing
-       |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |     +--ro traffic-property-name            string
-       |  |     +--ro fixed-latency-characteristic?    string
-       |  |     +--ro queing-latency-characteristic?   string
-       |  |     +--ro jitter-characteristic?           string
-       |  |     +--ro wander-characteristic?           string
-       |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-       |  +--ro uuid                          uuid
-       |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
-       +--ro link* [uuid]
-       |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-       |  +--ro state
-       |  |  +--ro administrative-state?   administrative-state
-       |  |  +--ro operational-state?      operational-state
-       |  |  +--ro lifecycle-state?        lifecycle-state
-       |  +--ro transfer-capacity
-       |  |  +--ro total-potential-capacity
        |  |  |  +--ro total-size
        |  |  |  |  +--ro value?   uint64
        |  |  |  |  +--ro unit?    capacity-unit
@@ -267,65 +146,163 @@ module: tapi-topology
        |  |  |     |  +--ro unit?    capacity-unit
        |  |  |     +--ro color-aware?                  boolean
        |  |  |     +--ro coupling-flag?                boolean
-       |  |  +--ro available-capacity
-       |  |     +--ro total-size
-       |  |     |  +--ro value?   uint64
-       |  |     |  +--ro unit?    capacity-unit
-       |  |     +--ro bandwidth-profile
-       |  |        +--ro bw-profile-type?              bandwidth-profile-type
-       |  |        +--ro committed-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro committed-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-information-rate
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro peak-burst-size
-       |  |        |  +--ro value?   uint64
-       |  |        |  +--ro unit?    capacity-unit
-       |  |        +--ro color-aware?                  boolean
-       |  |        +--ro coupling-flag?                boolean
-       |  +--ro transfer-cost
        |  |  +--ro cost-characteristic* [cost-name]
-       |  |     +--ro cost-name         string
-       |  |     +--ro cost-value?       string
-       |  |     +--ro cost-algorithm?   string
-       |  +--ro transfer-integrity
-       |  |  +--ro error-characteristic?                      string
-       |  |  +--ro loss-characteristic?                       string
-       |  |  +--ro repeat-delivery-characteristic?            string
-       |  |  +--ro delivery-order-characteristic?             string
-       |  |  +--ro unavailable-time-characteristic?           string
-       |  |  +--ro server-integrity-process-characteristic?   string
-       |  +--ro transfer-timing
+       |  |  |  +--ro cost-name         string
+       |  |  |  +--ro cost-value?       string
+       |  |  |  +--ro cost-algorithm?   string
        |  |  +--ro latency-characteristic* [traffic-property-name]
-       |  |     +--ro traffic-property-name            string
-       |  |     +--ro fixed-latency-characteristic?    string
-       |  |     +--ro queing-latency-characteristic?   string
-       |  |     +--ro jitter-characteristic?           string
-       |  |     +--ro wander-characteristic?           string
-       |  +--ro risk-parameter
+       |  |  |  +--ro traffic-property-name            string
+       |  |  |  +--ro fixed-latency-characteristic?    string
+       |  |  |  +--ro queing-latency-characteristic?   string
+       |  |  |  +--ro jitter-characteristic?           string
+       |  |  |  +--ro wander-characteristic?           string
        |  |  +--ro risk-characteristic* [risk-characteristic-name]
        |  |     +--ro risk-characteristic-name    string
        |  |     +--ro risk-identifier-list*       string
-       |  +--ro validation
-       |  |  +--ro validation-mechanism* [validation-mechanism]
-       |  |     +--ro validation-mechanism                  string
-       |  |     +--ro layer-protocol-adjacency-validated?   string
-       |  |     +--ro validation-robustness?                string
-       |  +--ro lp-transition
-       |  |  +--ro transitioned-layer-protocol-name*   string
-       |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-       |  +--ro direction?             tapi-common:forwarding-direction
+       |  +--ro encap-topology?                            -> /tapi-common:context/tapi-topology:topology/uuid
+       |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+       |  +--ro uuid                                       uuid
+       |  +--ro name* [value-name]
+       |  |  +--ro value-name    string
+       |  |  +--ro value?        string
+       |  +--ro administrative-state?                      administrative-state
+       |  +--ro operational-state?                         operational-state
+       |  +--ro lifecycle-state?                           lifecycle-state
+       |  +--ro total-potential-capacity
+       |  |  +--ro total-size
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    capacity-unit
+       |  |  +--ro bandwidth-profile
+       |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |     +--ro committed-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro committed-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
+       |  +--ro available-capacity
+       |  |  +--ro total-size
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    capacity-unit
+       |  |  +--ro bandwidth-profile
+       |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |     +--ro committed-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro committed-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
+       |  +--ro cost-characteristic* [cost-name]
+       |  |  +--ro cost-name         string
+       |  |  +--ro cost-value?       string
+       |  |  +--ro cost-algorithm?   string
+       |  +--ro error-characteristic?                      string
+       |  +--ro loss-characteristic?                       string
+       |  +--ro repeat-delivery-characteristic?            string
+       |  +--ro delivery-order-characteristic?             string
+       |  +--ro unavailable-time-characteristic?           string
+       |  +--ro server-integrity-process-characteristic?   string
+       |  +--ro latency-characteristic* [traffic-property-name]
+       |     +--ro traffic-property-name            string
+       |     +--ro fixed-latency-characteristic?    string
+       |     +--ro queing-latency-characteristic?   string
+       |     +--ro jitter-characteristic?           string
+       |     +--ro wander-characteristic?           string
+       +--ro link* [uuid]
+       |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+       |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
+       |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+       |  +--ro direction?                                 tapi-common:forwarding-direction
        |  +--ro resilience-type
        |  |  +--ro restoration-policy?   restoration-policy
        |  |  +--ro protection-type?      protection-type
-       |  +--ro uuid                   uuid
+       |  +--ro uuid                                       uuid
        |  +--ro name* [value-name]
-       |     +--ro value-name    string
-       |     +--ro value?        string
+       |  |  +--ro value-name    string
+       |  |  +--ro value?        string
+       |  +--ro administrative-state?                      administrative-state
+       |  +--ro operational-state?                         operational-state
+       |  +--ro lifecycle-state?                           lifecycle-state
+       |  +--ro total-potential-capacity
+       |  |  +--ro total-size
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    capacity-unit
+       |  |  +--ro bandwidth-profile
+       |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |     +--ro committed-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro committed-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
+       |  +--ro available-capacity
+       |  |  +--ro total-size
+       |  |  |  +--ro value?   uint64
+       |  |  |  +--ro unit?    capacity-unit
+       |  |  +--ro bandwidth-profile
+       |  |     +--ro bw-profile-type?              bandwidth-profile-type
+       |  |     +--ro committed-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro committed-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-information-rate
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro peak-burst-size
+       |  |     |  +--ro value?   uint64
+       |  |     |  +--ro unit?    capacity-unit
+       |  |     +--ro color-aware?                  boolean
+       |  |     +--ro coupling-flag?                boolean
+       |  +--ro cost-characteristic* [cost-name]
+       |  |  +--ro cost-name         string
+       |  |  +--ro cost-value?       string
+       |  |  +--ro cost-algorithm?   string
+       |  +--ro error-characteristic?                      string
+       |  +--ro loss-characteristic?                       string
+       |  +--ro repeat-delivery-characteristic?            string
+       |  +--ro delivery-order-characteristic?             string
+       |  +--ro unavailable-time-characteristic?           string
+       |  +--ro server-integrity-process-characteristic?   string
+       |  +--ro latency-characteristic* [traffic-property-name]
+       |  |  +--ro traffic-property-name            string
+       |  |  +--ro fixed-latency-characteristic?    string
+       |  |  +--ro queing-latency-characteristic?   string
+       |  |  +--ro jitter-characteristic?           string
+       |  |  +--ro wander-characteristic?           string
+       |  +--ro risk-characteristic* [risk-characteristic-name]
+       |  |  +--ro risk-characteristic-name    string
+       |  |  +--ro risk-identifier-list*       string
+       |  +--ro validation-mechanism* [validation-mechanism]
+       |  |  +--ro validation-mechanism                  string
+       |  |  +--ro layer-protocol-adjacency-validated?   string
+       |  |  +--ro validation-robustness?                string
+       |  +--ro transitioned-layer-protocol-name*          string
        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
        +--ro uuid                   uuid
        +--ro name* [value-name]
@@ -343,20 +320,18 @@ module: tapi-topology
     |        |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
-    |        |  |  +--ro state
-    |        |  |  |  +--ro administrative-state?   administrative-state
-    |        |  |  |  +--ro operational-state?      operational-state
-    |        |  |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  |  +--ro termination
-    |        |  |  |  +--ro termination-direction?   termination-direction
-    |        |  |  |  +--ro termination-state?       termination-state
     |        |  |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  |  +--ro link-port-role?                   tapi-common:port-role
     |        |  |  +--ro uuid                              uuid
     |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  |  +--ro value-name    string
+    |        |  |  |  +--ro value?        string
+    |        |  |  +--ro administrative-state?             administrative-state
+    |        |  |  +--ro operational-state?                operational-state
+    |        |  |  +--ro lifecycle-state?                  lifecycle-state
+    |        |  |  +--ro termination-direction?            termination-direction
+    |        |  |  +--ro termination-state?                termination-state
+    |        |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  +--ro node-rule-group* [uuid]
     |        |  |  +--ro rule* [local-id]
     |        |  |  |  +--ro rule-type?           rule-type
@@ -366,8 +341,8 @@ module: tapi-topology
     |        |  |  |  +--ro name* [value-name]
     |        |  |  |     +--ro value-name    string
     |        |  |  |     +--ro value?        string
-    |        |  |  +--ro node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  |  +--ro node-rule-group*     -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  |  +--ro node-edge-point*            -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro node-rule-group*            -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
     |        |  |  +--ro inter-rule-group* [uuid]
     |        |  |  |  +--ro rule* [local-id]
     |        |  |  |  |  +--ro rule-type?           rule-type
@@ -378,68 +353,10 @@ module: tapi-topology
     |        |  |  |  |     +--ro value-name    string
     |        |  |  |  |     +--ro value?        string
     |        |  |  |  +--ro associated-node-rule-group*   -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-    |        |  |  |  +--ro transfer-capacity
-    |        |  |  |  |  +--ro total-potential-capacity
-    |        |  |  |  |  |  +--ro total-size
-    |        |  |  |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  |  |  +--ro bandwidth-profile
-    |        |  |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |  |  |     +--ro committed-information-rate
-    |        |  |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |  |     +--ro committed-burst-size
-    |        |  |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |  |     +--ro peak-information-rate
-    |        |  |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |  |     +--ro peak-burst-size
-    |        |  |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  |  |  +--ro available-capacity
-    |        |  |  |  |     +--ro total-size
-    |        |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |     +--ro bandwidth-profile
-    |        |  |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |  |        +--ro committed-information-rate
-    |        |  |  |  |        |  +--ro value?   uint64
-    |        |  |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |  |        +--ro committed-burst-size
-    |        |  |  |  |        |  +--ro value?   uint64
-    |        |  |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |  |        +--ro peak-information-rate
-    |        |  |  |  |        |  +--ro value?   uint64
-    |        |  |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |  |        +--ro peak-burst-size
-    |        |  |  |  |        |  +--ro value?   uint64
-    |        |  |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |  |        +--ro color-aware?                  boolean
-    |        |  |  |  |        +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro transfer-cost
-    |        |  |  |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |  |  |     +--ro cost-name         string
-    |        |  |  |  |     +--ro cost-value?       string
-    |        |  |  |  |     +--ro cost-algorithm?   string
-    |        |  |  |  +--ro transfer-timing
-    |        |  |  |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  |  |     +--ro traffic-property-name            string
-    |        |  |  |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |  |  |     +--ro queing-latency-characteristic?   string
-    |        |  |  |  |     +--ro jitter-characteristic?           string
-    |        |  |  |  |     +--ro wander-characteristic?           string
-    |        |  |  |  +--ro risk-parameter
-    |        |  |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
-    |        |  |  |  |     +--ro risk-characteristic-name    string
-    |        |  |  |  |     +--ro risk-identifier-list*       string
     |        |  |  |  +--ro uuid                          uuid
     |        |  |  |  +--ro name* [value-name]
-    |        |  |  |     +--ro value-name    string
-    |        |  |  |     +--ro value?        string
-    |        |  |  +--ro transfer-capacity
+    |        |  |  |  |  +--ro value-name    string
+    |        |  |  |  |  +--ro value?        string
     |        |  |  |  +--ro total-potential-capacity
     |        |  |  |  |  +--ro total-size
     |        |  |  |  |  |  +--ro value?   uint64
@@ -461,51 +378,42 @@ module: tapi-topology
     |        |  |  |  |     +--ro color-aware?                  boolean
     |        |  |  |  |     +--ro coupling-flag?                boolean
     |        |  |  |  +--ro available-capacity
-    |        |  |  |     +--ro total-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro bandwidth-profile
-    |        |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |        +--ro committed-information-rate
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro committed-burst-size
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro peak-information-rate
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro peak-burst-size
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro color-aware?                  boolean
-    |        |  |  |        +--ro coupling-flag?                boolean
-    |        |  |  +--ro transfer-cost
+    |        |  |  |  |  +--ro total-size
+    |        |  |  |  |  |  +--ro value?   uint64
+    |        |  |  |  |  |  +--ro unit?    capacity-unit
+    |        |  |  |  |  +--ro bandwidth-profile
+    |        |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |  |  |     +--ro committed-information-rate
+    |        |  |  |  |     |  +--ro value?   uint64
+    |        |  |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |  |     +--ro committed-burst-size
+    |        |  |  |  |     |  +--ro value?   uint64
+    |        |  |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |  |     +--ro peak-information-rate
+    |        |  |  |  |     |  +--ro value?   uint64
+    |        |  |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |  |     +--ro peak-burst-size
+    |        |  |  |  |     |  +--ro value?   uint64
+    |        |  |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |  |     +--ro coupling-flag?                boolean
     |        |  |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |  |     +--ro cost-name         string
-    |        |  |  |     +--ro cost-value?       string
-    |        |  |  |     +--ro cost-algorithm?   string
-    |        |  |  +--ro transfer-timing
+    |        |  |  |  |  +--ro cost-name         string
+    |        |  |  |  |  +--ro cost-value?       string
+    |        |  |  |  |  +--ro cost-algorithm?   string
     |        |  |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  |     +--ro traffic-property-name            string
-    |        |  |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |  |     +--ro queing-latency-characteristic?   string
-    |        |  |  |     +--ro jitter-characteristic?           string
-    |        |  |  |     +--ro wander-characteristic?           string
-    |        |  |  +--ro risk-parameter
+    |        |  |  |  |  +--ro traffic-property-name            string
+    |        |  |  |  |  +--ro fixed-latency-characteristic?    string
+    |        |  |  |  |  +--ro queing-latency-characteristic?   string
+    |        |  |  |  |  +--ro jitter-characteristic?           string
+    |        |  |  |  |  +--ro wander-characteristic?           string
     |        |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
     |        |  |  |     +--ro risk-characteristic-name    string
     |        |  |  |     +--ro risk-identifier-list*       string
-    |        |  |  +--ro uuid                 uuid
+    |        |  |  +--ro uuid                        uuid
     |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro transfer-capacity
+    |        |  |  |  +--ro value-name    string
+    |        |  |  |  +--ro value?        string
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
     |        |  |  |  |  +--ro value?   uint64
@@ -527,58 +435,6 @@ module: tapi-topology
     |        |  |  |     +--ro color-aware?                  boolean
     |        |  |  |     +--ro coupling-flag?                boolean
     |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
-    |        |  +--ro transfer-cost
-    |        |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |     +--ro cost-name         string
-    |        |  |     +--ro cost-value?       string
-    |        |  |     +--ro cost-algorithm?   string
-    |        |  +--ro transfer-integrity
-    |        |  |  +--ro error-characteristic?                      string
-    |        |  |  +--ro loss-characteristic?                       string
-    |        |  |  +--ro repeat-delivery-characteristic?            string
-    |        |  |  +--ro delivery-order-characteristic?             string
-    |        |  |  +--ro unavailable-time-characteristic?           string
-    |        |  |  +--ro server-integrity-process-characteristic?   string
-    |        |  +--ro transfer-timing
-    |        |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |     +--ro traffic-property-name            string
-    |        |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |     +--ro queing-latency-characteristic?   string
-    |        |  |     +--ro jitter-characteristic?           string
-    |        |  |     +--ro wander-characteristic?           string
-    |        |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-    |        |  +--ro uuid                          uuid
-    |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro link* [uuid]
-    |        |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro transfer-capacity
-    |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
     |        |  |  |  |  +--ro value?   uint64
     |        |  |  |  |  +--ro unit?    capacity-unit
@@ -598,65 +454,163 @@ module: tapi-topology
     |        |  |  |     |  +--ro unit?    capacity-unit
     |        |  |  |     +--ro color-aware?                  boolean
     |        |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
-    |        |  +--ro transfer-cost
     |        |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |     +--ro cost-name         string
-    |        |  |     +--ro cost-value?       string
-    |        |  |     +--ro cost-algorithm?   string
-    |        |  +--ro transfer-integrity
-    |        |  |  +--ro error-characteristic?                      string
-    |        |  |  +--ro loss-characteristic?                       string
-    |        |  |  +--ro repeat-delivery-characteristic?            string
-    |        |  |  +--ro delivery-order-characteristic?             string
-    |        |  |  +--ro unavailable-time-characteristic?           string
-    |        |  |  +--ro server-integrity-process-characteristic?   string
-    |        |  +--ro transfer-timing
+    |        |  |  |  +--ro cost-name         string
+    |        |  |  |  +--ro cost-value?       string
+    |        |  |  |  +--ro cost-algorithm?   string
     |        |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |     +--ro traffic-property-name            string
-    |        |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |     +--ro queing-latency-characteristic?   string
-    |        |  |     +--ro jitter-characteristic?           string
-    |        |  |     +--ro wander-characteristic?           string
-    |        |  +--ro risk-parameter
+    |        |  |  |  +--ro traffic-property-name            string
+    |        |  |  |  +--ro fixed-latency-characteristic?    string
+    |        |  |  |  +--ro queing-latency-characteristic?   string
+    |        |  |  |  +--ro jitter-characteristic?           string
+    |        |  |  |  +--ro wander-characteristic?           string
     |        |  |  +--ro risk-characteristic* [risk-characteristic-name]
     |        |  |     +--ro risk-characteristic-name    string
     |        |  |     +--ro risk-identifier-list*       string
-    |        |  +--ro validation
-    |        |  |  +--ro validation-mechanism* [validation-mechanism]
-    |        |  |     +--ro validation-mechanism                  string
-    |        |  |     +--ro layer-protocol-adjacency-validated?   string
-    |        |  |     +--ro validation-robustness?                string
-    |        |  +--ro lp-transition
-    |        |  |  +--ro transitioned-layer-protocol-name*   string
-    |        |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        |  +--ro direction?             tapi-common:forwarding-direction
+    |        |  +--ro encap-topology?                            -> /tapi-common:context/tapi-topology:topology/uuid
+    |        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+    |        |  +--ro uuid                                       uuid
+    |        |  +--ro name* [value-name]
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?                      administrative-state
+    |        |  +--ro operational-state?                         operational-state
+    |        |  +--ro lifecycle-state?                           lifecycle-state
+    |        |  +--ro total-potential-capacity
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro available-capacity
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro cost-characteristic* [cost-name]
+    |        |  |  +--ro cost-name         string
+    |        |  |  +--ro cost-value?       string
+    |        |  |  +--ro cost-algorithm?   string
+    |        |  +--ro error-characteristic?                      string
+    |        |  +--ro loss-characteristic?                       string
+    |        |  +--ro repeat-delivery-characteristic?            string
+    |        |  +--ro delivery-order-characteristic?             string
+    |        |  +--ro unavailable-time-characteristic?           string
+    |        |  +--ro server-integrity-process-characteristic?   string
+    |        |  +--ro latency-characteristic* [traffic-property-name]
+    |        |     +--ro traffic-property-name            string
+    |        |     +--ro fixed-latency-characteristic?    string
+    |        |     +--ro queing-latency-characteristic?   string
+    |        |     +--ro jitter-characteristic?           string
+    |        |     +--ro wander-characteristic?           string
+    |        +--ro link* [uuid]
+    |        |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+    |        |  +--ro direction?                                 tapi-common:forwarding-direction
     |        |  +--ro resilience-type
     |        |  |  +--ro restoration-policy?   restoration-policy
     |        |  |  +--ro protection-type?      protection-type
-    |        |  +--ro uuid                   uuid
+    |        |  +--ro uuid                                       uuid
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?                      administrative-state
+    |        |  +--ro operational-state?                         operational-state
+    |        |  +--ro lifecycle-state?                           lifecycle-state
+    |        |  +--ro total-potential-capacity
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro available-capacity
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro cost-characteristic* [cost-name]
+    |        |  |  +--ro cost-name         string
+    |        |  |  +--ro cost-value?       string
+    |        |  |  +--ro cost-algorithm?   string
+    |        |  +--ro error-characteristic?                      string
+    |        |  +--ro loss-characteristic?                       string
+    |        |  +--ro repeat-delivery-characteristic?            string
+    |        |  +--ro delivery-order-characteristic?             string
+    |        |  +--ro unavailable-time-characteristic?           string
+    |        |  +--ro server-integrity-process-characteristic?   string
+    |        |  +--ro latency-characteristic* [traffic-property-name]
+    |        |  |  +--ro traffic-property-name            string
+    |        |  |  +--ro fixed-latency-characteristic?    string
+    |        |  |  +--ro queing-latency-characteristic?   string
+    |        |  |  +--ro jitter-characteristic?           string
+    |        |  |  +--ro wander-characteristic?           string
+    |        |  +--ro risk-characteristic* [risk-characteristic-name]
+    |        |  |  +--ro risk-characteristic-name    string
+    |        |  |  +--ro risk-identifier-list*       string
+    |        |  +--ro validation-mechanism* [validation-mechanism]
+    |        |  |  +--ro validation-mechanism                  string
+    |        |  |  +--ro layer-protocol-adjacency-validated?   string
+    |        |  |  +--ro validation-robustness?                string
+    |        |  +--ro transitioned-layer-protocol-name*          string
     |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
     |        +--ro uuid?                  uuid
     |        +--ro name* [value-name]
@@ -672,20 +626,18 @@ module: tapi-topology
     |        |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro state
-    |        |  |  +--ro administrative-state?   administrative-state
-    |        |  |  +--ro operational-state?      operational-state
-    |        |  |  +--ro lifecycle-state?        lifecycle-state
-    |        |  +--ro termination
-    |        |  |  +--ro termination-direction?   termination-direction
-    |        |  |  +--ro termination-state?       termination-state
     |        |  +--ro link-port-direction?              tapi-common:port-direction
     |        |  +--ro link-port-role?                   tapi-common:port-role
     |        |  +--ro uuid                              uuid
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
+    |        |  +--ro administrative-state?             administrative-state
+    |        |  +--ro operational-state?                operational-state
+    |        |  +--ro lifecycle-state?                  lifecycle-state
+    |        |  +--ro termination-direction?            termination-direction
+    |        |  +--ro termination-state?                termination-state
+    |        +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        +--ro node-rule-group* [uuid]
     |        |  +--ro rule* [local-id]
     |        |  |  +--ro rule-type?           rule-type
@@ -695,8 +647,8 @@ module: tapi-topology
     |        |  |  +--ro name* [value-name]
     |        |  |     +--ro value-name    string
     |        |  |     +--ro value?        string
-    |        |  +--ro node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro node-rule-group*     -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+    |        |  +--ro node-edge-point*            -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        |  +--ro node-rule-group*            -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
     |        |  +--ro inter-rule-group* [uuid]
     |        |  |  +--ro rule* [local-id]
     |        |  |  |  +--ro rule-type?           rule-type
@@ -707,68 +659,10 @@ module: tapi-topology
     |        |  |  |     +--ro value-name    string
     |        |  |  |     +--ro value?        string
     |        |  |  +--ro associated-node-rule-group*   -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-    |        |  |  +--ro transfer-capacity
-    |        |  |  |  +--ro total-potential-capacity
-    |        |  |  |  |  +--ro total-size
-    |        |  |  |  |  |  +--ro value?   uint64
-    |        |  |  |  |  |  +--ro unit?    capacity-unit
-    |        |  |  |  |  +--ro bandwidth-profile
-    |        |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |  |     +--ro committed-information-rate
-    |        |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |     +--ro committed-burst-size
-    |        |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |     +--ro peak-information-rate
-    |        |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |     +--ro peak-burst-size
-    |        |  |  |  |     |  +--ro value?   uint64
-    |        |  |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |  |     +--ro color-aware?                  boolean
-    |        |  |  |  |     +--ro coupling-flag?                boolean
-    |        |  |  |  +--ro available-capacity
-    |        |  |  |     +--ro total-size
-    |        |  |  |     |  +--ro value?   uint64
-    |        |  |  |     |  +--ro unit?    capacity-unit
-    |        |  |  |     +--ro bandwidth-profile
-    |        |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |  |        +--ro committed-information-rate
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro committed-burst-size
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro peak-information-rate
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro peak-burst-size
-    |        |  |  |        |  +--ro value?   uint64
-    |        |  |  |        |  +--ro unit?    capacity-unit
-    |        |  |  |        +--ro color-aware?                  boolean
-    |        |  |  |        +--ro coupling-flag?                boolean
-    |        |  |  +--ro transfer-cost
-    |        |  |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |  |     +--ro cost-name         string
-    |        |  |  |     +--ro cost-value?       string
-    |        |  |  |     +--ro cost-algorithm?   string
-    |        |  |  +--ro transfer-timing
-    |        |  |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |  |     +--ro traffic-property-name            string
-    |        |  |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |  |     +--ro queing-latency-characteristic?   string
-    |        |  |  |     +--ro jitter-characteristic?           string
-    |        |  |  |     +--ro wander-characteristic?           string
-    |        |  |  +--ro risk-parameter
-    |        |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
-    |        |  |  |     +--ro risk-characteristic-name    string
-    |        |  |  |     +--ro risk-identifier-list*       string
     |        |  |  +--ro uuid                          uuid
     |        |  |  +--ro name* [value-name]
-    |        |  |     +--ro value-name    string
-    |        |  |     +--ro value?        string
-    |        |  +--ro transfer-capacity
+    |        |  |  |  +--ro value-name    string
+    |        |  |  |  +--ro value?        string
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
     |        |  |  |  |  +--ro value?   uint64
@@ -790,51 +684,42 @@ module: tapi-topology
     |        |  |  |     +--ro color-aware?                  boolean
     |        |  |  |     +--ro coupling-flag?                boolean
     |        |  |  +--ro available-capacity
-    |        |  |     +--ro total-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro bandwidth-profile
-    |        |  |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |        +--ro committed-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro committed-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-information-rate
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro peak-burst-size
-    |        |  |        |  +--ro value?   uint64
-    |        |  |        |  +--ro unit?    capacity-unit
-    |        |  |        +--ro color-aware?                  boolean
-    |        |  |        +--ro coupling-flag?                boolean
-    |        |  +--ro transfer-cost
+    |        |  |  |  +--ro total-size
+    |        |  |  |  |  +--ro value?   uint64
+    |        |  |  |  |  +--ro unit?    capacity-unit
+    |        |  |  |  +--ro bandwidth-profile
+    |        |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |  |     +--ro committed-information-rate
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro committed-burst-size
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro peak-information-rate
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro peak-burst-size
+    |        |  |  |     |  +--ro value?   uint64
+    |        |  |  |     |  +--ro unit?    capacity-unit
+    |        |  |  |     +--ro color-aware?                  boolean
+    |        |  |  |     +--ro coupling-flag?                boolean
     |        |  |  +--ro cost-characteristic* [cost-name]
-    |        |  |     +--ro cost-name         string
-    |        |  |     +--ro cost-value?       string
-    |        |  |     +--ro cost-algorithm?   string
-    |        |  +--ro transfer-timing
+    |        |  |  |  +--ro cost-name         string
+    |        |  |  |  +--ro cost-value?       string
+    |        |  |  |  +--ro cost-algorithm?   string
     |        |  |  +--ro latency-characteristic* [traffic-property-name]
-    |        |  |     +--ro traffic-property-name            string
-    |        |  |     +--ro fixed-latency-characteristic?    string
-    |        |  |     +--ro queing-latency-characteristic?   string
-    |        |  |     +--ro jitter-characteristic?           string
-    |        |  |     +--ro wander-characteristic?           string
-    |        |  +--ro risk-parameter
+    |        |  |  |  +--ro traffic-property-name            string
+    |        |  |  |  +--ro fixed-latency-characteristic?    string
+    |        |  |  |  +--ro queing-latency-characteristic?   string
+    |        |  |  |  +--ro jitter-characteristic?           string
+    |        |  |  |  +--ro wander-characteristic?           string
     |        |  |  +--ro risk-characteristic* [risk-characteristic-name]
     |        |  |     +--ro risk-characteristic-name    string
     |        |  |     +--ro risk-identifier-list*       string
-    |        |  +--ro uuid                 uuid
+    |        |  +--ro uuid                        uuid
     |        |  +--ro name* [value-name]
-    |        |     +--ro value-name    string
-    |        |     +--ro value?        string
-    |        +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro transfer-capacity
+    |        |  |  +--ro value-name    string
+    |        |  |  +--ro value?        string
     |        |  +--ro total-potential-capacity
     |        |  |  +--ro total-size
     |        |  |  |  +--ro value?   uint64
@@ -856,49 +741,103 @@ module: tapi-topology
     |        |  |     +--ro color-aware?                  boolean
     |        |  |     +--ro coupling-flag?                boolean
     |        |  +--ro available-capacity
-    |        |     +--ro total-size
+    |        |  |  +--ro total-size
+    |        |  |  |  +--ro value?   uint64
+    |        |  |  |  +--ro unit?    capacity-unit
+    |        |  |  +--ro bandwidth-profile
+    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |  |     +--ro committed-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro committed-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-information-rate
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro peak-burst-size
+    |        |  |     |  +--ro value?   uint64
+    |        |  |     |  +--ro unit?    capacity-unit
+    |        |  |     +--ro color-aware?                  boolean
+    |        |  |     +--ro coupling-flag?                boolean
+    |        |  +--ro cost-characteristic* [cost-name]
+    |        |  |  +--ro cost-name         string
+    |        |  |  +--ro cost-value?       string
+    |        |  |  +--ro cost-algorithm?   string
+    |        |  +--ro latency-characteristic* [traffic-property-name]
+    |        |  |  +--ro traffic-property-name            string
+    |        |  |  +--ro fixed-latency-characteristic?    string
+    |        |  |  +--ro queing-latency-characteristic?   string
+    |        |  |  +--ro jitter-characteristic?           string
+    |        |  |  +--ro wander-characteristic?           string
+    |        |  +--ro risk-characteristic* [risk-characteristic-name]
+    |        |     +--ro risk-characteristic-name    string
+    |        |     +--ro risk-identifier-list*       string
+    |        +--ro encap-topology?                            -> /tapi-common:context/tapi-topology:topology/uuid
+    |        +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+    |        +--ro uuid?                                      uuid
+    |        +--ro name* [value-name]
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro administrative-state?                      administrative-state
+    |        +--ro operational-state?                         operational-state
+    |        +--ro lifecycle-state?                           lifecycle-state
+    |        +--ro total-potential-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
     |        |     |  +--ro value?   uint64
     |        |     |  +--ro unit?    capacity-unit
-    |        |     +--ro bandwidth-profile
-    |        |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |        +--ro committed-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro committed-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro color-aware?                  boolean
-    |        |        +--ro coupling-flag?                boolean
-    |        +--ro transfer-cost
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |     +--ro cost-name         string
-    |        |     +--ro cost-value?       string
-    |        |     +--ro cost-algorithm?   string
-    |        +--ro transfer-integrity
-    |        |  +--ro error-characteristic?                      string
-    |        |  +--ro loss-characteristic?                       string
-    |        |  +--ro repeat-delivery-characteristic?            string
-    |        |  +--ro delivery-order-characteristic?             string
-    |        |  +--ro unavailable-time-characteristic?           string
-    |        |  +--ro server-integrity-process-characteristic?   string
-    |        +--ro transfer-timing
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |     +--ro traffic-property-name            string
-    |        |     +--ro fixed-latency-characteristic?    string
-    |        |     +--ro queing-latency-characteristic?   string
-    |        |     +--ro jitter-characteristic?           string
-    |        |     +--ro wander-characteristic?           string
-    |        +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-    |        +--ro uuid?                         uuid
-    |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro available-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro error-characteristic?                      string
+    |        +--ro loss-characteristic?                       string
+    |        +--ro repeat-delivery-characteristic?            string
+    |        +--ro delivery-order-characteristic?             string
+    |        +--ro unavailable-time-characteristic?           string
+    |        +--ro server-integrity-process-characteristic?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |           +--ro traffic-property-name            string
+    |           +--ro fixed-latency-characteristic?    string
+    |           +--ro queing-latency-characteristic?   string
+    |           +--ro jitter-characteristic?           string
+    |           +--ro wander-characteristic?           string
     +---x get-node-edge-point-details
     |  +---w input
     |  |  +---w topology-id-or-name?   string
@@ -909,111 +848,101 @@ module: tapi-topology
     |        +--ro layer-protocol-name?              tapi-common:layer-protocol-name
     |        +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
     |        +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro termination
-    |        |  +--ro termination-direction?   termination-direction
-    |        |  +--ro termination-state?       termination-state
     |        +--ro link-port-direction?              tapi-common:port-direction
     |        +--ro link-port-role?                   tapi-common:port-role
     |        +--ro uuid?                             uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro administrative-state?             administrative-state
+    |        +--ro operational-state?                operational-state
+    |        +--ro lifecycle-state?                  lifecycle-state
+    |        +--ro termination-direction?            termination-direction
+    |        +--ro termination-state?                termination-state
     +---x get-link-details
     |  +---w input
     |  |  +---w topology-id-or-name?   string
     |  |  +---w link-id-or-name?       string
     |  +--ro output
     |     +--ro link
-    |        +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-    |        +--ro state
-    |        |  +--ro administrative-state?   administrative-state
-    |        |  +--ro operational-state?      operational-state
-    |        |  +--ro lifecycle-state?        lifecycle-state
-    |        +--ro transfer-capacity
-    |        |  +--ro total-potential-capacity
-    |        |  |  +--ro total-size
-    |        |  |  |  +--ro value?   uint64
-    |        |  |  |  +--ro unit?    capacity-unit
-    |        |  |  +--ro bandwidth-profile
-    |        |  |     +--ro bw-profile-type?              bandwidth-profile-type
-    |        |  |     +--ro committed-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro committed-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-information-rate
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro peak-burst-size
-    |        |  |     |  +--ro value?   uint64
-    |        |  |     |  +--ro unit?    capacity-unit
-    |        |  |     +--ro color-aware?                  boolean
-    |        |  |     +--ro coupling-flag?                boolean
-    |        |  +--ro available-capacity
-    |        |     +--ro total-size
-    |        |     |  +--ro value?   uint64
-    |        |     |  +--ro unit?    capacity-unit
-    |        |     +--ro bandwidth-profile
-    |        |        +--ro bw-profile-type?              bandwidth-profile-type
-    |        |        +--ro committed-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro committed-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-information-rate
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro peak-burst-size
-    |        |        |  +--ro value?   uint64
-    |        |        |  +--ro unit?    capacity-unit
-    |        |        +--ro color-aware?                  boolean
-    |        |        +--ro coupling-flag?                boolean
-    |        +--ro transfer-cost
-    |        |  +--ro cost-characteristic* [cost-name]
-    |        |     +--ro cost-name         string
-    |        |     +--ro cost-value?       string
-    |        |     +--ro cost-algorithm?   string
-    |        +--ro transfer-integrity
-    |        |  +--ro error-characteristic?                      string
-    |        |  +--ro loss-characteristic?                       string
-    |        |  +--ro repeat-delivery-characteristic?            string
-    |        |  +--ro delivery-order-characteristic?             string
-    |        |  +--ro unavailable-time-characteristic?           string
-    |        |  +--ro server-integrity-process-characteristic?   string
-    |        +--ro transfer-timing
-    |        |  +--ro latency-characteristic* [traffic-property-name]
-    |        |     +--ro traffic-property-name            string
-    |        |     +--ro fixed-latency-characteristic?    string
-    |        |     +--ro queing-latency-characteristic?   string
-    |        |     +--ro jitter-characteristic?           string
-    |        |     +--ro wander-characteristic?           string
-    |        +--ro risk-parameter
-    |        |  +--ro risk-characteristic* [risk-characteristic-name]
-    |        |     +--ro risk-characteristic-name    string
-    |        |     +--ro risk-identifier-list*       string
-    |        +--ro validation
-    |        |  +--ro validation-mechanism* [validation-mechanism]
-    |        |     +--ro validation-mechanism                  string
-    |        |     +--ro layer-protocol-adjacency-validated?   string
-    |        |     +--ro validation-robustness?                string
-    |        +--ro lp-transition
-    |        |  +--ro transitioned-layer-protocol-name*   string
-    |        +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-    |        +--ro direction?             tapi-common:forwarding-direction
+    |        +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+    |        +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
+    |        +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+    |        +--ro direction?                                 tapi-common:forwarding-direction
     |        +--ro resilience-type
     |        |  +--ro restoration-policy?   restoration-policy
     |        |  +--ro protection-type?      protection-type
-    |        +--ro uuid?                  uuid
+    |        +--ro uuid?                                      uuid
     |        +--ro name* [value-name]
-    |           +--ro value-name    string
-    |           +--ro value?        string
+    |        |  +--ro value-name    string
+    |        |  +--ro value?        string
+    |        +--ro administrative-state?                      administrative-state
+    |        +--ro operational-state?                         operational-state
+    |        +--ro lifecycle-state?                           lifecycle-state
+    |        +--ro total-potential-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro available-capacity
+    |        |  +--ro total-size
+    |        |  |  +--ro value?   uint64
+    |        |  |  +--ro unit?    capacity-unit
+    |        |  +--ro bandwidth-profile
+    |        |     +--ro bw-profile-type?              bandwidth-profile-type
+    |        |     +--ro committed-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro committed-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-information-rate
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro peak-burst-size
+    |        |     |  +--ro value?   uint64
+    |        |     |  +--ro unit?    capacity-unit
+    |        |     +--ro color-aware?                  boolean
+    |        |     +--ro coupling-flag?                boolean
+    |        +--ro cost-characteristic* [cost-name]
+    |        |  +--ro cost-name         string
+    |        |  +--ro cost-value?       string
+    |        |  +--ro cost-algorithm?   string
+    |        +--ro error-characteristic?                      string
+    |        +--ro loss-characteristic?                       string
+    |        +--ro repeat-delivery-characteristic?            string
+    |        +--ro delivery-order-characteristic?             string
+    |        +--ro unavailable-time-characteristic?           string
+    |        +--ro server-integrity-process-characteristic?   string
+    |        +--ro latency-characteristic* [traffic-property-name]
+    |        |  +--ro traffic-property-name            string
+    |        |  +--ro fixed-latency-characteristic?    string
+    |        |  +--ro queing-latency-characteristic?   string
+    |        |  +--ro jitter-characteristic?           string
+    |        |  +--ro wander-characteristic?           string
+    |        +--ro risk-characteristic* [risk-characteristic-name]
+    |        |  +--ro risk-characteristic-name    string
+    |        |  +--ro risk-identifier-list*       string
+    |        +--ro validation-mechanism* [validation-mechanism]
+    |        |  +--ro validation-mechanism                  string
+    |        |  +--ro layer-protocol-adjacency-validated?   string
+    |        |  +--ro validation-robustness?                string
+    |        +--ro transitioned-layer-protocol-name*          string
     +---x get-topology-list
        +--ro output
           +--ro topology*
@@ -1022,20 +951,18 @@ module: tapi-topology
              |  |  +--ro layer-protocol-name?              tapi-common:layer-protocol-name
              |  |  +--ro aggregated-node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
              |  |  +--ro mapped-service-interface-point*   -> /tapi-common:context/service-interface-point/uuid
-             |  |  +--ro state
-             |  |  |  +--ro administrative-state?   administrative-state
-             |  |  |  +--ro operational-state?      operational-state
-             |  |  |  +--ro lifecycle-state?        lifecycle-state
-             |  |  +--ro termination
-             |  |  |  +--ro termination-direction?   termination-direction
-             |  |  |  +--ro termination-state?       termination-state
              |  |  +--ro link-port-direction?              tapi-common:port-direction
              |  |  +--ro link-port-role?                   tapi-common:port-role
              |  |  +--ro uuid                              uuid
              |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro aggregated-node-edge-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  |  +--ro value-name    string
+             |  |  |  +--ro value?        string
+             |  |  +--ro administrative-state?             administrative-state
+             |  |  +--ro operational-state?                operational-state
+             |  |  +--ro lifecycle-state?                  lifecycle-state
+             |  |  +--ro termination-direction?            termination-direction
+             |  |  +--ro termination-state?                termination-state
+             |  +--ro aggregated-node-edge-point*                -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
              |  +--ro node-rule-group* [uuid]
              |  |  +--ro rule* [local-id]
              |  |  |  +--ro rule-type?           rule-type
@@ -1045,8 +972,8 @@ module: tapi-topology
              |  |  |  +--ro name* [value-name]
              |  |  |     +--ro value-name    string
              |  |  |     +--ro value?        string
-             |  |  +--ro node-edge-point*     -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  |  +--ro node-rule-group*     -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
+             |  |  +--ro node-edge-point*            -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  |  +--ro node-rule-group*            -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
              |  |  +--ro inter-rule-group* [uuid]
              |  |  |  +--ro rule* [local-id]
              |  |  |  |  +--ro rule-type?           rule-type
@@ -1057,68 +984,10 @@ module: tapi-topology
              |  |  |  |     +--ro value-name    string
              |  |  |  |     +--ro value?        string
              |  |  |  +--ro associated-node-rule-group*   -> /tapi-common:context/tapi-topology:topology/node/node-rule-group/uuid
-             |  |  |  +--ro transfer-capacity
-             |  |  |  |  +--ro total-potential-capacity
-             |  |  |  |  |  +--ro total-size
-             |  |  |  |  |  |  +--ro value?   uint64
-             |  |  |  |  |  |  +--ro unit?    capacity-unit
-             |  |  |  |  |  +--ro bandwidth-profile
-             |  |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
-             |  |  |  |  |     +--ro committed-information-rate
-             |  |  |  |  |     |  +--ro value?   uint64
-             |  |  |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |  |  |     +--ro committed-burst-size
-             |  |  |  |  |     |  +--ro value?   uint64
-             |  |  |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |  |  |     +--ro peak-information-rate
-             |  |  |  |  |     |  +--ro value?   uint64
-             |  |  |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |  |  |     +--ro peak-burst-size
-             |  |  |  |  |     |  +--ro value?   uint64
-             |  |  |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |  |  |     +--ro color-aware?                  boolean
-             |  |  |  |  |     +--ro coupling-flag?                boolean
-             |  |  |  |  +--ro available-capacity
-             |  |  |  |     +--ro total-size
-             |  |  |  |     |  +--ro value?   uint64
-             |  |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |  |     +--ro bandwidth-profile
-             |  |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-             |  |  |  |        +--ro committed-information-rate
-             |  |  |  |        |  +--ro value?   uint64
-             |  |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |  |        +--ro committed-burst-size
-             |  |  |  |        |  +--ro value?   uint64
-             |  |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |  |        +--ro peak-information-rate
-             |  |  |  |        |  +--ro value?   uint64
-             |  |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |  |        +--ro peak-burst-size
-             |  |  |  |        |  +--ro value?   uint64
-             |  |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |  |        +--ro color-aware?                  boolean
-             |  |  |  |        +--ro coupling-flag?                boolean
-             |  |  |  +--ro transfer-cost
-             |  |  |  |  +--ro cost-characteristic* [cost-name]
-             |  |  |  |     +--ro cost-name         string
-             |  |  |  |     +--ro cost-value?       string
-             |  |  |  |     +--ro cost-algorithm?   string
-             |  |  |  +--ro transfer-timing
-             |  |  |  |  +--ro latency-characteristic* [traffic-property-name]
-             |  |  |  |     +--ro traffic-property-name            string
-             |  |  |  |     +--ro fixed-latency-characteristic?    string
-             |  |  |  |     +--ro queing-latency-characteristic?   string
-             |  |  |  |     +--ro jitter-characteristic?           string
-             |  |  |  |     +--ro wander-characteristic?           string
-             |  |  |  +--ro risk-parameter
-             |  |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
-             |  |  |  |     +--ro risk-characteristic-name    string
-             |  |  |  |     +--ro risk-identifier-list*       string
              |  |  |  +--ro uuid                          uuid
              |  |  |  +--ro name* [value-name]
-             |  |  |     +--ro value-name    string
-             |  |  |     +--ro value?        string
-             |  |  +--ro transfer-capacity
+             |  |  |  |  +--ro value-name    string
+             |  |  |  |  +--ro value?        string
              |  |  |  +--ro total-potential-capacity
              |  |  |  |  +--ro total-size
              |  |  |  |  |  +--ro value?   uint64
@@ -1140,51 +1009,42 @@ module: tapi-topology
              |  |  |  |     +--ro color-aware?                  boolean
              |  |  |  |     +--ro coupling-flag?                boolean
              |  |  |  +--ro available-capacity
-             |  |  |     +--ro total-size
-             |  |  |     |  +--ro value?   uint64
-             |  |  |     |  +--ro unit?    capacity-unit
-             |  |  |     +--ro bandwidth-profile
-             |  |  |        +--ro bw-profile-type?              bandwidth-profile-type
-             |  |  |        +--ro committed-information-rate
-             |  |  |        |  +--ro value?   uint64
-             |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |        +--ro committed-burst-size
-             |  |  |        |  +--ro value?   uint64
-             |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |        +--ro peak-information-rate
-             |  |  |        |  +--ro value?   uint64
-             |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |        +--ro peak-burst-size
-             |  |  |        |  +--ro value?   uint64
-             |  |  |        |  +--ro unit?    capacity-unit
-             |  |  |        +--ro color-aware?                  boolean
-             |  |  |        +--ro coupling-flag?                boolean
-             |  |  +--ro transfer-cost
+             |  |  |  |  +--ro total-size
+             |  |  |  |  |  +--ro value?   uint64
+             |  |  |  |  |  +--ro unit?    capacity-unit
+             |  |  |  |  +--ro bandwidth-profile
+             |  |  |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |  |  |     +--ro committed-information-rate
+             |  |  |  |     |  +--ro value?   uint64
+             |  |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |  |     +--ro committed-burst-size
+             |  |  |  |     |  +--ro value?   uint64
+             |  |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |  |     +--ro peak-information-rate
+             |  |  |  |     |  +--ro value?   uint64
+             |  |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |  |     +--ro peak-burst-size
+             |  |  |  |     |  +--ro value?   uint64
+             |  |  |  |     |  +--ro unit?    capacity-unit
+             |  |  |  |     +--ro color-aware?                  boolean
+             |  |  |  |     +--ro coupling-flag?                boolean
              |  |  |  +--ro cost-characteristic* [cost-name]
-             |  |  |     +--ro cost-name         string
-             |  |  |     +--ro cost-value?       string
-             |  |  |     +--ro cost-algorithm?   string
-             |  |  +--ro transfer-timing
+             |  |  |  |  +--ro cost-name         string
+             |  |  |  |  +--ro cost-value?       string
+             |  |  |  |  +--ro cost-algorithm?   string
              |  |  |  +--ro latency-characteristic* [traffic-property-name]
-             |  |  |     +--ro traffic-property-name            string
-             |  |  |     +--ro fixed-latency-characteristic?    string
-             |  |  |     +--ro queing-latency-characteristic?   string
-             |  |  |     +--ro jitter-characteristic?           string
-             |  |  |     +--ro wander-characteristic?           string
-             |  |  +--ro risk-parameter
+             |  |  |  |  +--ro traffic-property-name            string
+             |  |  |  |  +--ro fixed-latency-characteristic?    string
+             |  |  |  |  +--ro queing-latency-characteristic?   string
+             |  |  |  |  +--ro jitter-characteristic?           string
+             |  |  |  |  +--ro wander-characteristic?           string
              |  |  |  +--ro risk-characteristic* [risk-characteristic-name]
              |  |  |     +--ro risk-characteristic-name    string
              |  |  |     +--ro risk-identifier-list*       string
-             |  |  +--ro uuid                 uuid
+             |  |  +--ro uuid                        uuid
              |  |  +--ro name* [value-name]
-             |  |     +--ro value-name    string
-             |  |     +--ro value?        string
-             |  +--ro encap-topology?               -> /tapi-common:context/tapi-topology:topology/uuid
-             |  +--ro state
-             |  |  +--ro administrative-state?   administrative-state
-             |  |  +--ro operational-state?      operational-state
-             |  |  +--ro lifecycle-state?        lifecycle-state
-             |  +--ro transfer-capacity
+             |  |  |  +--ro value-name    string
+             |  |  |  +--ro value?        string
              |  |  +--ro total-potential-capacity
              |  |  |  +--ro total-size
              |  |  |  |  +--ro value?   uint64
@@ -1206,58 +1066,6 @@ module: tapi-topology
              |  |  |     +--ro color-aware?                  boolean
              |  |  |     +--ro coupling-flag?                boolean
              |  |  +--ro available-capacity
-             |  |     +--ro total-size
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro bandwidth-profile
-             |  |        +--ro bw-profile-type?              bandwidth-profile-type
-             |  |        +--ro committed-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro committed-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro color-aware?                  boolean
-             |  |        +--ro coupling-flag?                boolean
-             |  +--ro transfer-cost
-             |  |  +--ro cost-characteristic* [cost-name]
-             |  |     +--ro cost-name         string
-             |  |     +--ro cost-value?       string
-             |  |     +--ro cost-algorithm?   string
-             |  +--ro transfer-integrity
-             |  |  +--ro error-characteristic?                      string
-             |  |  +--ro loss-characteristic?                       string
-             |  |  +--ro repeat-delivery-characteristic?            string
-             |  |  +--ro delivery-order-characteristic?             string
-             |  |  +--ro unavailable-time-characteristic?           string
-             |  |  +--ro server-integrity-process-characteristic?   string
-             |  +--ro transfer-timing
-             |  |  +--ro latency-characteristic* [traffic-property-name]
-             |  |     +--ro traffic-property-name            string
-             |  |     +--ro fixed-latency-characteristic?    string
-             |  |     +--ro queing-latency-characteristic?   string
-             |  |     +--ro jitter-characteristic?           string
-             |  |     +--ro wander-characteristic?           string
-             |  +--ro layer-protocol-name*          tapi-common:layer-protocol-name
-             |  +--ro uuid                          uuid
-             |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
-             +--ro link* [uuid]
-             |  +--ro node-edge-point*       -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  +--ro node*                  -> /tapi-common:context/tapi-topology:topology/node/uuid
-             |  +--ro state
-             |  |  +--ro administrative-state?   administrative-state
-             |  |  +--ro operational-state?      operational-state
-             |  |  +--ro lifecycle-state?        lifecycle-state
-             |  +--ro transfer-capacity
-             |  |  +--ro total-potential-capacity
              |  |  |  +--ro total-size
              |  |  |  |  +--ro value?   uint64
              |  |  |  |  +--ro unit?    capacity-unit
@@ -1277,65 +1085,163 @@ module: tapi-topology
              |  |  |     |  +--ro unit?    capacity-unit
              |  |  |     +--ro color-aware?                  boolean
              |  |  |     +--ro coupling-flag?                boolean
-             |  |  +--ro available-capacity
-             |  |     +--ro total-size
-             |  |     |  +--ro value?   uint64
-             |  |     |  +--ro unit?    capacity-unit
-             |  |     +--ro bandwidth-profile
-             |  |        +--ro bw-profile-type?              bandwidth-profile-type
-             |  |        +--ro committed-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro committed-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-information-rate
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro peak-burst-size
-             |  |        |  +--ro value?   uint64
-             |  |        |  +--ro unit?    capacity-unit
-             |  |        +--ro color-aware?                  boolean
-             |  |        +--ro coupling-flag?                boolean
-             |  +--ro transfer-cost
              |  |  +--ro cost-characteristic* [cost-name]
-             |  |     +--ro cost-name         string
-             |  |     +--ro cost-value?       string
-             |  |     +--ro cost-algorithm?   string
-             |  +--ro transfer-integrity
-             |  |  +--ro error-characteristic?                      string
-             |  |  +--ro loss-characteristic?                       string
-             |  |  +--ro repeat-delivery-characteristic?            string
-             |  |  +--ro delivery-order-characteristic?             string
-             |  |  +--ro unavailable-time-characteristic?           string
-             |  |  +--ro server-integrity-process-characteristic?   string
-             |  +--ro transfer-timing
+             |  |  |  +--ro cost-name         string
+             |  |  |  +--ro cost-value?       string
+             |  |  |  +--ro cost-algorithm?   string
              |  |  +--ro latency-characteristic* [traffic-property-name]
-             |  |     +--ro traffic-property-name            string
-             |  |     +--ro fixed-latency-characteristic?    string
-             |  |     +--ro queing-latency-characteristic?   string
-             |  |     +--ro jitter-characteristic?           string
-             |  |     +--ro wander-characteristic?           string
-             |  +--ro risk-parameter
+             |  |  |  +--ro traffic-property-name            string
+             |  |  |  +--ro fixed-latency-characteristic?    string
+             |  |  |  +--ro queing-latency-characteristic?   string
+             |  |  |  +--ro jitter-characteristic?           string
+             |  |  |  +--ro wander-characteristic?           string
              |  |  +--ro risk-characteristic* [risk-characteristic-name]
              |  |     +--ro risk-characteristic-name    string
              |  |     +--ro risk-identifier-list*       string
-             |  +--ro validation
-             |  |  +--ro validation-mechanism* [validation-mechanism]
-             |  |     +--ro validation-mechanism                  string
-             |  |     +--ro layer-protocol-adjacency-validated?   string
-             |  |     +--ro validation-robustness?                string
-             |  +--ro lp-transition
-             |  |  +--ro transitioned-layer-protocol-name*   string
-             |  +--ro layer-protocol-name*   tapi-common:layer-protocol-name
-             |  +--ro direction?             tapi-common:forwarding-direction
+             |  +--ro encap-topology?                            -> /tapi-common:context/tapi-topology:topology/uuid
+             |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+             |  +--ro uuid                                       uuid
+             |  +--ro name* [value-name]
+             |  |  +--ro value-name    string
+             |  |  +--ro value?        string
+             |  +--ro administrative-state?                      administrative-state
+             |  +--ro operational-state?                         operational-state
+             |  +--ro lifecycle-state?                           lifecycle-state
+             |  +--ro total-potential-capacity
+             |  |  +--ro total-size
+             |  |  |  +--ro value?   uint64
+             |  |  |  +--ro unit?    capacity-unit
+             |  |  +--ro bandwidth-profile
+             |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |     +--ro committed-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro committed-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
+             |  +--ro available-capacity
+             |  |  +--ro total-size
+             |  |  |  +--ro value?   uint64
+             |  |  |  +--ro unit?    capacity-unit
+             |  |  +--ro bandwidth-profile
+             |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |     +--ro committed-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro committed-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
+             |  +--ro cost-characteristic* [cost-name]
+             |  |  +--ro cost-name         string
+             |  |  +--ro cost-value?       string
+             |  |  +--ro cost-algorithm?   string
+             |  +--ro error-characteristic?                      string
+             |  +--ro loss-characteristic?                       string
+             |  +--ro repeat-delivery-characteristic?            string
+             |  +--ro delivery-order-characteristic?             string
+             |  +--ro unavailable-time-characteristic?           string
+             |  +--ro server-integrity-process-characteristic?   string
+             |  +--ro latency-characteristic* [traffic-property-name]
+             |     +--ro traffic-property-name            string
+             |     +--ro fixed-latency-characteristic?    string
+             |     +--ro queing-latency-characteristic?   string
+             |     +--ro jitter-characteristic?           string
+             |     +--ro wander-characteristic?           string
+             +--ro link* [uuid]
+             |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+             |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
+             |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
+             |  +--ro direction?                                 tapi-common:forwarding-direction
              |  +--ro resilience-type
              |  |  +--ro restoration-policy?   restoration-policy
              |  |  +--ro protection-type?      protection-type
-             |  +--ro uuid                   uuid
+             |  +--ro uuid                                       uuid
              |  +--ro name* [value-name]
-             |     +--ro value-name    string
-             |     +--ro value?        string
+             |  |  +--ro value-name    string
+             |  |  +--ro value?        string
+             |  +--ro administrative-state?                      administrative-state
+             |  +--ro operational-state?                         operational-state
+             |  +--ro lifecycle-state?                           lifecycle-state
+             |  +--ro total-potential-capacity
+             |  |  +--ro total-size
+             |  |  |  +--ro value?   uint64
+             |  |  |  +--ro unit?    capacity-unit
+             |  |  +--ro bandwidth-profile
+             |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |     +--ro committed-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro committed-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
+             |  +--ro available-capacity
+             |  |  +--ro total-size
+             |  |  |  +--ro value?   uint64
+             |  |  |  +--ro unit?    capacity-unit
+             |  |  +--ro bandwidth-profile
+             |  |     +--ro bw-profile-type?              bandwidth-profile-type
+             |  |     +--ro committed-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro committed-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-information-rate
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro peak-burst-size
+             |  |     |  +--ro value?   uint64
+             |  |     |  +--ro unit?    capacity-unit
+             |  |     +--ro color-aware?                  boolean
+             |  |     +--ro coupling-flag?                boolean
+             |  +--ro cost-characteristic* [cost-name]
+             |  |  +--ro cost-name         string
+             |  |  +--ro cost-value?       string
+             |  |  +--ro cost-algorithm?   string
+             |  +--ro error-characteristic?                      string
+             |  +--ro loss-characteristic?                       string
+             |  +--ro repeat-delivery-characteristic?            string
+             |  +--ro delivery-order-characteristic?             string
+             |  +--ro unavailable-time-characteristic?           string
+             |  +--ro server-integrity-process-characteristic?   string
+             |  +--ro latency-characteristic* [traffic-property-name]
+             |  |  +--ro traffic-property-name            string
+             |  |  +--ro fixed-latency-characteristic?    string
+             |  |  +--ro queing-latency-characteristic?   string
+             |  |  +--ro jitter-characteristic?           string
+             |  |  +--ro wander-characteristic?           string
+             |  +--ro risk-characteristic* [risk-characteristic-name]
+             |  |  +--ro risk-characteristic-name    string
+             |  |  +--ro risk-identifier-list*       string
+             |  +--ro validation-mechanism* [validation-mechanism]
+             |  |  +--ro validation-mechanism                  string
+             |  |  +--ro layer-protocol-adjacency-validated?   string
+             |  |  +--ro validation-robustness?                string
+             |  +--ro transitioned-layer-protocol-name*          string
              +--ro layer-protocol-name*   tapi-common:layer-protocol-name
              +--ro uuid?                  uuid
              +--ro name* [value-name]

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -39,46 +39,6 @@ module tapi-topology {
                 min-elements 2;
                 description "none";
             }
-            container state {
-                config false;
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
-            container transfer-capacity {
-                config false;
-                uses tapi-common:capacity-pac;
-                description "none";
-            }
-            container transfer-cost {
-                config false;
-                uses transfer-cost-pac;
-                description "none";
-            }
-            container transfer-integrity {
-                config false;
-                uses transfer-integrity-pac;
-                description "none";
-            }
-            container transfer-timing {
-                config false;
-                uses transfer-timing-pac;
-                description "none";
-            }
-            container risk-parameter {
-                config false;
-                uses risk-parameter-pac;
-                description "none";
-            }
-            container validation {
-                config false;
-                uses validation-pac;
-                description "none";
-            }
-            container lp-transition {
-                config false;
-                uses layer-protocol-transition-pac;
-                description "none";
-            }
             leaf-list layer-protocol-name {
                 type tapi-common:layer-protocol-name;
                 config false;
@@ -97,6 +57,14 @@ module tapi-topology {
                 description "none";
             }
             uses tapi-common:resource-spec;
+            uses tapi-common:admin-state-pac;
+            uses tapi-common:capacity-pac;
+            uses tapi-topology:transfer-cost-pac;
+            uses tapi-topology:transfer-integrity-pac;
+            uses tapi-topology:transfer-timing-pac;
+            uses tapi-topology:risk-parameter-pac;
+            uses tapi-topology:validation-pac;
+            uses tapi-topology:layer-protocol-transition-pac;
             description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
         }
         grouping node {
@@ -125,31 +93,6 @@ module tapi-topology {
                 config false;
                 description "none";
             }
-            container state {
-                config false;
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
-            container transfer-capacity {
-                config false;
-                uses tapi-common:capacity-pac;
-                description "none";
-            }
-            container transfer-cost {
-                config false;
-                uses transfer-cost-pac;
-                description "none";
-            }
-            container transfer-integrity {
-                config false;
-                uses transfer-integrity-pac;
-                description "none";
-            }
-            container transfer-timing {
-                config false;
-                uses transfer-timing-pac;
-                description "none";
-            }
             leaf-list layer-protocol-name {
                 type tapi-common:layer-protocol-name;
                 config false;
@@ -157,6 +100,11 @@ module tapi-topology {
                 description "none";
             }
             uses tapi-common:resource-spec;
+            uses tapi-common:admin-state-pac;
+            uses tapi-common:capacity-pac;
+            uses tapi-topology:transfer-cost-pac;
+            uses tapi-topology:transfer-integrity-pac;
+            uses tapi-topology:transfer-timing-pac;
             description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
                 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
         }
@@ -214,16 +162,6 @@ module tapi-topology {
                 }
                 description "NodeEdgePoint mapped to more than ServiceInterfacePoint (slicing/virtualizing) or a ServiceInterfacePoint mapped to more than one NodeEdgePoint (load balancing/Resilience) should be considered experimental";
             }
-            container state {
-                config false;
-                uses tapi-common:admin-state-pac;
-                description "none";
-            }
-            container termination {
-                config false;
-                uses tapi-common:termination-pac;
-                description "none";
-            }
             leaf link-port-direction {
                 type tapi-common:port-direction;
                 config false;
@@ -235,6 +173,8 @@ module tapi-topology {
                 description "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ";
             }
             uses tapi-common:resource-spec;
+            uses tapi-common:admin-state-pac;
+            uses tapi-common:termination-pac;
             description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
                 The structure of LTP supports all transport protocols including circuit and packet forms.";
         }
@@ -370,23 +310,11 @@ module tapi-topology {
                 min-elements 2;
                 description "none";
             }
-            container transfer-capacity {
-                uses tapi-common:capacity-pac;
-                description "none";
-            }
-            container transfer-cost {
-                uses transfer-cost-pac;
-                description "none";
-            }
-            container transfer-timing {
-                uses transfer-timing-pac;
-                description "none";
-            }
-            container risk-parameter {
-                uses risk-parameter-pac;
-                description "none";
-            }
             uses tapi-common:resource-spec;
+            uses tapi-common:capacity-pac;
+            uses tapi-topology:transfer-cost-pac;
+            uses tapi-topology:transfer-timing-pac;
+            uses tapi-topology:risk-parameter-pac;
             description "none";
         }
         grouping node-rule-group {
@@ -414,23 +342,11 @@ module tapi-topology {
                 uses inter-rule-group;
                 description "none";
             }
-            container transfer-capacity {
-                uses tapi-common:capacity-pac;
-                description "none";
-            }
-            container transfer-cost {
-                uses transfer-cost-pac;
-                description "none";
-            }
-            container transfer-timing {
-                uses transfer-timing-pac;
-                description "none";
-            }
-            container risk-parameter {
-                uses risk-parameter-pac;
-                description "none";
-            }
             uses tapi-common:resource-spec;
+            uses tapi-common:capacity-pac;
+            uses tapi-topology:transfer-cost-pac;
+            uses tapi-topology:transfer-timing-pac;
+            uses tapi-topology:risk-parameter-pac;
             description "none";
         }
         grouping rule {

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -527,16 +527,16 @@ module tapi-topology {
         }
         typedef forwarding-rule {
             type enumeration {
-                enum may-forward-across-group {
+                enum MAY_FORWARD_ACROSS_GROUP {
                     description "none";
                 }
-                enum must-forward-across-group {
+                enum MUST_FORWARD_ACROSS_GROUP {
                     description "none";
                 }
-                enum cannot-forward-across-group {
+                enum CANNOT_FORWARD_ACROSS_GROUP {
                     description "none";
                 }
-                enum no-statement-on-forwarding {
+                enum NO_STATEMENT_ON_FORWARDING {
                     description "none";
                 }
             }
@@ -544,22 +544,22 @@ module tapi-topology {
         }
         typedef rule-type {
             type enumeration {
-                enum forwarding {
+                enum FORWARDING {
                     description "none";
                 }
-                enum capacity {
+                enum CAPACITY {
                     description "none";
                 }
-                enum cost {
+                enum COST {
                     description "none";
                 }
-                enum timing {
+                enum TIMING {
                     description "none";
                 }
-                enum risk {
+                enum RISK {
                     description "none";
                 }
-                enum grouping {
+                enum GROUPING {
                     description "none";
                 }
             }
@@ -578,13 +578,13 @@ module tapi-topology {
         }
         typedef restoration-policy {
             type enumeration {
-                enum per-domain-restoration {
+                enum PER_DOMAIN_RESTORATION {
                     description "none";
                 }
-                enum end-to-end-restoration {
+                enum END_TO_END_RESTORATION {
                     description "none";
                 }
-                enum na {
+                enum NA {
                     description "none";
                 }
             }
@@ -592,25 +592,25 @@ module tapi-topology {
         }
         typedef protection-type {
             type enumeration {
-                enum no-protecton {
+                enum NO_PROTECTON {
                     description "none";
                 }
-                enum one-plus-one-protection {
+                enum ONE_PLUS_ONE_PROTECTION {
                     description "none";
                 }
-                enum one-plus-one-protection-with-dynamic-restoration {
+                enum ONE_PLUS_ONE_PROTECTION_WITH_DYNAMIC_RESTORATION {
                     description "none";
                 }
-                enum permanent-one-plus-one-protection {
+                enum PERMANENT_ONE_PLUS_ONE_PROTECTION {
                     description "none";
                 }
-                enum one-for-one-protection {
+                enum ONE_FOR_ONE_PROTECTION {
                     description "none";
                 }
-                enum dynamic-restoration {
+                enum DYNAMIC_RESTORATION {
                     description "none";
                 }
-                enum pre-computed-restoration {
+                enum PRE_COMPUTED_RESTORATION {
                     description "none";
                 }
             }


### PR DESCRIPTION
- Changes due to Eagle Uml2Yang tool updates to preserve UML literal names
-- the Eagle Uml2Yang tool was updated to preserve the literal names as defined in UML model. Since TAPI UML uses "ALL_CAPS" for enumeration literals, the resulting yang enums are now named in "ALL_CAPS"

- Changes due to Eagle Uml2Yang tool update to handle ExtendedComposite
-- the previous versions of the Uml2Yang tool was treating ExtendedComposite same as StrictComposite by generating container/list statement. Now the tool generates "uses" statement for
ExtendedComposite without the enclosing container/list statement.