### PR TITLE
Connectivity & Topology Model Optimization Updates

### DIFF
--- a/SWAGGER/tapi-connectivity.swagger
+++ b/SWAGGER/tapi-connectivity.swagger
@@ -12739,18 +12739,6 @@
                                 "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
                             }
                         },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
                         "route": {
                             "type": "array",
                             "items": {
@@ -12811,26 +12799,22 @@
                                 "ETY"
                             ]
                         },
-                        "client-node-edge-point": {
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "parent-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
                         "connection-port-direction": {
@@ -12986,17 +12970,6 @@
                 },
                 {
                     "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
@@ -13006,6 +12979,10 @@
                                 "ETH",
                                 "ETY"
                             ]
+                        },
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -13661,13 +13638,6 @@
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
                         },
                         "layer-protocol-name": {

--- a/SWAGGER/tapi-eth.swagger
+++ b/SWAGGER/tapi-eth.swagger
@@ -2227,13 +2227,6 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {
@@ -2803,18 +2796,6 @@
                                 "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
                             }
                         },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
                         "route": {
                             "type": "array",
                             "items": {
@@ -2875,26 +2856,22 @@
                                 "ETY"
                             ]
                         },
-                        "client-node-edge-point": {
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "parent-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
                         "connection-port-direction": {
@@ -3050,17 +3027,6 @@
                 },
                 {
                     "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
@@ -3070,6 +3036,10 @@
                                 "ETH",
                                 "ETY"
                             ]
+                        },
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"

--- a/SWAGGER/tapi-oam.swagger
+++ b/SWAGGER/tapi-oam.swagger
@@ -16019,18 +16019,6 @@
                                 "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
                             }
                         },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
                         "route": {
                             "type": "array",
                             "items": {
@@ -16091,26 +16079,22 @@
                                 "ETY"
                             ]
                         },
-                        "client-node-edge-point": {
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "parent-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
                         "connection-port-direction": {
@@ -16266,17 +16250,6 @@
                 },
                 {
                     "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
@@ -16286,6 +16259,10 @@
                                 "ETH",
                                 "ETY"
                             ]
+                        },
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -16665,13 +16642,6 @@
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
                         },
                         "layer-protocol-name": {

--- a/SWAGGER/tapi-odu.swagger
+++ b/SWAGGER/tapi-odu.swagger
@@ -1927,18 +1927,6 @@
                                 "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
                             }
                         },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
                         "route": {
                             "type": "array",
                             "items": {
@@ -1999,26 +1987,22 @@
                                 "ETY"
                             ]
                         },
-                        "client-node-edge-point": {
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "parent-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
                         "connection-port-direction": {
@@ -2174,17 +2158,6 @@
                 },
                 {
                     "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
@@ -2194,6 +2167,10 @@
                                 "ETH",
                                 "ETY"
                             ]
+                        },
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -2573,13 +2550,6 @@
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
                         },
                         "layer-protocol-name": {

--- a/SWAGGER/tapi-otsi.swagger
+++ b/SWAGGER/tapi-otsi.swagger
@@ -1380,18 +1380,6 @@
                                 "description": "An Connection object supports a recursive aggregation relationship such that the internal construction of an Connection can be exposed as multiple lower level Connection objects (partitioning).\nAggregation is used as for the Node/Topology  to allow changes in hierarchy. \nConnection aggregation reflects Node/Topology aggregation. \nThe FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning."
                             }
                         },
-                        "supported-link": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid",
-                                "description": "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer."
-                            }
-                        },
-                        "container-node": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                        },
                         "route": {
                             "type": "array",
                             "items": {
@@ -1452,26 +1440,22 @@
                                 "ETY"
                             ]
                         },
-                        "client-node-edge-point": {
+                        "connectivity-service-end-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id"
+                        },
+                        "parent-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "server-node-edge-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                        },
-                        "peer-connection-end-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                        },
-                        "associated-route": {
+                        "client-node-edge-point": {
                             "type": "array",
                             "items": {
                                 "type": "string",
-                                "x-path": "/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id"
+                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
                         "connection-port-direction": {
@@ -1627,17 +1611,6 @@
                 },
                 {
                     "properties": {
-                        "service-interface-point": {
-                            "type": "string",
-                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
-                        },
-                        "connection-end-point": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "string",
                             "enum": [
@@ -1647,6 +1620,10 @@
                                 "ETH",
                                 "ETY"
                             ]
+                        },
+                        "service-interface-point": {
+                            "type": "string",
+                            "x-path": "/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid"
                         },
                         "capacity": {
                             "$ref": "#/definitions/capacity-pac"
@@ -2026,13 +2003,6 @@
                             "items": {
                                 "type": "string",
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
-                            }
-                        },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
                             }
                         },
                         "layer-protocol-name": {

--- a/SWAGGER/tapi-path-computation.swagger
+++ b/SWAGGER/tapi-path-computation.swagger
@@ -9805,13 +9805,6 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {

--- a/SWAGGER/tapi-topology.swagger
+++ b/SWAGGER/tapi-topology.swagger
@@ -6775,13 +6775,6 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {

--- a/SWAGGER/tapi-virtual-network.swagger
+++ b/SWAGGER/tapi-virtual-network.swagger
@@ -9892,13 +9892,6 @@
                                 "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid"
                             }
                         },
-                        "node": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "x-path": "/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid"
-                            }
-                        },
                         "layer-protocol-name": {
                             "type": "array",
                             "items": {

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -147,14 +147,6 @@
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ihp2oUwPEeewALXL7BvPYw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mMWNCEee0bPnI-Gt-mQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd4mMmNCEee0bPnI-Gt-mQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_U4LlsUwOEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mM2NCEee0bPnI-Gt-mQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd4mNGNCEee0bPnI-Gt-mQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_niJd9WkKEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mNWNCEee0bPnI-Gt-mQ"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_Gd4mNmNCEee0bPnI-Gt-mQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mN2NCEee0bPnI-Gt-mQ"/>
@@ -1874,7 +1866,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3OjBGEeam35bpdXJzEw" y="5"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="677" y="79" width="167" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BlU3aDBGEeam35bpdXJzEw" x="692" y="79" width="167" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BlU3yjBGEeam35bpdXJzEw" type="2011">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3yzBGEeam35bpdXJzEw" type="5037"/>
@@ -1960,9 +1952,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bn3K2jBGEeam35bpdXJzEw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Bn3K2zBGEeam35bpdXJzEw" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bn3K3TBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bn3K3TBGEeam35bpdXJzEw" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bn3K3DBGEeam35bpdXJzEw" x="1073" y="369"/>
     </children>
@@ -2386,7 +2376,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgsxMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="884" y="180" width="194" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_luMgoRMjEee0L_IMWjydgQ" x="912" y="180" width="157" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6_LyABMjEee0L_IMWjydgQ" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_6_LyAhMjEee0L_IMWjydgQ" type="5029"/>
@@ -2412,7 +2402,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyExMjEee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="821" y="-110" width="229" height="59"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_LyARMjEee0L_IMWjydgQ" x="820" y="-94" width="229" height="59"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_UI4IaxMmEee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_UI4IbBMmEee0L_IMWjydgQ" showTitle="true"/>
@@ -2675,7 +2665,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU11TBGEeam35bpdXJzEw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU1WTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU11jBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="-15" y="-8"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU11zBGEeam35bpdXJzEw" x="-22" y="-4"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU12DBGEeam35bpdXJzEw" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU12TBGEeam35bpdXJzEw" x="-31" y="-3"/>
@@ -2695,8 +2685,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU14jBGEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU15jBGEeam35bpdXJzEw" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.4855769230769231,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.5174825174825175,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU15zBGEeam35bpdXJzEw" id="(0.6442307692307693,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU16DBGEeam35bpdXJzEw" id="(0.7482517482517482,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU2ozBGEeam35bpdXJzEw" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU2tzBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU2pDBGEeam35bpdXJzEw" type="6001">
@@ -2748,31 +2738,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DTBGEeam35bpdXJzEw" id="(0.625,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3DjBGEeam35bpdXJzEw" id="(0.41700404858299595,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BlU3DzBGEeam35bpdXJzEw" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3EDBGEeam35bpdXJzEw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ETBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3EjBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3EzBGEeam35bpdXJzEw" x="32" y="11"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3FDBGEeam35bpdXJzEw" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3FTBGEeam35bpdXJzEw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3FjBGEeam35bpdXJzEw" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3FzBGEeam35bpdXJzEw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3GDBGEeam35bpdXJzEw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3GTBGEeam35bpdXJzEw" x="13" y="-18"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_BlU3GjBGEeam35bpdXJzEw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3GzBGEeam35bpdXJzEw" x="-9" y="-12"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_BlU3HDBGEeam35bpdXJzEw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlU3IDBGEeam35bpdXJzEw" points="[0, 0, 262, 49]$[0, -49, 262, 0]$[-262, -49, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3ITBGEeam35bpdXJzEw" id="(0.2155688622754491,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlU3IjBGEeam35bpdXJzEw" id="(1.0,0.453125)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BlU3IzBGEeam35bpdXJzEw" type="4014" source="_BlU3yjBGEeam35bpdXJzEw" target="_ijqBwEwPEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_BlU3JDBGEeam35bpdXJzEw"/>
       <element xsi:nil="true"/>
@@ -2785,7 +2750,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3azBGEeam35bpdXJzEw" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bDBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="19" y="7"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bTBGEeam35bpdXJzEw" x="37" y="6"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3bjBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3bzBGEeam35bpdXJzEw" y="-20"/>
@@ -2863,7 +2828,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3uDBGEeam35bpdXJzEw" x="-3" y="28"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3uTBGEeam35bpdXJzEw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ujBGEeam35bpdXJzEw" x="-3" y="14"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3ujBGEeam35bpdXJzEw" x="2" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlU3uzBGEeam35bpdXJzEw" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlU3vDBGEeam35bpdXJzEw" y="-20"/>
@@ -2952,16 +2917,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BmhHEDBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHETBGEeam35bpdXJzEw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BmhHEjBGEeam35bpdXJzEw"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Bn3K3jBGEeam35bpdXJzEw" type="StereotypeCommentLink" source="_BlU3DzBGEeam35bpdXJzEw" target="_Bn3K2jBGEeam35bpdXJzEw">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Bn3K3zBGEeam35bpdXJzEw"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Bn3K4zBGEeam35bpdXJzEw" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiConnectivity.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Bn3K4DBGEeam35bpdXJzEw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bn3K4TBGEeam35bpdXJzEw"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bn3K4jBGEeam35bpdXJzEw"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__JVmRzIvEeamvfKYyWmELQ" type="StereotypeCommentLink" source="_BlU0MDBGEeam35bpdXJzEw" target="__JVmQzIvEeamvfKYyWmELQ">
       <styles xmi:type="notation:FontStyle" xmi:id="__JVmSDIvEeamvfKYyWmELQ"/>
@@ -3143,37 +3098,12 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUMhsEeaVlemTikmRHw" id="(0.9456869009584664,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mxsnUchsEeaVlemTikmRHw" id="(0.3173076923076923,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_lu32EBMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32ExMjEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32FBMjEee0L_IMWjydgQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32FRMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32FhMjEee0L_IMWjydgQ" x="6" y="-9"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32FxMjEee0L_IMWjydgQ" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32GBMjEee0L_IMWjydgQ" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32GRMjEee0L_IMWjydgQ" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32GhMjEee0L_IMWjydgQ" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32GxMjEee0L_IMWjydgQ" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32HBMjEee0L_IMWjydgQ" x="16" y="13"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_lu32HRMjEee0L_IMWjydgQ" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lu32HhMjEee0L_IMWjydgQ" x="-8" y="9"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_lu32ERMjEee0L_IMWjydgQ"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lu32EhMjEee0L_IMWjydgQ" points="[0, 0, -107, -57]$[107, 0, 0, -57]$[107, 57, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32HxMjEee0L_IMWjydgQ" id="(1.0,0.7413793103448276)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lu32IBMjEee0L_IMWjydgQ" id="(0.34536082474226804,0.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_piyMkBMjEee0L_IMWjydgQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_piyMkxMjEee0L_IMWjydgQ" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_piyMlBMjEee0L_IMWjydgQ" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_piyMlRMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_piyMlhMjEee0L_IMWjydgQ" x="-16" y="12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_piyMlhMjEee0L_IMWjydgQ" x="-20" y="15"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_piyMlxMjEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_piyMmBMjEee0L_IMWjydgQ" y="-20"/>
@@ -3189,16 +3119,16 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_piyMkRMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -142, 73]$[142, 0, 0, 73]$[142, -73, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_piyMkhMjEee0L_IMWjydgQ" points="[0, 0, -152, 73]$[152, 0, 0, 73]$[152, -73, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMnxMjEee0L_IMWjydgQ" id="(1.0,0.4603174603174603)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.4939271255060729,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_piyMoBMjEee0L_IMWjydgQ" id="(0.49044585987261147,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7AFw8BMjEee0L_IMWjydgQ" type="4001" source="_BlU3KDBGEeam35bpdXJzEw" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw8xMjEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="7" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9BMjEee0L_IMWjydgQ" x="-5" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9RMjEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="24" y="1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw9hMjEee0L_IMWjydgQ" x="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_7AFw9xMjEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_7AFw-BMjEee0L_IMWjydgQ" y="-20"/>
@@ -3215,15 +3145,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_7AFw8RMjEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7AFw8hMjEee0L_IMWjydgQ" points="[0, 0, 508, 132]$[-508, -132, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFw_xMjEee0L_IMWjydgQ" id="(0.9401197604790419,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFw_xMjEee0L_IMWjydgQ" id="(0.8502994011976048,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7AFxABMjEee0L_IMWjydgQ" id="(0.0611353711790393,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Fd7BwBMkEee0L_IMWjydgQ" type="4001" source="_luMgoBMjEee0L_IMWjydgQ" target="_6_LyABMjEee0L_IMWjydgQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BwxMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="63" y="-1"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxBMkEee0L_IMWjydgQ" x="23" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxRMkEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="74" y="-12"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7BxhMkEee0L_IMWjydgQ" x="37" y="2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_Fd7BxxMkEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Fd7ByBMkEee0L_IMWjydgQ" y="-20"/>
@@ -3240,15 +3170,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Fd7BwRMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Fd7BwhMkEee0L_IMWjydgQ" points="[0, 0, 89, 177]$[-60, -118, 29, 59]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.7783505154639175,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.9301310043668122,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7BzxMkEee0L_IMWjydgQ" id="(0.5859872611464968,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Fd7B0BMkEee0L_IMWjydgQ" id="(0.8034934497816594,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_tVhB4BMkEee0L_IMWjydgQ" type="4001" source="_6_LyABMjEee0L_IMWjydgQ" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB4xMkEee0L_IMWjydgQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5BMkEee0L_IMWjydgQ" x="-21" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5BMkEee0L_IMWjydgQ" x="7"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB5RMkEee0L_IMWjydgQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5hMkEee0L_IMWjydgQ" x="-39" y="-3"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB5hMkEee0L_IMWjydgQ" x="-8" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_tVhB5xMkEee0L_IMWjydgQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_tVhB6BMkEee0L_IMWjydgQ" y="-20"/>
@@ -3264,9 +3194,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_tVhB4RMkEee0L_IMWjydgQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 95, -138]$[0, 138, 95, 0]$[-95, 138, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.5152838427947598,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB8BMkEee0L_IMWjydgQ" id="(1.0,0.13793103448275862)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tVhB4hMkEee0L_IMWjydgQ" points="[0, 0, 84, -143]$[-84, 0, 0, -143]$[-84, 143, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB7xMkEee0L_IMWjydgQ" id="(0.0,0.5084745762711864)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tVhB8BMkEee0L_IMWjydgQ" id="(0.2634730538922156,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_UI4IbxMmEee0L_IMWjydgQ" type="StereotypeCommentLink" source="_luMgoBMjEee0L_IMWjydgQ" target="_UI4IaxMmEee0L_IMWjydgQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_UI4IcBMmEee0L_IMWjydgQ"/>
@@ -3348,31 +3278,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJZ0q9EeexQa2RWFy3AQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_w3MJaEq9EeexQa2RWFy3AQ"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_VZoF4EwOEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_luMgoBMjEee0L_IMWjydgQ">
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF40wOEeewALXL7BvPYw" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5EwOEeewALXL7BvPYw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF5UwOEeewALXL7BvPYw" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF5kwOEeewALXL7BvPYw" x="-47" y="-10"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF50wOEeewALXL7BvPYw" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6EwOEeewALXL7BvPYw" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF6UwOEeewALXL7BvPYw" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF6kwOEeewALXL7BvPYw" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF60wOEeewALXL7BvPYw" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF7EwOEeewALXL7BvPYw" x="11" y="-17"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VZoF7UwOEeewALXL7BvPYw" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VZoF7kwOEeewALXL7BvPYw" x="-9" y="-10"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_VZoF4UwOEeewALXL7BvPYw"/>
-      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_U4H7UEwOEeewALXL7BvPYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VZoF4kwOEeewALXL7BvPYw" points="[0, 0, -465, -137]$[0, 137, -465, 0]$[465, 137, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbFecEwOEeewALXL7BvPYw" id="(0.8461538461538461,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VbGFgEwOEeewALXL7BvPYw" id="(0.0,0.3728813559322034)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ijqBwEwPEeewALXL7BvPYw" type="4001" source="_BlU0cTBGEeam35bpdXJzEw" target="_BlU0cTBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_ijqBw0wPEeewALXL7BvPYw" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ijqBxEwPEeewALXL7BvPYw" y="-20"/>
@@ -3443,10 +3348,10 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_HPiAQGJrEeek3OrhDuslYQ" type="4001" source="_BlU1BDBGEeam35bpdXJzEw" target="_BlU3KDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_HPiAQ2JrEeek3OrhDuslYQ" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUGJrEeek3OrhDuslYQ" x="36" y="4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUGJrEeek3OrhDuslYQ" x="12" y="3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HPinUWJrEeek3OrhDuslYQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUmJrEeek3OrhDuslYQ" x="48" y="22"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinUmJrEeek3OrhDuslYQ" x="29" y="-2"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_HPinU2JrEeek3OrhDuslYQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_HPinVGJrEeek3OrhDuslYQ" y="-20"/>
@@ -3464,7 +3369,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HPiAQmJrEeek3OrhDuslYQ" points="[0, 0, 24, 204]$[-18, -146, 6, 58]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinW2JrEeek3OrhDuslYQ" id="(0.7867647058823529,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinXGJrEeek3OrhDuslYQ" id="(0.7844311377245509,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HPinXGJrEeek3OrhDuslYQ" id="(0.6946107784431138,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_HPsYUWJrEeek3OrhDuslYQ" type="StereotypeCommentLink" source="_HPiAQGJrEeek3OrhDuslYQ" target="_HPrxQ2JrEeek3OrhDuslYQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_HPsYUmJrEeek3OrhDuslYQ"/>
@@ -3621,15 +3526,15 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMc6LTEeeG6K0eZHmVww" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3aUMdKLTEeeG6K0eZHmVww" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMdaLTEeeG6K0eZHmVww" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aUMdaLTEeeG6K0eZHmVww" x="10" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_3aWosKLTEeeG6K0eZHmVww" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aWosaLTEeeG6K0eZHmVww" y="-20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3aWosaLTEeeG6K0eZHmVww" x="-10" y="-16"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_3aRwMaLTEeeG6K0eZHmVww"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_3TemUMhmEeaVlemTikmRHw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3aRwMqLTEeeG6K0eZHmVww" points="[0, 0, 820, -143]$[-820, 143, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZE8KLTEeeG6K0eZHmVww" id="(0.48034934497816595,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZE8KLTEeeG6K0eZHmVww" id="(0.4759825327510917,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aZE8aLTEeeG6K0eZHmVww" id="(0.46601941747572817,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3a3mFKLTEeeG6K0eZHmVww" type="StereotypeCommentLink" source="_3aRwMKLTEeeG6K0eZHmVww" target="_3a3mEKLTEeeG6K0eZHmVww">
@@ -3670,7 +3575,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlYrgKOTEeeDzr1ZQC1JMQ" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlYrgaOTEeeDzr1ZQC1JMQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSkKOTEeeDzr1ZQC1JMQ" x="31" y="-23"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSkKOTEeeDzr1ZQC1JMQ" x="-12" y="-3"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_BlZSkaOTEeeDzr1ZQC1JMQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BlZSkqOTEeeDzr1ZQC1JMQ" y="-20"/>
@@ -3688,7 +3593,7 @@
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BlSk4qOTEeeDzr1ZQC1JMQ" points="[0, 0, 24, 204]$[-18, -146, 6, 58]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Blmt8KOTEeeDzr1ZQC1JMQ" id="(0.125,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlnVAKOTEeeDzr1ZQC1JMQ" id="(0.24550898203592814,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BlnVAKOTEeeDzr1ZQC1JMQ" id="(0.15568862275449102,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_eIpYwMZSEeeAD9H5zOiMUQ" type="4001" source="_BlU1WTBGEeam35bpdXJzEw" target="_BlU1BDBGEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_eIscEMZSEeeAD9H5zOiMUQ" type="6001">
@@ -3734,10 +3639,6 @@
         <children xmi:type="notation:Shape" xmi:id="_ZBp6ssZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBp6s8ZbEeeAD9H5zOiMUQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBqhwMZbEeeAD9H5zOiMUQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_cfZ_c4bpEeWLkaOCu--9xg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhwcZbEeeAD9H5zOiMUQ"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_ZBqhwsZbEeeAD9H5zOiMUQ" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
@@ -4430,10 +4331,6 @@
         <children xmi:type="notation:Shape" xmi:id="_r7GsgusbEealN7CdLT_GPw" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_r7Gsg-sbEealN7CdLT_GPw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_r7GshOsbEealN7CdLT_GPw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_niJd9WkKEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_r7GshesbEealN7CdLT_GPw"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_r7H6oOsbEealN7CdLT_GPw" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_QZdZkusUEealN7CdLT_GPw"/>

--- a/UML/TapiConnectivity.notation
+++ b/UML/TapiConnectivity.notation
@@ -7,45 +7,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0G9yijBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0G9yizBFEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_Rz6qUGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyxRgNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4Es8M2kIEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz6qUWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyxRgdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz7RYGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyx4kNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_4EtL4EUcEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz7RYWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyx4kdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz7RYmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyx4ktoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_WFu44u_qEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz7RY2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyx4k9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz7RZGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyyfoNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TyD6Qv4yEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz7RZWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfodoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz7RZmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyyfotoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nfDxo-_pEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz7RZ2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfo9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz74cGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyyfpNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_caIFkNnlEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz74cWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfpdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Rz74cmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyyfptoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kuDzQ0HaEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rz74c2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfp9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_LlavcIfbEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyyfqNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MKK0kIfWEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_LlavcYfbEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyyfqdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2vrn8IfgEeet-8tHdGGp_w" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyzGsNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2vrn8YfgEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyzGsdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2vs2EIfgEeet-8tHdGGp_w" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_cyzGstoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2vs2EYfgEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_cyzGs9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G9zbDBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G9zbTBFEeam35bpdXJzEw"/>
@@ -73,45 +73,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0G91jzBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0G91kDBFEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_Ud_3EIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poGlMNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_lY2XULvZEeWYrqoqXLgguw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ud_3EYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poGlMdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBFMIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHMQNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3bhE4L2BEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBFMYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHMQdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBFMohGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHMQtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_1dtjYIfYEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBFM4hGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHMQ9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBFNIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHMRNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_-YtW8L11EeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBFNYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHMRdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBFNohGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzUNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ru76gGNFEee0bPnI-Gt-mQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBFN4hGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzUdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBsQIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzUtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_RhdgwL2HEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsQYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzU9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBsQohGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzVNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_GqeeML2JEeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsQ4hGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzVdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBsRIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzVtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_7Zr48IfgEeet-8tHdGGp_w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsRYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzV9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBsRohGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzWNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_l8TgscF3EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsR4hGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzWdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_UeBsSIhGEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_poHzWtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wt-RckXOEeaB8vMnkFQLXQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_UeBsSYhGEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_poHzW9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0G928TBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0G928jBFEeam35bpdXJzEw"/>
@@ -139,41 +139,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHiozBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0HHipDBFEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_Gd3_IGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f458ANoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ijcPo2kHEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd3_IWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f458AdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd4mMGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f458AtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ihp2oUwPEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mMWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f458A9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd4mNmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f458BNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd4mN2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f458BdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd5NQGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f46jENoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_QZdZkusUEealN7CdLT_GPw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd5NQWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f46jEdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd5NQmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f46jEtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B0rIk-_sEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd5NQ2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f46jE9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd5NRGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f46jFNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_V2I0INnlEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd5NRWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f46jFdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd5NRmNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f46jFtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IZ3vc0HbEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd5NR2NCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f46jF9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd5NSGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f46jGNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd5NSWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f46jGdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Gd50UGNCEee0bPnI-Gt-mQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_f47KINoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Gd50UWNCEee0bPnI-Gt-mQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_f47KIdoHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0HHjbDBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0HHjbTBFEeam35bpdXJzEw"/>
@@ -193,7 +193,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjeTBFEeam35bpdXJzEw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjpzBFEeam35bpdXJzEw" x="719" y="230" height="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0HHjpzBFEeam35bpdXJzEw" x="719" y="230" height="196"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0HHjqDBFEeam35bpdXJzEw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_0HHjqTBFEeam35bpdXJzEw" type="5029"/>
@@ -239,37 +239,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_0HHlMzBFEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_0HHlNDBFEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_ThJgsGJcEeek3OrhDuslYQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQBBwNoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nPhusKhLEeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQBBwdoHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_jQBo0NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThJgsWJcEeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQBo0doHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ThKHwmJcEeek3OrhDuslYQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQBo0toHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_EN4L8WJREeek3OrhDuslYQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKHw2JcEeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQBo09oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ThKu0GJcEeek3OrhDuslYQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQBo1NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKu0WJcEeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQBo1doHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ThKu0mJcEeek3OrhDuslYQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQCP4NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKu02JcEeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQCP4doHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ThKu1GJcEeek3OrhDuslYQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQCP4toHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ThKu1WJcEeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQCP49oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_5K17cIfjEeet-8tHdGGp_w" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQCP5NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_207M8IfjEeet-8tHdGGp_w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_5K17cYfjEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQCP5doHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_5K17cofjEeet-8tHdGGp_w" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQCP5toHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_5K17c4fjEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQCP59oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_5K17dIfjEeet-8tHdGGp_w" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_jQCP6NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_5K17dYfjEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_jQCP6doHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_0HHl3DBFEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_0HHl3TBFEeam35bpdXJzEw"/>
@@ -813,41 +817,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_BDPgJP4xEea_VPdGG2-szQ" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_BDPgJf4xEea_VPdGG2-szQ" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_au4DYE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dMgNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nxcI8jLCEeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4DYU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dMgdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au4qcE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzkNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_c8MLxDLEEeaULOmJRJKM0Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qcU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzkdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au4qck5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzktoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_wGVAhMF-EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qc05rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzk9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au4qdE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzlNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_xyluAsF-EeaALJQAf08uAg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au4qdU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzldoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au5RgE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzltoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Ca3vhP4zEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5RgU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzl9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au5Rgk5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzmNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MjEHhP4zEea_VPdGG2-szQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5Rg05rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzmdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au5RhE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4dzmtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_tAVeAE5qEeeicu4cm-7qRg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au5RhU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4dzm9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au54kE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4eaoNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_5TDM0U5qEeeicu4cm-7qRg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au54kU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4eaodoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_au6foE5rEeeicu4cm-7qRg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_n4eaotoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_3_SWwL11EeWdore3Cxez9g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_au6foU5rEeeicu4cm-7qRg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n4eao9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_BDPgJv4xEea_VPdGG2-szQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_BDPgJ_4xEea_VPdGG2-szQ"/>
@@ -883,49 +887,49 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__Y_oIYfVEeeirpBaj87qAw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__Y_oIofVEeeirpBaj87qAw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_CdnPsIfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV4urzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CdnPsYfWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdn2wIfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV5erzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdn2wYfWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdod0IfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV7OrzEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdod0YfWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdod0ofWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kKvJ4PKiEeaAIfPpmDwI5Q"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdod04fWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdod1IfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_zpUU8O4GEeaRONVEJOGI1g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdod1YfWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdod1ofWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nuZ_TOryEeaeHOJw3lCT8A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdod14fWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_CdpE4IfWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CdpE4YfWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_CdpE4ofWEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_l_p30NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_0gCMcIfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CdpE44fWEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_p30doHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_CdpE5IfWEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_l_p30toHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#__jB_0IfTEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CdpE5YfWEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_p309oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_CdpE5ofWEeeirpBaj87qAw" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_k13kMIfUEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CdpE54fWEeeirpBaj87qAw"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_Cdpr8IfWEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_l_qe4NoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_rgC9MIfUEeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Cdpr8YfWEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe4doHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_qe4toHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV4urzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe49oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_qe5NoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV5erzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe5doHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_qe5toHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MBqV7OrzEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe59oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_qe6NoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_kKvJ4PKiEeaAIfPpmDwI5Q"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe6doHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_qe6toHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_zpUU8O4GEeaRONVEJOGI1g"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_qe69oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_rF8NoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nuZ_TOryEeaeHOJw3lCT8A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF8doHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_rF8toHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_k13kMIfUEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF89oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_l_rF9NoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_fkqlwIfTEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_l_rF9doHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__Y_oI4fVEeeirpBaj87qAw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__Y_oJIfVEeeirpBaj87qAw"/>
@@ -1003,33 +1007,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_SCZesIhDEeeOl5P_FBJSmA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_SCZesYhDEeeOl5P_FBJSmA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_TUQIIIhDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXA0QNoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXA0QdoIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MXA0QtoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHpeAHIzEeeSiaQ95-6r9w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXA0Q9oIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MXBbUNoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXBbUdoIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MXBbUtoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQIIYhDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXBbU9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQvMohDEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQvM4hDEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQvNIhDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXBbVNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQvNYhDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXBbVdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQvNohDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXBbVtoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXBbV9oIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_MXBbWNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQvN4hDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXBbWdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TUQvOIhDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXCCYNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TUQvOYhDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXCCYdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TURWQIhDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXCCYtoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TURWQYhDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXCCY9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TURWQohDEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_MXCCZNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TURWQ4hDEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_MXCCZdoIEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_SCZesohDEeeOl5P_FBJSmA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_SCZes4hDEeeOl5P_FBJSmA"/>
@@ -1049,7 +1065,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCZev4hDEeeOl5P_FBJSmA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCXpgYhDEeeOl5P_FBJSmA" x="715" y="-296" height="203"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SCXpgYhDEeeOl5P_FBJSmA" x="715" y="-296" width="386" height="206"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_SCrLgIhDEeeOl5P_FBJSmA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_SCrLgYhDEeeOl5P_FBJSmA" showTitle="true"/>
@@ -1207,9 +1223,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_0HHlKTBFEeam35bpdXJzEw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlLTBFEeam35bpdXJzEw" points="[0, 0, 278, 65]$[-278, 0, 0, 65]$[-278, -65, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLjBFEeam35bpdXJzEw" id="(0.0,0.3548387096774194)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLzBFEeam35bpdXJzEw" id="(0.7664233576642335,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0HHlLTBFEeam35bpdXJzEw" points="[0, 0, 278, 63]$[-278, 0, 0, 63]$[-278, -63, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLjBFEeam35bpdXJzEw" id="(0.0,0.3826530612244898)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0HHlLzBFEeam35bpdXJzEw" id="(0.7657342657342657,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_0KiqFDBFEeam35bpdXJzEw" type="StereotypeCommentLink" source="_0HHlHDBFEeam35bpdXJzEw" target="_0KiqEDBFEeam35bpdXJzEw">
       <styles xmi:type="notation:FontStyle" xmi:id="_0KiqFTBFEeam35bpdXJzEw"/>
@@ -1526,8 +1542,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_i926QYhDEeeOl5P_FBJSmA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i926QohDEeeOl5P_FBJSmA" points="[0, 0, 9, 252]$[-2, -49, 7, 203]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcIhDEeeOl5P_FBJSmA" id="(0.4440789473684211,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcYhDEeeOl5P_FBJSmA" id="(0.5387596899224806,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcIhDEeeOl5P_FBJSmA" id="(0.5526315789473685,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i94vcYhDEeeOl5P_FBJSmA" id="(0.4430051813471503,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_4p8MMIhDEeeOl5P_FBJSmA" type="4001" source="_SCXpgIhDEeeOl5P_FBJSmA" target="_0HHioDBFEeam35bpdXJzEw">
       <children xmi:type="notation:DecorationNode" xmi:id="_4p8MM4hDEeeOl5P_FBJSmA" type="6001">
@@ -1550,7 +1566,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_4p8MMYhDEeeOl5P_FBJSmA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4p8MMohDEeeOl5P_FBJSmA" points="[0, 0, -4, -449]$[-88, 0, -92, -449]$[-88, 449, -92, 0]$[4, 449, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4p8MMohDEeeOl5P_FBJSmA" points="[0, 0, -4, -446]$[-88, 0, -92, -446]$[-88, 446, -92, 0]$[4, 446, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4p8zQIhDEeeOl5P_FBJSmA" id="(0.0,0.458128078817734)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4p8zQYhDEeeOl5P_FBJSmA" id="(0.0,0.07373271889400922)"/>
     </edges>
@@ -3628,45 +3644,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_LsrifzBGEeam35bpdXJzEw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_LsrigDBGEeam35bpdXJzEw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_ZBoskMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWpxoNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBoskcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWpxodoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBp6sMZbEeeAD9H5zOiMUQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBp6scZbEeeAD9H5zOiMUQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_XWqYsNoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHpeAHIzEeeSiaQ95-6r9w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWqYsdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBp6ssZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWqYstoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBp6s8ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWqYs9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBqhwsZbEeeAD9H5zOiMUQ" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhw8ZbEeeAD9H5zOiMUQ"/>
+        <children xmi:type="notation:Shape" xmi:id="_XWqYtNoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWqYtdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBqhxMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWqYttoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhxcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWqYt9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBqhxsZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWqYuNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhx8ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWqYudoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBqhyMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWq_wNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBqhycZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWq_wdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBrI0MZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWq_wtoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI0cZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWq_w9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBrI0sZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWq_xNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI08ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWq_xdoIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZBrI1MZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_XWq_xtoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZBrI1cZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XWq_x9oIEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_LsrjdjBGEeam35bpdXJzEw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_LsrjdzBGEeam35bpdXJzEw"/>
@@ -3760,29 +3776,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_rT1e8kwEEeewALXL7BvPYw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_rT1e80wEEeewALXL7BvPYw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_AR_ecEwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0d34NoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nPhusKhLEeeAVfY3jqnvAA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0d34doIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Z0ee8NoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_YyoyAmkJEeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR_ecUwGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0ee8doIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_AR_eckwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0ee8toIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_EN4L8WJREeek3OrhDuslYQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0ee89oIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Z0ee9NoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_nJqIEUwFEeewALXL7BvPYw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_AR_ec0wGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0ee9doIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ASAFgEwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0ee9toIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTK2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFgUwGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0ee99oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ASAFgkwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0ee-NoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_MIWTJ2h5EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFg0wGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0ee-doIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ASAFhEwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0fGANoIEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_207M8IfjEeet-8tHdGGp_w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0fGAdoIEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Z0fGAtoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAFhUwGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0fGA9oIEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ASAskEwGEeewALXL7BvPYw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_Z0fGBNoIEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_MP7aAJLQEeaqpNd__7dv4w"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ASAskUwGEeewALXL7BvPYw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Z0fGBdoIEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_rT1e9EwEEeewALXL7BvPYw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_rT1e9UwEEeewALXL7BvPYw"/>
@@ -3802,7 +3830,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT1fAUwEEeewALXL7BvPYw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT034UwEEeewALXL7BvPYw" x="15" y="306" height="155"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rT034UwEEeewALXL7BvPYw" x="11" y="354" width="306" height="196"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rT-o4EwEEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_rT-o4UwEEeewALXL7BvPYw" showTitle="true"/>
@@ -3844,7 +3872,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnum4UwFEeewALXL7BvPYw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnt_wUwFEeewALXL7BvPYw" x="607" y="345" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wnt_wUwFEeewALXL7BvPYw" x="603" y="393" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Wn2io0wFEeewALXL7BvPYw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Wn2ipEwFEeewALXL7BvPYw" showTitle="true"/>
@@ -4018,8 +4046,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_nLYmYUwFEeewALXL7BvPYw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_nJo58EwFEeewALXL7BvPYw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nLYmYkwFEeewALXL7BvPYw" points="[15, 0, -301, -9]$[306, 6, -10, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.47096774193548385)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQUwFEeewALXL7BvPYw" id="(0.0,0.3655913978494624)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQEwFEeewALXL7BvPYw" id="(1.0,0.4387755102040816)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nMlgQUwFEeewALXL7BvPYw" id="(0.0,0.5053763440860215)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_uUeThEwGEeewALXL7BvPYw" type="StereotypeCommentLink" source="_nLYmYEwFEeewALXL7BvPYw" target="_uUeTgEwGEeewALXL7BvPYw">
       <styles xmi:type="notation:FontStyle" xmi:id="_uUeThUwGEeewALXL7BvPYw"/>
@@ -4075,6 +4103,31 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zl1ZdsZaEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zl1Zd8ZaEeeAD9H5zOiMUQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zl1ZeMZaEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gyjrYNoIEeeYx-v40uoW_Q" type="4001" source="_LsrifDBGEeam35bpdXJzEw" target="_rT034EwEEeewALXL7BvPYw">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykScNoIEeeYx-v40uoW_Q" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykScdoIEeeYx-v40uoW_Q" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykSctoIEeeYx-v40uoW_Q" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykSc9oIEeeYx-v40uoW_Q" x="-2" y="-1"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykSdNoIEeeYx-v40uoW_Q" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykSddoIEeeYx-v40uoW_Q" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykSdtoIEeeYx-v40uoW_Q" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykSd9oIEeeYx-v40uoW_Q" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykSeNoIEeeYx-v40uoW_Q" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykSedoIEeeYx-v40uoW_Q" x="18" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gykSetoIEeeYx-v40uoW_Q" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gykSe9oIEeeYx-v40uoW_Q" x="-18" y="-24"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_gyjrYdoIEeeYx-v40uoW_Q"/>
+      <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hF804HIzEeeSiaQ95-6r9w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gyjrYtoIEeeYx-v40uoW_Q" points="[57, 218, -13, -46]$[70, 264, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gyk5gNoIEeeYx-v40uoW_Q" id="(0.46206896551724136,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gyk5gdoIEeeYx-v40uoW_Q" id="(0.4411764705882353,0.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_l51YUOr0EeaeHOJw3lCT8A" type="PapyrusUMLClassDiagram" name="Resilience" measurementUnit="Pixel">
@@ -4208,7 +4261,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ryFlM-r0EeaeHOJw3lCT8A"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_jwuBoOryEeaeHOJw3lCT8A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ryFlIer0EeaeHOJw3lCT8A" x="382" y="157" height="164"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ryFlIer0EeaeHOJw3lCT8A" x="385" y="184" height="164"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ryRye-r0EeaeHOJw3lCT8A" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_ryRyfOr0EeaeHOJw3lCT8A" showTitle="true"/>
@@ -4374,7 +4427,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W43igesTEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W4xb0esTEealN7CdLT_GPw" x="174" y="-231" width="312" height="189"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W4xb0esTEealN7CdLT_GPw" x="178" y="-306" width="312" height="189"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W5Dvy-sTEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_W5DvzOsTEealN7CdLT_GPw" showTitle="true"/>
@@ -4422,33 +4475,45 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="__j6ptOscEealN7CdLT_GPw" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="__j6ptescEealN7CdLT_GPw" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_TNxiIIhCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WfkQNoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_IOhXAKeWEeeBGPv_1DT5og"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WfkQdoHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="__WfkQtoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_hHpeAHIzEeeSiaQ95-6r9w"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WfkQ9oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="__WgLUNoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLUdoHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="__WgLUtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNxiIYhCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLU9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNyJMohCEeeOl5P_FBJSmA" type="3012">
-          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_p4y04EUeEeWEwNCluy4jrw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNyJM4hCEeeOl5P_FBJSmA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNyJNIhCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WgLVNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNyJNYhCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLVdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNyJNohCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WgLVtoHEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sGvxssZaEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLV9oHEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="__WgLWNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNyJN4hCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLWdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNywQIhCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WgLWtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiConnectivity.uml#_sIutJ2h-EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNywQYhCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgLW9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNywQohCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WgyYNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNywQ4hCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgyYdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_TNywRIhCEeeOl5P_FBJSmA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="__WgyYtoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_TNywRYhCEeeOl5P_FBJSmA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="__WgyY9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="__j6ptuscEealN7CdLT_GPw"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="__j6pt-scEealN7CdLT_GPw"/>
@@ -4468,7 +4533,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6pw-scEealN7CdLT_GPw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6psescEealN7CdLT_GPw" x="738" y="-77" width="269" height="220"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__j6psescEealN7CdLT_GPw" x="761" y="-77" width="395" height="208"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__kAwa-scEealN7CdLT_GPw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__kAwbOscEealN7CdLT_GPw" showTitle="true"/>
@@ -4640,9 +4705,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__MdIwesYEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#__LyaYOsYEealN7CdLT_GPw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MdIwusYEealN7CdLT_GPw" points="[0, 0, -204, -51]$[0, 51, -204, 0]$[204, 51, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__MdIwusYEealN7CdLT_GPw" points="[0, 0, -207, -51]$[0, 51, -207, 0]$[207, 51, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywOsYEealN7CdLT_GPw" id="(0.5655430711610487,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywesYEealN7CdLT_GPw" id="(0.0,0.3780487804878049)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__N-ywesYEealN7CdLT_GPw" id="(0.0,0.21341463414634146)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__NH3J-sYEealN7CdLT_GPw" type="StereotypeCommentLink" source="__MdIwOsYEealN7CdLT_GPw" target="__NH3I-sYEealN7CdLT_GPw">
       <styles xmi:type="notation:FontStyle" xmi:id="__NH3KOsYEealN7CdLT_GPw"/>
@@ -4710,7 +4775,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_lREA8escEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ZiXD4EUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 64, 67]$[-64, 0, 0, 67]$[-64, -67, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lREA8uscEealN7CdLT_GPw" points="[0, 0, 60, 142]$[-60, 0, 0, 142]$[-60, -142, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREA_-scEealN7CdLT_GPw" id="(0.0,0.2872340425531915)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lREBAOscEealN7CdLT_GPw" id="(0.6442307692307693,1.0)"/>
     </edges>
@@ -4755,9 +4820,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_OoQWIeseEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OoQWIuseEealN7CdLT_GPw" points="[0, 0, 374, 115]$[0, -115, 374, 0]$[-374, -115, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWL-seEealN7CdLT_GPw" id="(0.45353159851301117,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWMOseEealN7CdLT_GPw" id="(1.0,0.20634920634920634)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OoQWIuseEealN7CdLT_GPw" points="[0, 0, 450, 141]$[0, -141, 450, 0]$[-450, -141, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWL-seEealN7CdLT_GPw" id="(0.4531645569620253,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OoQWMOseEealN7CdLT_GPw" id="(1.0,0.4656084656084656)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hUADkOseEealN7CdLT_GPw" type="4001" source="_ryFlIOr0EeaeHOJw3lCT8A" target="__j6psOscEealN7CdLT_GPw">
       <children xmi:type="notation:DecorationNode" xmi:id="_hUADk-seEealN7CdLT_GPw" type="6001">
@@ -4780,9 +4845,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_hUADkeseEealN7CdLT_GPw"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_hSkgMOseEealN7CdLT_GPw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hUADkuseEealN7CdLT_GPw" points="[0, 0, -138, 121]$[138, 0, 0, 121]$[138, -121, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hWq9EOseEealN7CdLT_GPw" id="(1.0,0.6524390243902439)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hWq9EeseEealN7CdLT_GPw" id="(0.4423791821561338,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hUADkuseEealN7CdLT_GPw" points="[0, 0, -213, 133]$[213, 0, 0, 133]$[213, -133, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hWq9EOseEealN7CdLT_GPw" id="(1.0,0.4878048780487805)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hWq9EeseEealN7CdLT_GPw" id="(0.44050632911392407,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_hU2_N-seEealN7CdLT_GPw" type="StereotypeCommentLink" source="_hUADkOseEealN7CdLT_GPw" target="_hU2_M-seEealN7CdLT_GPw">
       <styles xmi:type="notation:FontStyle" xmi:id="_hU2_OOseEealN7CdLT_GPw"/>
@@ -4863,7 +4928,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_QX5ecfLXEeaAIfPpmDwI5Q" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QX5ecvLXEeaAIfPpmDwI5Q" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_QX5ec_LXEeaAIfPpmDwI5Q" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QX5ec_LXEeaAIfPpmDwI5Q" x="2" y="-22"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_QX5edPLXEeaAIfPpmDwI5Q" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_QX5edfLXEeaAIfPpmDwI5Q" y="-20"/>
@@ -4881,7 +4946,7 @@
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_KnJbUPIoEea79czpMf3AVQ"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QX43YvLXEeaAIfPpmDwI5Q" points="[0, 0, 113, -168]$[-113, 168, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgPLXEeaAIfPpmDwI5Q" id="(0.4486301369863014,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgfLXEeaAIfPpmDwI5Q" id="(0.5578635014836796,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QX6FgfLXEeaAIfPpmDwI5Q" id="(0.5489614243323442,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QYR49_LXEeaAIfPpmDwI5Q" type="StereotypeCommentLink" source="_QX43YPLXEeaAIfPpmDwI5Q" target="_QYR48_LXEeaAIfPpmDwI5Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_QYR4-PLXEeaAIfPpmDwI5Q"/>
@@ -4934,7 +4999,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_GUzEkYhCEeeOl5P_FBJSmA"/>
       <element xmi:type="uml:Association" href="TapiConnectivity.uml#_p4w_sEUeEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GUzEkohCEeeOl5P_FBJSmA" points="[0, 0, -169, 46]$[0, -54, -169, -8]$[169, -46, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GUzEkohCEeeOl5P_FBJSmA" points="[0, 0, -192, 63]$[0, -63, -192, 0]$[192, -63, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GU05wIhCEeeOl5P_FBJSmA" id="(0.4452054794520548,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GU05wYhCEeeOl5P_FBJSmA" id="(0.0,0.05909090909090909)"/>
     </edges>

--- a/UML/TapiConnectivity.uml
+++ b/UML/TapiConnectivity.uml
@@ -38,34 +38,19 @@
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_nfDxpe_pEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_niJd8GkKEeWZEqTYAF8eqA" name="ConnectionIsBoundedByNode" memberEnd="_niJd82kKEeWZEqTYAF8eqA _niJd9WkKEeWZEqTYAF8eqA">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_niJd8WkKEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_niJd8mkKEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_niJd82kKEeWZEqTYAF8eqA" name="_conectionRefList" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_niJd8GkKEeWZEqTYAF8eqA">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0hPKkGkKEeWZEqTYAF8eqA"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0hPKkWkKEeWZEqTYAF8eqA" value="*"/>
-        </ownedEnd>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_cfZ_cIbpEeWLkaOCu--9xg" name="CEPConnectsToPeerCEP" memberEnd="_cfZ_c4bpEeWLkaOCu--9xg _cfjJYIbpEeWLkaOCu--9xg">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cfZ_cYbpEeWLkaOCu--9xg" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cfZ_cobpEeWLkaOCu--9xg" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_cfjJYIbpEeWLkaOCu--9xg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_cfZ_cIbpEeWLkaOCu--9xg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_Zb5MoH5NEeWWkJKpap4S3A" name="CEPHasClientNEPs" memberEnd="_Zb_6UH5NEeWWkJKpap4S3A _ZcC9oH5NEeWWkJKpap4S3A">
+      <packagedElement xmi:type="uml:Association" xmi:id="_Zb5MoH5NEeWWkJKpap4S3A" name="CEPSupportsClientNEPs" memberEnd="_Zb_6UH5NEeWWkJKpap4S3A _ZcC9oH5NEeWWkJKpap4S3A">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Zb_TQH5NEeWWkJKpap4S3A" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Zb_TQX5NEeWWkJKpap4S3A" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_ZcC9oH5NEeWWkJKpap4S3A" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_Zb5MoH5NEeWWkJKpap4S3A"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_B3JLoEHCEeWqPKyD1j6LMg" name="CEPHasServerNEP" memberEnd="_B3KZwUHCEeWqPKyD1j6LMg _B3Ln4EHCEeWqPKyD1j6LMg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_B3JLoEHCEeWqPKyD1j6LMg" name="CEPIsSupportedByNEP" memberEnd="_B3KZwUHCEeWqPKyD1j6LMg _B3Ln4EHCEeWqPKyD1j6LMg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B3JysEHCEeWqPKyD1j6LMg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B3KZwEHCEeWqPKyD1j6LMg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_B3KZwUHCEeWqPKyD1j6LMg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_B3JLoEHCEeWqPKyD1j6LMg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_T8JpMEHCEeWqPKyD1j6LMg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_T8LeYEHCEeWqPKyD1j6LMg" value="*"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_T8LeYEHCEeWqPKyD1j6LMg" value="1"/>
         </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_ijcPoGkHEeWZEqTYAF8eqA" name="ConnTerminatesOnCEP" memberEnd="_ijcPo2kHEeWZEqTYAF8eqA _ijcPpWkHEeWZEqTYAF8eqA">
@@ -99,6 +84,10 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p4yN0EUeEeWEwNCluy4jrw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p4yN0UUeEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
         </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_p4y04EUeEeWEwNCluy4jrw" name="_associatedRoute" type="_kkzTEEUbEeWKAbXi7_SowQ" association="_p4w_sEUeEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x40xEEUfEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x430YEUfEeWEwNCluy4jrw" value="*"/>
+        </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_c8MLwDLEEeaULOmJRJKM0Q" name="ConstrHasAvoidTopology" memberEnd="_c8MLxDLEEeaULOmJRJKM0Q _c8MLxzLEEeaULOmJRJKM0Q">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_c8MLwjLEEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
@@ -229,15 +218,6 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6fX0AEwPEeewALXL7BvPYw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_U4H7UEwOEeewALXL7BvPYw" name="ConnectionSupportsLink" memberEnd="_U4LlsUwOEeewALXL7BvPYw _U4Mz0EwOEeewALXL7BvPYw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_U4K-oEwOEeewALXL7BvPYw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_U4LlsEwOEeewALXL7BvPYw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_U4Mz0EwOEeewALXL7BvPYw" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_U4H7UEwOEeewALXL7BvPYw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mUsf4EwOEeewALXL7BvPYw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mUu8IEwOEeewALXL7BvPYw" value="1"/>
-        </ownedEnd>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_5TB-sE5qEeeicu4cm-7qRg" name="ConstrHasExcludeNode" memberEnd="_5TDM0U5qEeeicu4cm-7qRg _5TDz4k5qEeeicu4cm-7qRg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5TClwE5qEeeicu4cm-7qRg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5TDM0E5qEeeicu4cm-7qRg" key="nature" value="UML_Nature"/>
@@ -274,13 +254,13 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UypGQIfWEeeirpBaj87qAw" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_hF804HIzEeeSiaQ95-6r9w" name="CSEPHasCEP" memberEnd="_hHoP4nIzEeeSiaQ95-6r9w _hHpeAHIzEeeSiaQ95-6r9w">
+      <packagedElement xmi:type="uml:Association" xmi:id="_hF804HIzEeeSiaQ95-6r9w" name="CEPRelatesToCSEP" memberEnd="_hHoP4nIzEeeSiaQ95-6r9w _hHpeAHIzEeeSiaQ95-6r9w">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hHoP4HIzEeeSiaQ95-6r9w" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hHoP4XIzEeeSiaQ95-6r9w" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_hHpeAHIzEeeSiaQ95-6r9w" name="connectivityserviceendpoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_hF804HIzEeeSiaQ95-6r9w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s7y5EHMFEeeSiaQ95-6r9w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s71VUHMFEeeSiaQ95-6r9w" value="1"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_hHoP4nIzEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_hF804HIzEeeSiaQ95-6r9w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X5h9EHI9EeeSiaQ95-6r9w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X5mOgHI9EeeSiaQ95-6r9w" value="*"/>
         </ownedEnd>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_7ZpcsIfgEeet-8tHdGGp_w" name="ConnConstraintHasRouteComputePolicy" memberEnd="_7Zr48IfgEeet-8tHdGGp_w _7ZsgAofgEeet-8tHdGGp_w">
@@ -404,19 +384,6 @@ The FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is 
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5kzpMEwPEeewALXL7BvPYw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5k1eYEwPEeewALXL7BvPYw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_U4LlsUwOEeewALXL7BvPYw" name="_supportedLink" association="_U4H7UEwOEeewALXL7BvPYw">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_M35f8EwPEeewALXL7BvPYw" annotatedElement="_U4LlsUwOEeewALXL7BvPYw">
-            <body>An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer.</body>
-          </ownedComment>
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lVIgUEwOEeewALXL7BvPYw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lVLjoEwOEeewALXL7BvPYw" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_niJd9WkKEeWZEqTYAF8eqA" name="_containerNode" isReadOnly="true" association="_niJd8GkKEeWZEqTYAF8eqA">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Aoh_oN5TEeWHTPgMsm3CIw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Aokb4N5TEeWHTPgMsm3CIw" value="1"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" isReadOnly="true" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_obsPoEUcEeWEwNCluy4jrw" value="*"/>
@@ -448,20 +415,19 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IOhXAKeWEeeBGPv_1DT5og" name="layerProtocolName" isReadOnly="true">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
         </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hHpeAHIzEeeSiaQ95-6r9w" name="_connectivityServiceEndPoint" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_hF804HIzEeeSiaQ95-6r9w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s7y5EHMFEeeSiaQ95-6r9w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s71VUHMFEeeSiaQ95-6r9w" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_B3Ln4EHCEeWqPKyD1j6LMg" name="_parentNodeEdgePoint" isReadOnly="true" association="_B3JLoEHCEeWqPKyD1j6LMg">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WeYVYEHCEeWqPKyD1j6LMg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="*"/>
+        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Zb_6UH5NEeWWkJKpap4S3A" name="_clientNodeEdgePoint" isReadOnly="true" aggregation="shared" association="_Zb5MoH5NEeWWkJKpap4S3A">
           <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XMYckH5XEeWWkJKpap4S3A"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XNugYH5XEeWWkJKpap4S3A" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_B3Ln4EHCEeWqPKyD1j6LMg" name="_serverNodeEdgePoint" isReadOnly="true" association="_B3JLoEHCEeWqPKyD1j6LMg">
-          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WeYVYEHCEeWqPKyD1j6LMg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_cfZ_c4bpEeWLkaOCu--9xg" name="_peerConnectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_cfZ_cIbpEeWLkaOCu--9xg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_p4y04EUeEeWEwNCluy4jrw" name="_associatedRoute" type="_kkzTEEUbEeWKAbXi7_SowQ" association="_p4w_sEUeEeWEwNCluy4jrw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x40xEEUfEeWEwNCluy4jrw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x430YEUfEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
@@ -591,15 +557,11 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
         <generalization xmi:type="uml:Generalization" xmi:id="_Wx2QAN8rEeWT9tG0gGLRFw">
           <general xmi:type="uml:Class" href="TapiCommon.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
         </generalization>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceInterfacePoint" association="_YyfoEGkJEeWZEqTYAF8eqA">
-          <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hHoP4nIzEeeSiaQ95-6r9w" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_hF804HIzEeeSiaQ95-6r9w">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X5h9EHI9EeeSiaQ95-6r9w"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X5mOgHI9EeeSiaQ95-6r9w" value="*"/>
-        </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nPhusKhLEeeAVfY3jqnvAA" name="layerProtocolName">
           <type xmi:type="uml:Enumeration" href="TapiCommon.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceInterfacePoint" association="_YyfoEGkJEeWZEqTYAF8eqA">
+          <type xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EN4L8WJREeek3OrhDuslYQ" name="_state" aggregation="composite" association="_EN290GJREeek3OrhDuslYQ">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
@@ -1009,10 +971,8 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_4Es8NGkIEeWZEqTYAF8eqA" base_StructuralFeature="_4Es8M2kIEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_4Es8NmkIEeWZEqTYAF8eqA" base_StructuralFeature="_4Es8NWkIEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_YyoyBWkJEeWZEqTYAF8eqA" base_StructuralFeature="_YyoyBGkJEeWZEqTYAF8eqA"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_niJd9GkKEeWZEqTYAF8eqA" base_StructuralFeature="_niJd82kKEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcAhYH5NEeWWkJKpap4S3A" base_StructuralFeature="_Zb_6UH5NEeWWkJKpap4S3A"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcC9oX5NEeWWkJKpap4S3A" base_StructuralFeature="_ZcC9oH5NEeWWkJKpap4S3A"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_cfZ_dIbpEeWLkaOCu--9xg" base_StructuralFeature="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_T9ChoaU5EeWkWNPM1BHzGA" base_Parameter="_T9ChoKU5EeWkWNPM1BHzGA"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_7BwFUbvMEeWYrqoqXLgguw" base_Parameter="_7BwFULvMEeWYrqoqXLgguw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_lY2XUbvZEeWYrqoqXLgguw" base_StructuralFeature="_lY2XULvZEeWYrqoqXLgguw"/>
@@ -1055,12 +1015,10 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nxcI8zLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxcI8jLCEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLxTLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxDLEEeaULOmJRJKM0Q"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yA-gBhrEeewCs0lkpWskw" base_Property="_B3Ln4EHCEeWqPKyD1j6LMg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__yBlkBhrEeewCs0lkpWskw" base_Property="_cfZ_c4bpEeWLkaOCu--9xg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nxl58TLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxl58DLCEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLyDLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxzLEEeaULOmJRJKM0Q"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wt-RdEXOEeaB8vMnkFQLXQ" base_StructuralFeature="_wt-RckXOEeaB8vMnkFQLXQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_wuAGokXOEeaB8vMnkFQLXQ" base_StructuralFeature="_wuAGoEXOEeaB8vMnkFQLXQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_niJd9mkKEeWZEqTYAF8eqA" base_StructuralFeature="_niJd9WkKEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_p40qEEUeEeWEwNCluy4jrw" base_StructuralFeature="_p40DAEUeEeWEwNCluy4jrw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_YyoyA2kJEeWZEqTYAF8eqA" base_StructuralFeature="_YyoyAmkJEeWZEqTYAF8eqA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_l8Tgs8F3EeaALJQAf08uAg" base_StructuralFeature="_l8TgscF3EeaALJQAf08uAg"/>
@@ -1124,7 +1082,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x0xQBhrEeewCs0lkpWskw" base_Property="_WFu45O_qEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x1_YRhrEeewCs0lkpWskw" base_Property="_4Es8NWkIEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x2mcBhrEeewCs0lkpWskw" base_Property="_nfDxpe_pEeWLlrwIF3w0vA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x2mcRhrEeewCs0lkpWskw" base_Property="_niJd82kKEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x3NgBhrEeewCs0lkpWskw" base_Property="_ZcC9oH5NEeWWkJKpap4S3A"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x3NghhrEeewCs0lkpWskw" base_Property="_ijcPpWkHEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x30kBhrEeewCs0lkpWskw" base_Property="_4EuaAEUcEeWEwNCluy4jrw"/>
@@ -1149,7 +1106,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x9UIRhrEeewCs0lkpWskw" base_Property="_Ca3vh_4zEea_VPdGG2-szQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97MBhrEeewCs0lkpWskw" base_Property="_ijcPo2kHEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97MRhrEeewCs0lkpWskw" base_Property="_ZiYSAEUcEeWEwNCluy4jrw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97MhhrEeewCs0lkpWskw" base_Property="_niJd9WkKEeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97MxhrEeewCs0lkpWskw" base_Property="_QZdZkusUEealN7CdLT_GPw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x97NBhrEeewCs0lkpWskw" base_Property="_B0rIk-_sEeWLlrwIF3w0vA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="__x-iQBhrEeewCs0lkpWskw" base_Property="_IZ3vc0HbEeWqPKyD1j6LMg"/>
@@ -1204,14 +1160,10 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_nJqvIkwFEeewALXL7BvPYw" base_Property="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_nJrWMEwFEeewALXL7BvPYw" base_StructuralFeature="_nJqvIUwFEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_uUXl0EwGEeewALXL7BvPYw" base_Association="_nJo58EwFEeewALXL7BvPYw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_U4LlskwOEeewALXL7BvPYw" base_Property="_U4LlsUwOEeewALXL7BvPYw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_U4MMwEwOEeewALXL7BvPYw" base_StructuralFeature="_U4LlsUwOEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ihp2okwPEeewALXL7BvPYw" base_Property="_ihp2oUwPEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ihqdsEwPEeewALXL7BvPYw" base_StructuralFeature="_ihp2oUwPEeewALXL7BvPYw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_ihqdskwPEeewALXL7BvPYw" base_Property="_ihqdsUwPEeewALXL7BvPYw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_ihqds0wPEeewALXL7BvPYw" base_StructuralFeature="_ihqdsUwPEeewALXL7BvPYw"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_U4Mz0UwOEeewALXL7BvPYw" base_Property="_U4Mz0EwOEeewALXL7BvPYw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_VXlegEwOEeewALXL7BvPYw" base_StructuralFeature="_U4Mz0EwOEeewALXL7BvPYw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_COm-UEwVEeewALXL7BvPYw" base_Association="_l5X4MMhsEeaVlemTikmRHw"/>
   <OpenModel_Profile:StrictComposite xmi:id="_Durp8EwVEeewALXL7BvPYw" base_Association="_mvBt0MhsEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_tAVeAU5qEeeicu4cm-7qRg" base_Property="_tAVeAE5qEeeicu4cm-7qRg"/>
@@ -1302,4 +1254,6 @@ Note: Only relevant when part of a protection scheme.</body>
   <OpenModel_Profile:ExtendedComposite xmi:id="_4ak1AM4UEeehIvzuBRCtZQ" base_Association="_7ZpcsIfgEeet-8tHdGGp_w"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_51xAoM4UEeehIvzuBRCtZQ" base_Association="_MKHxQIfWEeeirpBaj87qAw"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_7MbRkM4UEeehIvzuBRCtZQ" base_Association="_Tx9zoP4yEea_VPdGG2-szQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XLHewNoCEeeYx-v40uoW_Q" base_StructuralFeature="_B3KZwUHCEeWqPKyD1j6LMg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_XLHewdoCEeeYx-v40uoW_Q" base_Property="_B3KZwUHCEeWqPKyD1j6LMg"/>
 </xmi:XMI>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -669,6 +669,14 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oBGxAsZlEeeAD9H5zOiMUQ" x="726" y="106"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_UI7u4Nn8EeeYx-v40uoW_Q" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UI7u4dn8EeeYx-v40uoW_Q" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UI7u49n8EeeYx-v40uoW_Q" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UI7u4tn8EeeYx-v40uoW_Q" x="726" y="106"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_JS4dITBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_JS4dIjBDEea4fKwSGMr6CA"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_JS4dIzBDEea4fKwSGMr6CA">
@@ -887,6 +895,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oBGxBsZlEeeAD9H5zOiMUQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oBGxB8ZlEeeAD9H5zOiMUQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oBGxCMZlEeeAD9H5zOiMUQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UI7u5Nn8EeeYx-v40uoW_Q" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_UI7u4Nn8EeeYx-v40uoW_Q">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UI7u5dn8EeeYx-v40uoW_Q"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UI8V8Nn8EeeYx-v40uoW_Q" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UI7u5tn8EeeYx-v40uoW_Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UI7u59n8EeeYx-v40uoW_Q"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UI7u6Nn8EeeYx-v40uoW_Q"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SFF5oDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceDetails" measurementUnit="Pixel">
@@ -1118,10 +1136,6 @@
         <children xmi:type="notation:Shape" xmi:id="_aOCA4MFlEeaALJQAf08uAg" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_tQQ4U2j_EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_aOCA4cFlEeaALJQAf08uAg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHgMFlEeaALJQAf08uAg" type="3012">
-          <element xmi:type="uml:Property" href="TapiTopology.uml#_8VW-oD-_EeWNAdBR30aJhw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHgcFlEeaALJQAf08uAg"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_aOIHgsFlEeaALJQAf08uAg" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_IZggA98AEeW-BtRsuJPbqg"/>
@@ -1389,9 +1403,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Ww6vpjBDEea4fKwSGMr6CA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Ww6vpzBDEea4fKwSGMr6CA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ww6vqTBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ww6vqTBDEea4fKwSGMr6CA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ww6vqDBDEea4fKwSGMr6CA" x="645" y="131"/>
     </children>
@@ -1951,31 +1963,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlWSDBDEea4fKwSGMr6CA" id="(1.0,0.26573426573426573)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlWSTBDEea4fKwSGMr6CA" id="(0.0,0.3088235294117647)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_WvlWSjBDEea4fKwSGMr6CA" type="4001" source="_WvSZKTBDEea4fKwSGMr6CA" target="_WvbikTBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWSzBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWTDBDEea4fKwSGMr6CA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWTTBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWTjBDEea4fKwSGMr6CA" y="11"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWTzBDEea4fKwSGMr6CA" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWUDBDEea4fKwSGMr6CA" y="-20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWUTBDEea4fKwSGMr6CA" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWUjBDEea4fKwSGMr6CA" y="20"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWUzBDEea4fKwSGMr6CA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWVDBDEea4fKwSGMr6CA" x="17" y="15"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_WvlWVTBDEea4fKwSGMr6CA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWVjBDEea4fKwSGMr6CA" x="-7" y="9"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_WvlWVzBDEea4fKwSGMr6CA"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvlWWzBDEea4fKwSGMr6CA" points="[0, 0, 863, 40]$[-587, -28, 276, 12]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlWXDBDEea4fKwSGMr6CA" id="(0.0,0.49387755102040815)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WvlWXTBDEea4fKwSGMr6CA" id="(1.0,0.6713286713286714)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WvlWXjBDEea4fKwSGMr6CA" type="4001" source="_WvbikTBDEea4fKwSGMr6CA" target="_WvlS0DBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_WvlWXzBDEea4fKwSGMr6CA" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_WvlWYDBDEea4fKwSGMr6CA" x="11" y="-13"/>
@@ -2020,16 +2007,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WwB-0DBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WwB-0TBDEea4fKwSGMr6CA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WwB-0jBDEea4fKwSGMr6CA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ww6vqjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvlWSjBDEea4fKwSGMr6CA" target="_Ww6vpjBDEea4fKwSGMr6CA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ww6vqzBDEea4fKwSGMr6CA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Ww6vrzBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ww6vrDBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ww6vrTBDEea4fKwSGMr6CA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ww6vrjBDEea4fKwSGMr6CA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Ww6vwDBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_WvlVOTBDEea4fKwSGMr6CA" target="_Ww6vvDBDEea4fKwSGMr6CA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Ww6vwTBDEea4fKwSGMr6CA"/>
@@ -2435,7 +2412,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LRyTBDEea4fKwSGMr6CA" y="5"/>
       </children>
       <element xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i9LR9zBDEea4fKwSGMr6CA" x="326" y="158" width="212" height="53"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i9LR9zBDEea4fKwSGMr6CA" x="368" y="158" width="168" height="53"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_i9LSWTBDEea4fKwSGMr6CA" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_i9LSWjBDEea4fKwSGMr6CA" type="5029"/>
@@ -2508,9 +2485,7 @@
     </children>
     <children xmi:type="notation:Shape" xmi:id="_i_QUujBDEea4fKwSGMr6CA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_i_QUuzBDEea4fKwSGMr6CA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i_QUvTBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      </styles>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i_QUvTBDEea4fKwSGMr6CA" name="BASE_ELEMENT"/>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i_QUvDBDEea4fKwSGMr6CA" x="416" y="273"/>
     </children>
@@ -2720,7 +2695,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpsxM3Eee0L_IMWjydgQ"/>
       </children>
       <element xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpoRM3Eee0L_IMWjydgQ" x="412" y="-206" height="71"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p9gpoRM3Eee0L_IMWjydgQ" x="412" y="-206" width="213" height="71"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_p9s27hM3Eee0L_IMWjydgQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_p9s27xM3Eee0L_IMWjydgQ" showTitle="true"/>
@@ -2773,9 +2748,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_i9BgHTBDEea4fKwSGMr6CA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T3T6ID_NEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9BgITBDEea4fKwSGMr6CA" points="[0, 0, -64, -151]$[64, 0, 0, -151]$[64, 151, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgIjBDEea4fKwSGMr6CA" id="(1.0,0.6226415094339622)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgIzBDEea4fKwSGMr6CA" id="(0.6753246753246753,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9BgITBDEea4fKwSGMr6CA" points="[0, 0, -93, -153]$[93, 0, 0, -153]$[92, 152, -1, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgIjBDEea4fKwSGMr6CA" id="(1.0,0.5962264150943396)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgIzBDEea4fKwSGMr6CA" id="(0.8545454545454545,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_i9BgJDBDEea4fKwSGMr6CA" type="4001" source="_i9LRtzBDEea4fKwSGMr6CA" target="_i9BgRjBDEea4fKwSGMr6CA">
       <children xmi:type="notation:DecorationNode" xmi:id="_i9BgJTBDEea4fKwSGMr6CA" type="6001">
@@ -2798,7 +2773,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_i9BgMTBDEea4fKwSGMr6CA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_T7gvkD_LEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9BgNTBDEea4fKwSGMr6CA" points="[0, 0, 107, 159]$[0, -159, 107, 0]$[-107, -159, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9BgNTBDEea4fKwSGMr6CA" points="[0, -1, 110, 158]$[0, -159, 110, 0]$[-111, -159, -1, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgNjBDEea4fKwSGMr6CA" id="(0.8773584905660378,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9BgNzBDEea4fKwSGMr6CA" id="(1.0,0.4230769230769231)"/>
     </edges>
@@ -2874,33 +2849,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_i9LSRjBDEea4fKwSGMr6CA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9LSSjBDEea4fKwSGMr6CA" points="[0, 0, 45, -76]$[-41, 69, 4, -7]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSSzBDEea4fKwSGMr6CA" id="(0.9358288770053476,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSTDBDEea4fKwSGMr6CA" id="(0.3160377358490566,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_i9LSnDBDEea4fKwSGMr6CA" type="4001" source="_i9LSWTBDEea4fKwSGMr6CA" target="_i9LRtzBDEea4fKwSGMr6CA">
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSnTBDEea4fKwSGMr6CA" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSnjBDEea4fKwSGMr6CA" x="-2" y="-2"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSnzBDEea4fKwSGMr6CA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSoDBDEea4fKwSGMr6CA" x="22" y="6"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSoTBDEea4fKwSGMr6CA" visible="false" type="6003">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSojBDEea4fKwSGMr6CA" x="-26" y="8"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSozBDEea4fKwSGMr6CA" visible="false" type="6005">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSpDBDEea4fKwSGMr6CA" x="33" y="-51"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSpTBDEea4fKwSGMr6CA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSpjBDEea4fKwSGMr6CA" x="14" y="-14"/>
-      </children>
-      <children xmi:type="notation:DecorationNode" xmi:id="_i9LSpzBDEea4fKwSGMr6CA" type="6034">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_i9LSqDBDEea4fKwSGMr6CA" x="-9" y="-16"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_i9LSqTBDEea4fKwSGMr6CA"/>
-      <element xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i9LSrTBDEea4fKwSGMr6CA" points="[0, 0, -133, 13]$[133, -13, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSrjBDEea4fKwSGMr6CA" id="(0.9272727272727272,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSrzBDEea4fKwSGMr6CA" id="(0.10849056603773585,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSSzBDEea4fKwSGMr6CA" id="(0.93048128342246,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i9LSTDBDEea4fKwSGMr6CA" id="(0.14285714285714285,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_i9eMDjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_i9LRlzBDEea4fKwSGMr6CA" target="_i9eMCjBDEea4fKwSGMr6CA">
       <styles xmi:type="notation:FontStyle" xmi:id="_i9eMDzBDEea4fKwSGMr6CA"/>
@@ -2951,16 +2901,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i-qe9jBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i-qe9zBDEea4fKwSGMr6CA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i-qe-DBDEea4fKwSGMr6CA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_i_QUvjBDEea4fKwSGMr6CA" type="StereotypeCommentLink" source="_i9LSnDBDEea4fKwSGMr6CA" target="_i_QUujBDEea4fKwSGMr6CA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_i_QUvzBDEea4fKwSGMr6CA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_i_QUwzBDEea4fKwSGMr6CA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_8VTUQD-_EeWNAdBR30aJhw"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i_QUwDBDEea4fKwSGMr6CA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i_QUwTBDEea4fKwSGMr6CA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i_QUwjBDEea4fKwSGMr6CA"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EdmFBzBKEeaSroGqGbZ6jg" type="StereotypeCommentLink" source="_i9BgRjBDEea4fKwSGMr6CA" target="_EdmFAzBKEeaSroGqGbZ6jg">
       <styles xmi:type="notation:FontStyle" xmi:id="_EdmFCDBKEeaSroGqGbZ6jg"/>
@@ -3079,8 +3019,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_xrS7gU0EEeabHNlo0UKXdA"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xrS7gk0EEeabHNlo0UKXdA" points="[-1, -13, 0, 131]$[-1, -144, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xrS7j00EEeabHNlo0UKXdA" id="(0.05844155844155844,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xrS7kE0EEeabHNlo0UKXdA" id="(0.8537735849056604,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xrS7j00EEeabHNlo0UKXdA" id="(0.04935064935064935,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xrS7kE0EEeabHNlo0UKXdA" id="(0.819047619047619,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_xrl2d00EEeabHNlo0UKXdA" type="StereotypeCommentLink" source="_xrS7gE0EEeabHNlo0UKXdA" target="_xrl2c00EEeabHNlo0UKXdA">
       <styles xmi:type="notation:FontStyle" xmi:id="_xrl2eE0EEeabHNlo0UKXdA"/>
@@ -3232,7 +3172,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGakEpZEeexQa2RWFy3AQ" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_uMGakUpZEeexQa2RWFy3AQ" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGakkpZEeexQa2RWFy3AQ" y="20"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGakkpZEeexQa2RWFy3AQ" x="4" y="11"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_uMGak0pZEeexQa2RWFy3AQ" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_uMGalEpZEeexQa2RWFy3AQ" y="-20"/>
@@ -3248,9 +3188,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_uMDXQUpZEeexQa2RWFy3AQ"/>
       <element xmi:type="uml:Association" href="TapiTopology.uml#_G1pfMNnfEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMDXQkpZEeexQa2RWFy3AQ" points="[0, 0, 115, 0]$[0, 49, 115, 49]$[-115, 49, 0, 49]$[-115, 0, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uMDXQkpZEeexQa2RWFy3AQ" points="[0, -1, 130, -1]$[0, 49, 130, 49]$[-130, 49, 0, 49]$[-130, -1, 0, -1]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMI20EpZEeexQa2RWFy3AQ" id="(0.922077922077922,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMI20UpZEeexQa2RWFy3AQ" id="(0.17532467532467533,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uMI20UpZEeexQa2RWFy3AQ" id="(0.08051948051948052,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_BMhsoUpcEeexQa2RWFy3AQ" type="StereotypeCommentLink" source="_3Vf_kMhmEeaVlemTikmRHw" target="_BMhFkEpcEeexQa2RWFy3AQ">
       <styles xmi:type="notation:FontStyle" xmi:id="_BMhsokpcEeexQa2RWFy3AQ"/>

--- a/UML/TapiTopology.notation
+++ b/UML/TapiTopology.notation
@@ -419,41 +419,41 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_NPs5VjBDEea4fKwSGMr6CA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_NPs5VzBDEea4fKwSGMr6CA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_EneVgMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEF2kNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_qpAjEKg3EeeAVfY3jqnvAA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EneVgcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEF2kdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Ene8kMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEF2ktoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_G1pfM9nfEeWIOYiRCk5bbQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ene8kcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEF2k9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Ene8ksZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEGdoNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_MM6iEEHBEeWqPKyD1j6LMg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Ene8k8ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdodoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EnfjoMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEGdotoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_STzYA-_tEeWLlrwIF3w0vA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EnfjocZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdo9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EnfjosZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEGdpNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_UbQckqg5EeeAVfY3jqnvAA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Enfjo8ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdpdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EnfjpMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEGdptoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdVA2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EnfjpcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdp9oHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EngKsMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEGdqNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7vdU-2h_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngKscZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEGdqdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EngKssZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEHEsNoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngKs8ZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEHEsdoHEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_EngxwMZbEeeAD9H5zOiMUQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_OEHEstoHEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EngxwcZbEeeAD9H5zOiMUQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OEHEs9oHEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_NPs5_zBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_NPs6ADBDEea4fKwSGMr6CA"/>
@@ -676,6 +676,14 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UI7u4tn8EeeYx-v40uoW_Q" x="726" y="106"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0wAjMNoGEeeYx-v40uoW_Q" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0wAjMdoGEeeYx-v40uoW_Q" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0wAjM9oGEeeYx-v40uoW_Q" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0wAjMtoGEeeYx-v40uoW_Q" x="726" y="106"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_JS4dITBDEea4fKwSGMr6CA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_JS4dIjBDEea4fKwSGMr6CA"/>
@@ -906,6 +914,16 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UI7u59n8EeeYx-v40uoW_Q"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UI7u6Nn8EeeYx-v40uoW_Q"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0wAjNNoGEeeYx-v40uoW_Q" type="StereotypeCommentLink" source="_Uco8oKg5EeeAVfY3jqnvAA" target="_0wAjMNoGEeeYx-v40uoW_Q">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0wAjNdoGEeeYx-v40uoW_Q"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0wAjOdoGEeeYx-v40uoW_Q" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiTopology.uml#_UbP1gKg5EeeAVfY3jqnvAA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0wAjNtoGEeeYx-v40uoW_Q" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0wAjN9oGEeeYx-v40uoW_Q"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0wAjONoGEeeYx-v40uoW_Q"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_SFF5oDBDEea4fKwSGMr6CA" type="PapyrusUMLClassDiagram" name="TopologyServiceDetails" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_WvSX4DBDEea4fKwSGMr6CA" type="2008">
@@ -994,49 +1012,53 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZLDBDEea4fKwSGMr6CA" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_WvSZLTBDEea4fKwSGMr6CA" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_WvSZLjBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RFH8NoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_Iz0OAKf4EeW6jfwWQNiYcg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZTTBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFH8doGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZTjBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RFH8toGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_T3VIQT_NEeWNAdBR30aJhw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZdDBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFH89oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZdTBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RFvANoGEeeYx-v40uoW_Q" type="3012">
+          <element xmi:type="uml:Property" href="TapiTopology.uml#_u43kIhk8EeeV4o0osG5stg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFvAdoGEeeYx-v40uoW_Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_8RFvAtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_T7gvkz_LEeWNAdBR30aJhw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZmzBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFvA9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZnDBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RFvBNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_W9zh097-EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZuzBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFvBdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZvDBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RFvBtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_tOFAk97rEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZ2zBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RFvB9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZ3DBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RGWENoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_7DdfM97vEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSZ-zBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RGWEdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSZ_DBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RGWEtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_lqLYA97wEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSaGzBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RGWE9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSaHDBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RGWFNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_kTBiY97xEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSaOzBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RGWFdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_WvSaPDBDEea4fKwSGMr6CA" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RGWFtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_xImb1OK4EeSq5fATALSQkQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_WvSaWzBDEea4fKwSGMr6CA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RGWF9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_7wZaQBMoEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RGWGNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7wZaQRMoEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RGWGdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_7wZaQhMoEee0L_IMWjydgQ" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_8RG9INoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7wZaQxMoEee0L_IMWjydgQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_8RG9IdoGEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvSaXDBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvSaXTBDEea4fKwSGMr6CA"/>
@@ -1133,61 +1155,61 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rC_Z8NLLEea8leFJHAK2YQ" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rC_Z8dLLEea8leFJHAK2YQ" key="showTitle" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_aOCA4MFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41fK0NoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_tQQ4U2j_EeWZEqTYAF8eqA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOCA4cFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41fK0doGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHgsFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41fx4NoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_IZggA98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHg8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41fx4doGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHhMFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41gY8NoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_WSiGU971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHhcFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41gY8doGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHhsFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hAANoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_cQkyE971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHh8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hAAdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHiMFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hAAtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_gJx4Q971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHicFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hAA9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHisFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hABNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_kZ4bg971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHi8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hABdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHjMFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hABtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_rJUvA971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHjcFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hAB9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHjsFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hnENoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#__ET2w971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHj8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hnEdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHkMFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hnEtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_CM28E972EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHkcFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hnE9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHksFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41hnFNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_37fFROMCEeSdZOEXoN8VDQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHk8FlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41hnFdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_aOIHlMFlEeaALJQAf08uAg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41iOINoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_QpQJIINtEeW35P6IpRw6Dg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_aOIHlcFlEeaALJQAf08uAg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41iOIdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_CuVJEIfSEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41iOItoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiTopology.uml#_6TXH4IfREeeirpBaj87qAw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CuVJEYfSEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41iOI9oGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_CufhIIfSEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41iOJNoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CufhIYfSEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41iOJdoGEeeYx-v40uoW_Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_CufhIofSEeeirpBaj87qAw" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_41iOJtoGEeeYx-v40uoW_Q" type="3012">
           <element xmi:type="uml:Property" href="TapiCommon.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_CufhI4fSEeeirpBaj87qAw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_41iOJ9oGEeeYx-v40uoW_Q"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_WvbkHTBDEea4fKwSGMr6CA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_WvbkHjBDEea4fKwSGMr6CA"/>

--- a/UML/TapiTopology.uml
+++ b/UML/TapiTopology.uml
@@ -95,15 +95,6 @@
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_N1sMcaf4EeW6jfwWQNiYcg" value="1"/>
         </ownedEnd>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_8VTUQD-_EeWNAdBR30aJhw" name="LinkHasAsociatedNodes" memberEnd="_8VW-oD-_EeWNAdBR30aJhw _8VYMwD-_EeWNAdBR30aJhw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8VVJcD-_EeWNAdBR30aJhw" source="org.eclipse.papyrus">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8VVwgD-_EeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
-        </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_8VYMwD-_EeWNAdBR30aJhw" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_8VTUQD-_EeWNAdBR30aJhw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GSZ2kD_AEeWNAdBR30aJhw"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GScS0D_AEeWNAdBR30aJhw" value="*"/>
-        </ownedEnd>
-      </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_tQQ4UGj_EeWZEqTYAF8eqA" name="LinkTerminatesOnNEP" memberEnd="_tQQ4U2j_EeWZEqTYAF8eqA _tQQ4VWj_EeWZEqTYAF8eqA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tQQ4UWj_EeWZEqTYAF8eqA" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tQQ4Umj_EeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
@@ -367,10 +358,6 @@
         <ownedAttribute xmi:type="uml:Property" xmi:id="_tQQ4U2j_EeWZEqTYAF8eqA" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" association="_tQQ4UGj_EeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QK-uwGkAEeWZEqTYAF8eqA" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QK-uwWkAEeWZEqTYAF8eqA" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_8VW-oD-_EeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" isReadOnly="true" association="_8VTUQD-_EeWNAdBR30aJhw">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TiWCoD_AEeWNAdBR30aJhw" value="2"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TiZtAD_AEeWNAdBR30aJhw" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IZggA98AEeW-BtRsuJPbqg" name="_state" isReadOnly="true" aggregation="composite" association="_IZggAN8AEeW-BtRsuJPbqg">
           <type xmi:type="uml:Class" href="TapiCommon.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
@@ -997,8 +984,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelParameter xmi:id="_QDy9YfM7EeSb-q8_djA2ng" base_Parameter="_QDy9YPM7EeSb-q8_djA2ng"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_bH8AQfM7EeSb-q8_djA2ng" base_Parameter="_bH8AQPM7EeSb-q8_djA2ng"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_EGaoEv5BEeSIs5T3yQwyyw" base_Parameter="_0HRXMPMxEeSb-q8_djA2ng"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_8VW-oT-_EeWNAdBR30aJhw" base_StructuralFeature="_8VW-oD-_EeWNAdBR30aJhw"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_8VYz0D-_EeWNAdBR30aJhw" base_StructuralFeature="_8VYMwD-_EeWNAdBR30aJhw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GkeWoD_DEeWNAdBR30aJhw" base_StructuralFeature="_Gkdvkj_DEeWNAdBR30aJhw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GkgL0D_DEeWNAdBR30aJhw" base_StructuralFeature="_GkfkwD_DEeWNAdBR30aJhw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_9-Bkkz_KEeWNAdBR30aJhw" base_StructuralFeature="_9-Bkkj_KEeWNAdBR30aJhw"/>
@@ -1139,7 +1124,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rVxhsEeewCs0lkpWskw" base_Property="_W9zh1d7-EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rWBhsEeewCs0lkpWskw" base_Property="_kTBiZd7xEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rWRhsEeewCs0lkpWskw" base_Property="_Iz6UoKf4EeW6jfwWQNiYcg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rWhhsEeewCs0lkpWskw" base_Property="_8VYMwD-_EeWNAdBR30aJhw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rWxhsEeewCs0lkpWskw" base_Property="_tQQ4VWj_EeWZEqTYAF8eqA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rXBhsEeewCs0lkpWskw" base_Property="_T3W9cD_NEeWNAdBR30aJhw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC2rXRhsEeewCs0lkpWskw" base_Property="_T7hWoD_LEeWNAdBR30aJhw"/>
@@ -1151,7 +1135,6 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x8hhsEeewCs0lkpWskw" base_Property="_SofFEMhmEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x8xhsEeewCs0lkpWskw" base_Property="_3Tks8shmEeaVlemTikmRHw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x9BhsEeewCs0lkpWskw" base_Property="_tQQ4U2j_EeWZEqTYAF8eqA"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x9RhsEeewCs0lkpWskw" base_Property="_8VW-oD-_EeWNAdBR30aJhw"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x9hhsEeewCs0lkpWskw" base_Property="_IZggA98AEeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x9xhsEeewCs0lkpWskw" base_Property="_WSiGU971EeW-BtRsuJPbqg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_PC8x-BhsEeewCs0lkpWskw" base_Property="_cQkyE971EeW-BtRsuJPbqg"/>

--- a/YANG/tapi-connectivity.tree
+++ b/YANG/tapi-connectivity.tree
@@ -2,9 +2,8 @@ module: tapi-connectivity
   augment /tapi-common:context:
     +--rw connectivity-service* [uuid]
     |  +--rw end-point* [local-id]
-    |  |  +--rw service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  +--rw layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  +--rw service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  +--rw capacity
     |  |  |  +--ro total-potential-capacity
     |  |  |  |  +--ro total-size
@@ -131,8 +130,6 @@ module: tapi-connectivity
     +--ro connection* [uuid]
        +--ro connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        +--ro lower-connection*       -> /tapi-common:context/tapi-connectivity:connection/uuid
-       +--ro supported-link*         -> /tapi-common:context/tapi-topology:topology/link/uuid
-       +--ro container-node?         -> /tapi-common:context/tapi-topology:topology/node/uuid
        +--ro route* [local-id]
        |  +--ro connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
        |  +--ro local-id                string
@@ -178,21 +175,20 @@ module: tapi-connectivity
        +--ro lifecycle-state?        lifecycle-state
   augment /tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point:
     +--ro connection-end-point* [uuid]
-       +--ro layer-protocol-name?         tapi-common:layer-protocol-name
-       +--ro client-node-edge-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       +--ro server-node-edge-point?      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       +--ro peer-connection-end-point?   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
-       +--ro associated-route*            -> /tapi-common:context/tapi-connectivity:connection/route/local-id
-       +--ro connection-port-direction?   tapi-common:port-direction
-       +--ro connection-port-role?        tapi-common:port-role
-       +--ro uuid                         uuid
+       +--ro layer-protocol-name?              tapi-common:layer-protocol-name
+       +--ro connectivity-service-end-point?   -> /tapi-common:context/tapi-connectivity:connectivity-service/end-point/local-id
+       +--ro parent-node-edge-point*           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+       +--ro client-node-edge-point*           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
+       +--ro connection-port-direction?        tapi-common:port-direction
+       +--ro connection-port-role?             tapi-common:port-role
+       +--ro uuid                              uuid
        +--ro name* [value-name]
        |  +--ro value-name    string
        |  +--ro value?        string
-       +--ro operational-state?           operational-state
-       +--ro lifecycle-state?             lifecycle-state
-       +--ro termination-direction?       termination-direction
-       +--ro termination-state?           termination-state
+       +--ro operational-state?                operational-state
+       +--ro lifecycle-state?                  lifecycle-state
+       +--ro termination-direction?            termination-direction
+       +--ro termination-state?                termination-state
 
   rpcs:
     +---x get-connection-details
@@ -203,8 +199,6 @@ module: tapi-connectivity
     |     +--ro connection
     |        +--ro connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        +--ro lower-connection*       -> /tapi-common:context/tapi-connectivity:connection/uuid
-    |        +--ro supported-link*         -> /tapi-common:context/tapi-topology:topology/link/uuid
-    |        +--ro container-node?         -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        +--ro route* [local-id]
     |        |  +--ro connection-end-point*   -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro local-id                string
@@ -252,9 +246,8 @@ module: tapi-connectivity
     |  +--ro output
     |     +--ro service*
     |        +--ro end-point* [local-id]
-    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -384,9 +377,8 @@ module: tapi-connectivity
     |  +--ro output
     |     +--ro service
     |        +--ro end-point* [local-id]
-    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -513,9 +505,8 @@ module: tapi-connectivity
     +---x create-connectivity-service
     |  +---w input
     |  |  +---w end-point*
-    |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w capacity
     |  |  |  |  +---w total-potential-capacity
     |  |  |  |  |  +---w total-size
@@ -636,9 +627,8 @@ module: tapi-connectivity
     |  +--ro output
     |     +--ro service
     |        +--ro end-point* [local-id]
-    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -766,9 +756,8 @@ module: tapi-connectivity
     |  +---w input
     |  |  +---w service-id-or-name?      string
     |  |  +---w end-point
-    |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |  |  |  +---w connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |  |  |  +---w layer-protocol-name?       tapi-common:layer-protocol-name
+    |  |  |  +---w service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |  |  |  +---w capacity
     |  |  |  |  +---w total-potential-capacity
     |  |  |  |  |  +---w total-size
@@ -889,9 +878,8 @@ module: tapi-connectivity
     |  +--ro output
     |     +--ro service
     |        +--ro end-point* [local-id]
-    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-    |        |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
     |        |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+    |        |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
     |        |  +--ro capacity
     |        |  |  +--ro total-potential-capacity
     |        |  |  |  +--ro total-size
@@ -1021,9 +1009,8 @@ module: tapi-connectivity
        +--ro output
           +--ro service
              +--ro end-point* [local-id]
-             |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
-             |  +--ro connection-end-point*      -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/tapi-connectivity:connection-end-point/uuid
              |  +--ro layer-protocol-name?       tapi-common:layer-protocol-name
+             |  +--ro service-interface-point?   -> /tapi-common:context/service-interface-point/uuid
              |  +--ro capacity
              |  |  +--ro total-potential-capacity
              |  |  |  +--ro total-size

--- a/YANG/tapi-connectivity.yang
+++ b/YANG/tapi-connectivity.yang
@@ -50,19 +50,6 @@ module tapi-connectivity {
                     Connection aggregation reflects Node/Topology aggregation. 
                     The FC represents a Cross-Connection in an NE. The Cross-Connection in an NE is not necessarily the lowest level of FC partitioning.";
             }
-            leaf-list supported-link {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:link/tapi-topology:uuid';
-                }
-                description "An Connection that spans between CEPs that terminate the LayerProtocol usually supports one or more links in the client layer.";
-            }
-            leaf container-node {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
-                }
-                config false;
-                description "none";
-            }
             list route {
                 key 'local-id';
                 config false;
@@ -96,31 +83,25 @@ module tapi-connectivity {
                 config false;
                 description "none";
             }
+            leaf connectivity-service-end-point {
+                type leafref {
+                    path '/tapi-common:context/tapi-connectivity:connectivity-service/tapi-connectivity:end-point/tapi-connectivity:local-id';
+                }
+                description "none";
+            }
+            leaf-list parent-node-edge-point {
+                type leafref {
+                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                min-elements 1;
+                description "none";
+            }
             leaf-list client-node-edge-point {
                 type leafref {
                     path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
                 }
                 config false;
-                description "none";
-            }
-            leaf server-node-edge-point {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
-                }
-                config false;
-                description "none";
-            }
-            leaf peer-connection-end-point {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
-                }
-                config false;
-                description "none";
-            }
-            leaf-list associated-route {
-                type leafref {
-                    path '/tapi-common:context/tapi-connectivity:connection/tapi-connectivity:route/tapi-connectivity:local-id';
-                }
                 description "none";
             }
             leaf connection-port-direction {
@@ -224,21 +205,14 @@ module tapi-connectivity {
                 At the lowest level of recursion, a FC represents a cross-connection within an NE.";
         }
         grouping connectivity-service-end-point {
+            leaf layer-protocol-name {
+                type tapi-common:layer-protocol-name;
+                description "none";
+            }
             leaf service-interface-point {
                 type leafref {
                     path '/tapi-common:context/tapi-common:service-interface-point/tapi-common:uuid';
                 }
-                description "none";
-            }
-            leaf-list connection-end-point {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
-                }
-                config false;
-                description "none";
-            }
-            leaf layer-protocol-name {
-                type tapi-common:layer-protocol-name;
                 description "none";
             }
             container capacity {

--- a/YANG/tapi-topology.tree
+++ b/YANG/tapi-topology.tree
@@ -226,7 +226,6 @@ module: tapi-topology
        |     +--ro wander-characteristic?           string
        +--ro link* [uuid]
        |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-       |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
        |  +--ro direction?                                 tapi-common:forwarding-direction
        |  +--ro resilience-type
@@ -534,7 +533,6 @@ module: tapi-topology
     |        |     +--ro wander-characteristic?           string
     |        +--ro link* [uuid]
     |        |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        |  +--ro direction?                                 tapi-common:forwarding-direction
     |        |  +--ro resilience-type
@@ -866,7 +864,6 @@ module: tapi-topology
     |  +--ro output
     |     +--ro link
     |        +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-    |        +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
     |        +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
     |        +--ro direction?                                 tapi-common:forwarding-direction
     |        +--ro resilience-type
@@ -1165,7 +1162,6 @@ module: tapi-topology
              |     +--ro wander-characteristic?           string
              +--ro link* [uuid]
              |  +--ro node-edge-point*                           -> /tapi-common:context/tapi-topology:topology/node/owned-node-edge-point/uuid
-             |  +--ro node*                                      -> /tapi-common:context/tapi-topology:topology/node/uuid
              |  +--ro layer-protocol-name*                       tapi-common:layer-protocol-name
              |  +--ro direction?                                 tapi-common:forwarding-direction
              |  +--ro resilience-type

--- a/YANG/tapi-topology.yang
+++ b/YANG/tapi-topology.yang
@@ -31,14 +31,6 @@ module tapi-topology {
                 min-elements 2;
                 description "none";
             }
-            leaf-list node {
-                type leafref {
-                    path '/tapi-common:context/tapi-topology:topology/tapi-topology:node/tapi-topology:uuid';
-                }
-                config false;
-                min-elements 2;
-                description "none";
-            }
             leaf-list layer-protocol-name {
                 type tapi-common:layer-protocol-name;
                 config false;


### PR DESCRIPTION
- Removed association-LinkHasAsociatedNodes
- Removed association: ConnectionSupportsLink
- Removed association: ConnectionIsBoundedByNode
- Removed association: CEPConnectsToPeerCEP
- Renamed association CEPHasClientNEP to CEPSupportsClientNEP
- Renamed association CEPHasServerNEP to CEPIsSupportedByNEP and its association-end ConnectionEndPoint:_serverNodeEdgePoint to ConnectionEndPoint:_parentNodeEdgePoint
- Renamed CSEPHasCEP to CEPRelatesToCSEP and reversed navigation direction